### PR TITLE
feat: implement decoders for bonkswap and raydium programs

### DIFF
--- a/src/bonkswap/anchor_self_cpi.rs
+++ b/src/bonkswap/anchor_self_cpi.rs
@@ -1,0 +1,55 @@
+//! BonkSwap on-chain events emitted via `emit!`.
+
+use crate::ParseError;
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+
+// -----------------------------------------------------------------------------
+// Discriminators
+// -----------------------------------------------------------------------------
+pub const SWAP_EVENT: [u8; 8] = [248, 198, 158, 145, 225, 117, 135, 200];
+
+// -----------------------------------------------------------------------------
+// Event enumeration
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BonkSwapEvent {
+    Swap(SwapEvent),
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Payload structs
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SwapEvent {
+    pub delta_in: u64,
+    pub price_limit: u128,
+    pub x_to_y: bool,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for BonkSwapEvent {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.len() < 8 {
+            return Err(ParseError::TooShort(data.len()));
+        }
+
+        let (disc, payload) = data.split_at(8);
+        let discriminator: [u8; 8] = disc.try_into().expect("slice len 8");
+
+        Ok(match discriminator {
+            SWAP_EVENT => Self::Swap(SwapEvent::try_from_slice(payload)?),
+            other => return Err(ParseError::Unknown(other)),
+        })
+    }
+}
+
+/// Convenience wrapper that forwards to `TryFrom`.
+pub fn unpack(data: &[u8]) -> Result<BonkSwapEvent, ParseError> {
+    BonkSwapEvent::try_from(data)
+}

--- a/src/bonkswap/instructions.rs
+++ b/src/bonkswap/instructions.rs
@@ -1,0 +1,55 @@
+//! BonkSwap on-chain instructions.
+
+use crate::ParseError;
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+
+// -----------------------------------------------------------------------------
+// Discriminators
+// -----------------------------------------------------------------------------
+pub const SWAP: [u8; 8] = [248, 198, 158, 145, 225, 117, 135, 200];
+
+// -----------------------------------------------------------------------------
+// Instruction enumeration
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BonkSwapInstruction {
+    Swap(SwapInstruction),
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Payload structs
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SwapInstruction {
+    pub delta_in: u64,
+    pub price_limit: u128,
+    pub x_to_y: bool,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for BonkSwapInstruction {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.len() < 8 {
+            return Err(ParseError::TooShort(data.len()));
+        }
+
+        let (disc, payload) = data.split_at(8);
+        let discriminator: [u8; 8] = disc.try_into().expect("slice len 8");
+
+        Ok(match discriminator {
+            SWAP => Self::Swap(SwapInstruction::try_from_slice(payload)?),
+            other => return Err(ParseError::Unknown(other)),
+        })
+    }
+}
+
+/// Convenience wrapper that forwards to `TryFrom`.
+pub fn unpack(data: &[u8]) -> Result<BonkSwapInstruction, ParseError> {
+    BonkSwapInstruction::try_from(data)
+}

--- a/src/bonkswap/logs.rs
+++ b/src/bonkswap/logs.rs
@@ -1,0 +1,3 @@
+//! BonkSwap program logs.
+
+pub use super::anchor_self_cpi::{unpack, BonkSwapEvent as BonkSwapLog, SwapEvent, SWAP_EVENT};

--- a/src/bonkswap/mod.rs
+++ b/src/bonkswap/mod.rs
@@ -1,0 +1,10 @@
+use substreams_solana::b58;
+
+pub mod anchor_self_cpi;
+pub mod instructions;
+pub mod logs;
+
+/// BonkSwap AMM program
+///
+/// https://solscan.io/account/BSwp6bEBihVLdqJRKGgzjcGLHkcTuzmSo1TQkHepzH8p
+pub const PROGRAM_ID: [u8; 32] = b58!("BSwp6bEBihVLdqJRKGgzjcGLHkcTuzmSo1TQkHepzH8p");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod bonkswap;
 pub mod jupiter;
 pub mod pumpfun;
 pub mod raydium;

--- a/src/raydium/clmm/mod.rs
+++ b/src/raydium/clmm/mod.rs
@@ -1,0 +1,1 @@
+pub mod v3;

--- a/src/raydium/clmm/v3/anchor_self_cpi.rs
+++ b/src/raydium/clmm/v3/anchor_self_cpi.rs
@@ -1,0 +1,65 @@
+//! Raydium CLMM swap events.
+
+use crate::ParseError;
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+use solana_program::pubkey::Pubkey;
+
+// -----------------------------------------------------------------------------
+// Discriminator
+// -----------------------------------------------------------------------------
+pub const SWAP_EVENT: [u8; 8] = [64, 198, 205, 232, 38, 8, 113, 226];
+
+// -----------------------------------------------------------------------------
+// Event enumeration
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RaydiumClmmEvent {
+    SwapEvent(SwapEvent),
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Payload struct
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SwapEvent {
+    pub pool_state: Pubkey,
+    pub sender: Pubkey,
+    pub token_account_0: Pubkey,
+    pub token_account_1: Pubkey,
+    pub amount_0: u64,
+    pub transfer_fee_0: u64,
+    pub amount_1: u64,
+    pub transfer_fee_1: u64,
+    pub zero_for_one: bool,
+    pub sqrt_price_x64: u128,
+    pub liquidity: u128,
+    pub tick: i32,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for RaydiumClmmEvent {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.len() < 8 {
+            return Err(ParseError::TooShort(data.len()));
+        }
+
+        let disc: [u8; 8] = data[0..8].try_into().expect("slice len 8");
+        let payload = &data[8..];
+
+        Ok(match disc {
+            SWAP_EVENT => Self::SwapEvent(SwapEvent::try_from_slice(payload)?),
+            other => return Err(ParseError::Unknown(other)),
+        })
+    }
+}
+
+/// Convenience wrapper that forwards to `TryFrom`.
+pub fn unpack(data: &[u8]) -> Result<RaydiumClmmEvent, ParseError> {
+    RaydiumClmmEvent::try_from(data)
+}

--- a/src/raydium/clmm/v3/instructions.rs
+++ b/src/raydium/clmm/v3/instructions.rs
@@ -1,0 +1,26 @@
+//! Raydium CLMM instructions (currently undefined).
+
+use crate::ParseError;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RaydiumClmmInstruction {
+    /// Unknown discriminator
+    Unknown,
+}
+
+impl<'a> TryFrom<&'a [u8]> for RaydiumClmmInstruction {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.len() < 8 {
+            return Err(ParseError::TooShort(data.len()));
+        }
+        let disc: [u8; 8] = data[0..8].try_into().expect("slice len 8");
+        Err(ParseError::Unknown(disc))
+    }
+}
+
+pub fn unpack(data: &[u8]) -> Result<RaydiumClmmInstruction, ParseError> {
+    RaydiumClmmInstruction::try_from(data)
+}

--- a/src/raydium/clmm/v3/logs.rs
+++ b/src/raydium/clmm/v3/logs.rs
@@ -1,0 +1,3 @@
+//! Raydium CLMM logs re-export.
+
+pub use super::anchor_self_cpi::{unpack, RaydiumClmmEvent as RaydiumClmmLog, SwapEvent, SWAP_EVENT};

--- a/src/raydium/clmm/v3/mod.rs
+++ b/src/raydium/clmm/v3/mod.rs
@@ -1,0 +1,10 @@
+use substreams_solana::b58;
+
+pub mod anchor_self_cpi;
+pub mod instructions;
+pub mod logs;
+
+/// Raydium CLMM v3 program
+///
+/// https://solscan.io/account/CAMMCzo5YL8w4VFF8KVHrK22GGUsp5VTaW7grrKgrWqK
+pub const PROGRAM_ID: [u8; 32] = b58!("CAMMCzo5YL8w4VFF8KVHrK22GGUsp5VTaW7grrKgrWqK");

--- a/src/raydium/cpmm/anchor_self_cpi.rs
+++ b/src/raydium/cpmm/anchor_self_cpi.rs
@@ -1,0 +1,82 @@
+//! Raydium CPMM events emitted via `emit!`.
+
+use crate::ParseError;
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+use solana_program::pubkey::Pubkey;
+
+// -----------------------------------------------------------------------------
+// Discriminators
+// -----------------------------------------------------------------------------
+pub const SWAP_EVENT: [u8; 8] = [64, 198, 205, 232, 38, 8, 113, 226];
+pub const LP_CHANGE_EVENT: [u8; 8] = [121, 163, 205, 201, 57, 218, 117, 60];
+
+// -----------------------------------------------------------------------------
+// Event enumeration
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RaydiumCpmmEvent {
+    SwapEvent(SwapEvent),
+    LpChangeEvent(LpChangeEvent),
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Payload structs
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SwapEvent {
+    pub pool_id: Pubkey,
+    pub input_vault_before: u64,
+    pub output_vault_before: u64,
+    pub input_amount: u64,
+    pub output_amount: u64,
+    pub input_transfer_fee: u64,
+    pub output_transfer_fee: u64,
+    pub base_input: bool,
+    pub input_mint: Pubkey,
+    pub output_mint: Pubkey,
+    pub trade_fee: u64,
+    pub creator_fee: u64,
+    pub creator_fee_on_input: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct LpChangeEvent {
+    pub pool_id: Pubkey,
+    pub lp_amount_before: u64,
+    pub token_0_vault_before: u64,
+    pub token_1_vault_before: u64,
+    pub token_0_amount: u64,
+    pub token_1_amount: u64,
+    pub token_0_transfer_fee: u64,
+    pub token_1_transfer_fee: u64,
+    pub change_type: u32,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for RaydiumCpmmEvent {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.len() < 8 {
+            return Err(ParseError::TooShort(data.len()));
+        }
+
+        let disc: [u8; 8] = data[0..8].try_into().expect("slice len 8");
+        let payload = &data[8..];
+
+        Ok(match disc {
+            SWAP_EVENT => Self::SwapEvent(SwapEvent::try_from_slice(payload)?),
+            LP_CHANGE_EVENT => Self::LpChangeEvent(LpChangeEvent::try_from_slice(payload)?),
+            other => return Err(ParseError::Unknown(other)),
+        })
+    }
+}
+
+/// Convenience wrapper that forwards to `TryFrom`.
+pub fn unpack(data: &[u8]) -> Result<RaydiumCpmmEvent, ParseError> {
+    RaydiumCpmmEvent::try_from(data)
+}

--- a/src/raydium/cpmm/instructions.rs
+++ b/src/raydium/cpmm/instructions.rs
@@ -1,0 +1,63 @@
+//! Raydium CPMM swap instructions.
+
+use crate::ParseError;
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+
+// -----------------------------------------------------------------------------
+// Discriminators
+// -----------------------------------------------------------------------------
+pub const SWAP_BASE_INPUT: [u8; 8] = [143, 190, 90, 218, 196, 30, 51, 222];
+pub const SWAP_BASE_OUTPUT: [u8; 8] = [55, 217, 98, 86, 163, 74, 180, 173];
+
+// -----------------------------------------------------------------------------
+// Instruction enumeration
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RaydiumCpmmInstruction {
+    SwapBaseInput(SwapBaseInputInstruction),
+    SwapBaseOutput(SwapBaseOutputInstruction),
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Payload structs
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SwapBaseInputInstruction {
+    pub amount_in: u64,
+    pub minimum_amount_out: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SwapBaseOutputInstruction {
+    pub max_amount_in: u64,
+    pub amount_out: u64,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for RaydiumCpmmInstruction {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.len() < 8 {
+            return Err(ParseError::TooShort(data.len()));
+        }
+
+        let (disc, payload) = data.split_at(8);
+        let discriminator: [u8; 8] = disc.try_into().expect("slice len 8");
+
+        Ok(match discriminator {
+            SWAP_BASE_INPUT => Self::SwapBaseInput(SwapBaseInputInstruction::try_from_slice(payload)?),
+            SWAP_BASE_OUTPUT => Self::SwapBaseOutput(SwapBaseOutputInstruction::try_from_slice(payload)?),
+            other => return Err(ParseError::Unknown(other)),
+        })
+    }
+}
+
+/// Convenience wrapper that forwards to `TryFrom`.
+pub fn unpack(data: &[u8]) -> Result<RaydiumCpmmInstruction, ParseError> {
+    RaydiumCpmmInstruction::try_from(data)
+}

--- a/src/raydium/cpmm/logs.rs
+++ b/src/raydium/cpmm/logs.rs
@@ -1,0 +1,3 @@
+//! Raydium CPMM logs re-export.
+
+pub use super::anchor_self_cpi::{unpack, LpChangeEvent, RaydiumCpmmEvent as RaydiumCpmmLog, SwapEvent, LP_CHANGE_EVENT, SWAP_EVENT};

--- a/src/raydium/cpmm/mod.rs
+++ b/src/raydium/cpmm/mod.rs
@@ -1,0 +1,10 @@
+use substreams_solana::b58;
+
+pub mod anchor_self_cpi;
+pub mod instructions;
+pub mod logs;
+
+/// Raydium Concentrated Pool Market Maker program
+///
+/// https://solscan.io/account/CPMMoo8L3F4NbTegBCKVNunggL7H1ZpdTHKxQB5qKP1C
+pub const PROGRAM_ID: [u8; 32] = b58!("CPMMoo8L3F4NbTegBCKVNunggL7H1ZpdTHKxQB5qKP1C");

--- a/src/raydium/launchpad/anchor_self_cpi.rs
+++ b/src/raydium/launchpad/anchor_self_cpi.rs
@@ -1,0 +1,70 @@
+//! Raydium Launchpad trade events.
+
+use crate::ParseError;
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+use solana_program::pubkey::Pubkey;
+
+// -----------------------------------------------------------------------------
+// Discriminators
+// -----------------------------------------------------------------------------
+pub const TRADE_EVENT: [u8; 8] = [189, 219, 127, 211, 78, 230, 97, 238];
+
+// -----------------------------------------------------------------------------
+// Event enumeration
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RaydiumLaunchpadEvent {
+    TradeEvent(TradeEvent),
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Payload struct
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct TradeEvent {
+    pub pool_state: Pubkey,
+    pub total_base_sell: u64,
+    pub virtual_base: u64,
+    pub virtual_quote: u64,
+    pub real_base_before: u64,
+    pub real_quote_before: u64,
+    pub real_base_after: u64,
+    pub real_quote_after: u64,
+    pub amount_in: u64,
+    pub amount_out: u64,
+    pub protocol_fee: u64,
+    pub platform_fee: u64,
+    pub creator_fee: u64,
+    pub share_fee: u64,
+    pub trade_direction: u8,
+    pub pool_status: u8,
+    pub exact_in: bool,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for RaydiumLaunchpadEvent {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.len() < 8 {
+            return Err(ParseError::TooShort(data.len()));
+        }
+
+        let disc: [u8; 8] = data[0..8].try_into().expect("slice len 8");
+        let payload = &data[8..];
+
+        Ok(match disc {
+            TRADE_EVENT => Self::TradeEvent(TradeEvent::try_from_slice(payload)?),
+            other => return Err(ParseError::Unknown(other)),
+        })
+    }
+}
+
+/// Convenience wrapper that forwards to `TryFrom`.
+pub fn unpack(data: &[u8]) -> Result<RaydiumLaunchpadEvent, ParseError> {
+    RaydiumLaunchpadEvent::try_from(data)
+}

--- a/src/raydium/launchpad/instructions.rs
+++ b/src/raydium/launchpad/instructions.rs
@@ -1,0 +1,85 @@
+//! Raydium Launchpad trading instructions.
+
+use crate::ParseError;
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+
+// -----------------------------------------------------------------------------
+// Discriminators
+// -----------------------------------------------------------------------------
+pub const BUY_EXACT_IN: [u8; 8] = [250, 234, 13, 123, 213, 156, 19, 236];
+pub const BUY_EXACT_OUT: [u8; 8] = [24, 211, 116, 40, 105, 3, 153, 56];
+pub const SELL_EXACT_IN: [u8; 8] = [149, 39, 222, 155, 211, 124, 152, 26];
+pub const SELL_EXACT_OUT: [u8; 8] = [95, 200, 71, 34, 8, 9, 11, 166];
+
+// -----------------------------------------------------------------------------
+// Instruction enumeration
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RaydiumLaunchpadInstruction {
+    BuyExactIn(BuyExactInInstruction),
+    BuyExactOut(BuyExactOutInstruction),
+    SellExactIn(SellExactInInstruction),
+    SellExactOut(SellExactOutInstruction),
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Payload structs
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct BuyExactInInstruction {
+    pub amount_in: u64,
+    pub minimum_amount_out: u64,
+    pub share_fee_rate: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct BuyExactOutInstruction {
+    pub amount_out: u64,
+    pub maximum_amount_in: u64,
+    pub share_fee_rate: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SellExactInInstruction {
+    pub amount_in: u64,
+    pub minimum_amount_out: u64,
+    pub share_fee_rate: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SellExactOutInstruction {
+    pub amount_out: u64,
+    pub maximum_amount_in: u64,
+    pub share_fee_rate: u64,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for RaydiumLaunchpadInstruction {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.len() < 8 {
+            return Err(ParseError::TooShort(data.len()));
+        }
+
+        let (disc, payload) = data.split_at(8);
+        let discriminator: [u8; 8] = disc.try_into().expect("slice len 8");
+
+        Ok(match discriminator {
+            BUY_EXACT_IN => Self::BuyExactIn(BuyExactInInstruction::try_from_slice(payload)?),
+            BUY_EXACT_OUT => Self::BuyExactOut(BuyExactOutInstruction::try_from_slice(payload)?),
+            SELL_EXACT_IN => Self::SellExactIn(SellExactInInstruction::try_from_slice(payload)?),
+            SELL_EXACT_OUT => Self::SellExactOut(SellExactOutInstruction::try_from_slice(payload)?),
+            other => return Err(ParseError::Unknown(other)),
+        })
+    }
+}
+
+/// Convenience wrapper that forwards to `TryFrom`.
+pub fn unpack(data: &[u8]) -> Result<RaydiumLaunchpadInstruction, ParseError> {
+    RaydiumLaunchpadInstruction::try_from(data)
+}

--- a/src/raydium/launchpad/logs.rs
+++ b/src/raydium/launchpad/logs.rs
@@ -1,0 +1,3 @@
+//! Raydium Launchpad logs re-export.
+
+pub use super::anchor_self_cpi::{unpack, RaydiumLaunchpadEvent as RaydiumLaunchpadLog, TradeEvent, TRADE_EVENT};

--- a/src/raydium/launchpad/mod.rs
+++ b/src/raydium/launchpad/mod.rs
@@ -1,0 +1,10 @@
+use substreams_solana::b58;
+
+pub mod anchor_self_cpi;
+pub mod instructions;
+pub mod logs;
+
+/// Raydium Launchpad program
+///
+/// https://solscan.io/account/LanMV9sAd7wArD4vJFi2qDdfnVhFxYSUg6eADduJ3uj
+pub const PROGRAM_ID: [u8; 32] = b58!("LanMV9sAd7wArD4vJFi2qDdfnVhFxYSUg6eADduJ3uj");

--- a/src/raydium/mod.rs
+++ b/src/raydium/mod.rs
@@ -1,1 +1,4 @@
 pub mod amm;
+pub mod clmm;
+pub mod cpmm;
+pub mod launchpad;

--- a/tests/bonkswap.rs
+++ b/tests/bonkswap.rs
@@ -1,0 +1,27 @@
+#[cfg(test)]
+mod tests {
+    use borsh::BorshSerialize;
+    use substreams_solana_idls::bonkswap;
+
+    #[test]
+    fn unpack_swap_instruction() {
+        use bonkswap::instructions::{unpack, BonkSwapInstruction, SwapInstruction, SWAP};
+
+        let payload = SwapInstruction {
+            delta_in: 1,
+            price_limit: 2,
+            x_to_y: true,
+        };
+        let mut data = SWAP.to_vec();
+        payload.serialize(&mut data).unwrap();
+
+        match unpack(&data).expect("decode") {
+            BonkSwapInstruction::Swap(ix) => {
+                assert_eq!(ix.delta_in, 1);
+                assert_eq!(ix.price_limit, 2);
+                assert!(ix.x_to_y);
+            }
+            _ => panic!("expected swap"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add BonkSwap instruction and event decoders
- add Raydium CPMM, Launchpad, and CLMM decoders
- include basic test for BonkSwap swap instruction

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_68b2c449a84c8328970f1910d512eda2