### PR TITLE
Expand BonkSwap IDL coverage

### DIFF
--- a/src/bonkswap/accounts.rs
+++ b/src/bonkswap/accounts.rs
@@ -4,7 +4,67 @@ use solana_program::pubkey::Pubkey;
 use substreams_solana::block_view::InstructionView;
 use thiserror::Error;
 
-// Zero-based indices into `InstructionView.accounts()`
+// -----------------------------------------------------------------------------
+// Error type
+// -----------------------------------------------------------------------------
+#[derive(Debug, Error)]
+pub enum AccountsError {
+    #[error("missing required account `{name}` at index {index}")]
+    Missing { name: &'static str, index: usize },
+    #[error("invalid key length for `{name}` at index {index}: got {got}, want 32")]
+    InvalidLen { name: &'static str, index: usize, got: usize },
+}
+
+#[inline]
+fn to_pubkey(name: &'static str, index: usize, bytes: &[u8]) -> Result<Pubkey, AccountsError> {
+    let arr: [u8; 32] = bytes
+        .try_into()
+        .map_err(|_| AccountsError::InvalidLen { name, index, got: bytes.len() })?;
+    Ok(Pubkey::new_from_array(arr))
+}
+
+// -----------------------------------------------------------------------------
+// Helper macro for required-only account structs
+// -----------------------------------------------------------------------------
+macro_rules! accounts {
+    ($name:ident, $getter:ident, { $($field:ident),+ $(,)? }) => {
+        #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+        pub struct $name {
+            $(pub $field: Pubkey,)+
+        }
+
+        impl<'ix> TryFrom<&InstructionView<'ix>> for $name {
+            type Error = AccountsError;
+
+            fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+                let accounts = ix.accounts();
+                let mut idx = 0;
+                $(
+                    let $field = {
+                        let name = stringify!($field);
+                        let a = accounts
+                            .get(idx)
+                            .ok_or(AccountsError::Missing { name, index: idx })?;
+                        let pk = to_pubkey(name, idx, &a.0)?;
+                        idx += 1;
+                        pk
+                    };
+                )+
+                let _ = idx;
+                Ok(Self { $($field,)+ })
+            }
+        }
+
+        pub fn $getter(ix: &InstructionView) -> Result<$name, AccountsError> {
+            $name::try_from(ix)
+        }
+    };
+}
+
+// -----------------------------------------------------------------------------
+// Swap accounts (with optional referrer)
+// -----------------------------------------------------------------------------
+const IDX_STATE: usize = 0;
 const IDX_POOL: usize = 1;
 const IDX_TOKEN_X: usize = 2;
 const IDX_TOKEN_Y: usize = 3;
@@ -17,9 +77,15 @@ const IDX_SWAPPER: usize = 8;
 const IDX_REFERRER_X_ACCOUNT: usize = 9;
 const IDX_REFERRER_Y_ACCOUNT: usize = 10;
 const IDX_REFERRER: usize = 11;
+const IDX_PROGRAM_AUTHORITY: usize = 12;
+const IDX_SYSTEM_PROGRAM: usize = 13;
+const IDX_TOKEN_PROGRAM: usize = 14;
+const IDX_ASSOCIATED_TOKEN_PROGRAM: usize = 15;
+const IDX_RENT: usize = 16;
 
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
 pub struct SwapAccounts {
+    pub state: Pubkey,
     pub pool: Pubkey,
     pub token_x: Pubkey,
     pub token_y: Pubkey,
@@ -31,40 +97,33 @@ pub struct SwapAccounts {
     pub referrer_x_account: Option<Pubkey>,
     pub referrer_y_account: Option<Pubkey>,
     pub referrer: Option<Pubkey>,
-}
-
-#[derive(Debug, Error)]
-pub enum SwapAccountsError {
-    #[error("missing required account `{name}` at index {index}")]
-    Missing { name: &'static str, index: usize },
-    #[error("invalid key length for `{name}` at index {index}: got {got}, want 32")]
-    InvalidLen { name: &'static str, index: usize, got: usize },
-}
-
-#[inline]
-fn to_pubkey(name: &'static str, index: usize, bytes: &[u8]) -> Result<Pubkey, SwapAccountsError> {
-    let arr: [u8; 32] = bytes.try_into().map_err(|_| SwapAccountsError::InvalidLen { name, index, got: bytes.len() })?;
-    Ok(Pubkey::new_from_array(arr))
+    pub program_authority: Pubkey,
+    pub system_program: Pubkey,
+    pub token_program: Pubkey,
+    pub associated_token_program: Pubkey,
+    pub rent: Pubkey,
 }
 
 impl<'ix> TryFrom<&InstructionView<'ix>> for SwapAccounts {
-    type Error = SwapAccountsError;
+    type Error = AccountsError;
 
     fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
-        // IMPORTANT: call once to avoid borrowing from a temporary
-        // If `accounts()` returns a Vec, we own it; if it returns a slice, call `.to_vec()`.
         let accounts = ix.accounts();
 
-        // Required account getter
-        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, SwapAccountsError> {
-            let a = accounts.get(index).ok_or(SwapAccountsError::Missing { name, index })?;
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
             to_pubkey(name, index, &a.0)
         };
 
-        // Optional account getter
-        let get_opt = |index: usize| -> Option<Pubkey> { accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        let get_opt = |index: usize| -> Option<Pubkey> {
+            accounts
+                .get(index)
+                .and_then(|a| a.0.as_slice().try_into().ok())
+                .map(Pubkey::new_from_array)
+        };
 
         Ok(SwapAccounts {
+            state: get_req(IDX_STATE, "state")?,
             pool: get_req(IDX_POOL, "pool")?,
             token_x: get_req(IDX_TOKEN_X, "token_x")?,
             token_y: get_req(IDX_TOKEN_Y, "token_y")?,
@@ -76,11 +135,412 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for SwapAccounts {
             referrer_x_account: get_opt(IDX_REFERRER_X_ACCOUNT),
             referrer_y_account: get_opt(IDX_REFERRER_Y_ACCOUNT),
             referrer: get_opt(IDX_REFERRER),
+            program_authority: get_req(IDX_PROGRAM_AUTHORITY, "program_authority")?,
+            system_program: get_req(IDX_SYSTEM_PROGRAM, "system_program")?,
+            token_program: get_req(IDX_TOKEN_PROGRAM, "token_program")?,
+            associated_token_program: get_req(IDX_ASSOCIATED_TOKEN_PROGRAM, "associated_token_program")?,
+            rent: get_req(IDX_RENT, "rent")?,
         })
     }
 }
 
-// Convenience wrapper matching your original API
-pub fn get_swap_accounts(ix: &InstructionView) -> Result<SwapAccounts, SwapAccountsError> {
+pub fn get_swap_accounts(ix: &InstructionView) -> Result<SwapAccounts, AccountsError> {
     SwapAccounts::try_from(ix)
 }
+
+// -----------------------------------------------------------------------------
+// Account structs for other instructions
+// -----------------------------------------------------------------------------
+accounts!(
+    CreatePoolAccounts,
+    get_create_pool_accounts,
+    {
+        state,
+        pool,
+        token_x,
+        token_y,
+        pool_x_account,
+        pool_y_account,
+        admin_x_account,
+        admin_y_account,
+        admin,
+        project_owner,
+        program_authority,
+        system_program,
+        token_program,
+        rent
+    }
+);
+
+accounts!(
+    CreateProviderAccounts,
+    get_create_provider_accounts,
+    {
+        pool,
+        farm,
+        provider,
+        token_x,
+        token_y,
+        pool_x_account,
+        pool_y_account,
+        owner_x_account,
+        owner_y_account,
+        owner,
+        system_program,
+        token_program,
+        rent
+    }
+);
+
+accounts!(
+    CreateStateAccounts,
+    get_create_state_accounts,
+    {
+        state,
+        admin,
+        program_authority,
+        system_program
+    }
+);
+
+accounts!(
+    AddTokensAccounts,
+    get_add_tokens_accounts,
+    {
+        state,
+        pool,
+        farm,
+        provider,
+        token_x,
+        token_y,
+        token_marco,
+        token_project_first,
+        token_project_second,
+        owner_x_account,
+        owner_y_account,
+        pool_x_account,
+        pool_y_account,
+        owner_marco_account,
+        owner_project_first_account,
+        owner_project_second_account,
+        token_marco_account,
+        token_project_first_account,
+        token_project_second_account,
+        owner,
+        program_authority,
+        system_program,
+        token_program,
+        associated_token_program,
+        rent
+    }
+);
+
+accounts!(
+    WithdrawBuybackAccounts,
+    get_withdraw_buyback_accounts,
+    {
+        state,
+        pool,
+        token_x,
+        token_y,
+        buyback_x_account,
+        buyback_y_account,
+        pool_x_account,
+        pool_y_account,
+        admin,
+        program_authority,
+        system_program,
+        token_program,
+        associated_token_program,
+        rent
+    }
+);
+
+accounts!(
+    WithdrawSharesAccounts,
+    get_withdraw_shares_accounts,
+    {
+        state,
+        pool,
+        farm,
+        provider,
+        token_x,
+        token_y,
+        token_marco,
+        token_project_first,
+        token_project_second,
+        pool_x_account,
+        pool_y_account,
+        token_marco_account,
+        token_project_first_account,
+        token_project_second_account,
+        owner_x_account,
+        owner_y_account,
+        owner_marco_account,
+        owner_project_first_account,
+        owner_project_second_account,
+        owner,
+        program_authority,
+        system_program,
+        token_program,
+        associated_token_program,
+        rent
+    }
+);
+
+accounts!(
+    WithdrawLpFeeAccounts,
+    get_withdraw_lp_fee_accounts,
+    {
+        state,
+        pool,
+        provider,
+        token_x,
+        token_y,
+        owner_x_account,
+        owner_y_account,
+        pool_x_account,
+        pool_y_account,
+        owner,
+        program_authority,
+        system_program,
+        token_program,
+        associated_token_program,
+        rent
+    }
+);
+
+accounts!(
+    WithdrawProjectFeeAccounts,
+    get_withdraw_project_fee_accounts,
+    {
+        state,
+        pool,
+        token_x,
+        token_y,
+        project_owner_x_account,
+        project_owner_y_account,
+        pool_x_account,
+        pool_y_account,
+        project_owner,
+        program_authority,
+        system_program,
+        token_program,
+        associated_token_program,
+        rent
+    }
+);
+
+accounts!(
+    CreateFarmAccounts,
+    get_create_farm_accounts,
+    {
+        state,
+        pool,
+        farm,
+        token_x,
+        token_y,
+        token_marco,
+        token_marco_account,
+        admin_marco_account,
+        admin,
+        program_authority,
+        system_program,
+        token_program,
+        rent
+    }
+);
+
+accounts!(
+    CreateDualFarmAccounts,
+    get_create_dual_farm_accounts,
+    {
+        state,
+        pool,
+        farm,
+        token_x,
+        token_y,
+        token_marco,
+        token_project_first,
+        token_marco_account,
+        token_project_first_account,
+        admin_marco_account,
+        admin_project_first_account,
+        admin,
+        program_authority,
+        system_program,
+        token_program,
+        rent
+    }
+);
+
+accounts!(
+    CreateTripleFarmAccounts,
+    get_create_triple_farm_accounts,
+    {
+        state,
+        pool,
+        farm,
+        token_x,
+        token_y,
+        token_marco,
+        token_project_first,
+        token_project_second,
+        token_marco_account,
+        token_project_first_account,
+        token_project_second_account,
+        admin_marco_account,
+        admin_project_first_account,
+        admin_project_second_account,
+        admin,
+        program_authority,
+        system_program,
+        token_program,
+        rent
+    }
+);
+
+accounts!(
+    WithdrawRewardsAccounts,
+    get_withdraw_rewards_accounts,
+    {
+        state,
+        pool,
+        farm,
+        provider,
+        token_x,
+        token_y,
+        token_marco,
+        token_project_first,
+        token_project_second,
+        token_marco_account,
+        token_project_first_account,
+        token_project_second_account,
+        owner_marco_account,
+        owner_project_first_account,
+        owner_project_second_account,
+        owner,
+        program_authority,
+        system_program,
+        token_program,
+        associated_token_program,
+        rent
+    }
+);
+
+accounts!(
+    ClosePoolAccounts,
+    get_close_pool_accounts,
+    {
+        state,
+        pool,
+        farm,
+        token_x,
+        token_y,
+        token_marco_account,
+        token_project_first_account,
+        token_project_second_account,
+        pool_x_account,
+        pool_y_account,
+        buyback_x_account,
+        buyback_y_account,
+        admin,
+        program_authority,
+        token_program
+    }
+);
+
+accounts!(
+    WithdrawMercantiFeeAccounts,
+    get_withdraw_mercanti_fee_accounts,
+    {
+        state,
+        pool,
+        token_x,
+        token_y,
+        mercanti_x_account,
+        mercanti_y_account,
+        pool_x_account,
+        pool_y_account,
+        admin,
+        program_authority,
+        token_program
+    }
+);
+
+accounts!(
+    AddSupplyAccounts,
+    get_add_supply_accounts,
+    {
+        state,
+        pool,
+        farm,
+        token_x,
+        token_y,
+        token_marco_account,
+        token_project_first_account,
+        token_project_second_account,
+        admin_marco_account,
+        admin_project_first_account,
+        admin_project_second_account,
+        admin,
+        token_program
+    }
+);
+
+accounts!(
+    UpdateFeesAccounts,
+    get_update_fees_accounts,
+    {
+        state,
+        pool,
+        token_x,
+        token_y,
+        admin,
+        program_authority
+    }
+);
+
+accounts!(
+    ResetFarmAccounts,
+    get_reset_farm_accounts,
+    {
+        state,
+        pool,
+        farm,
+        token_x,
+        token_y,
+        token_marco,
+        token_marco_account,
+        token_project_first_account,
+        token_project_second_account,
+        admin_marco_account,
+        admin_project_first_account,
+        admin_project_second_account,
+        admin,
+        program_authority,
+        system_program,
+        token_program,
+        rent
+    }
+);
+
+accounts!(
+    UpdateRewardTokensAccounts,
+    get_update_reward_tokens_accounts,
+    {
+        state,
+        pool,
+        farm,
+        token_marco_account,
+        token_project_first_account,
+        token_project_second_account,
+        token_marco,
+        new_token_marco_account,
+        admin,
+        program_authority,
+        system_program,
+        token_program
+    }
+);
+

--- a/src/bonkswap/instructions.rs
+++ b/src/bonkswap/instructions.rs
@@ -5,16 +5,65 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 
 // -----------------------------------------------------------------------------
+// Custom types
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct FixedPoint {
+    pub v: u128,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct Token {
+    pub v: u64,
+}
+
+// -----------------------------------------------------------------------------
 // Discriminators
 // -----------------------------------------------------------------------------
+pub const CREATE_POOL: [u8; 8] = [244, 236, 117, 4, 18, 0, 62, 88];
+pub const CREATE_PROVIDER: [u8; 8] = [229, 222, 145, 200, 251, 64, 186, 242];
+pub const CREATE_STATE: [u8; 8] = [96, 136, 104, 83, 116, 63, 225, 58];
+pub const ADD_TOKENS: [u8; 8] = [235, 5, 251, 241, 34, 5, 87, 148];
+pub const WITHDRAW_BUYBACK: [u8; 8] = [165, 47, 140, 185, 166, 81, 67, 193];
 pub const SWAP: [u8; 8] = [248, 198, 158, 145, 225, 117, 135, 200];
+pub const WITHDRAW_SHARES: [u8; 8] = [154, 125, 104, 220, 109, 76, 190, 75];
+pub const WITHDRAW_LP_FEE: [u8; 8] = [228, 128, 27, 71, 99, 91, 176, 245];
+pub const WITHDRAW_PROJECT_FEE: [u8; 8] = [217, 56, 100, 164, 87, 185, 120, 122];
+pub const CREATE_FARM: [u8; 8] = [132, 184, 152, 144, 36, 178, 106, 65];
+pub const CREATE_DUAL_FARM: [u8; 8] = [116, 188, 85, 98, 87, 133, 44, 198];
+pub const CREATE_TRIPLE_FARM: [u8; 8] = [47, 47, 162, 177, 193, 92, 246, 43];
+pub const WITHDRAW_REWARDS: [u8; 8] = [12, 208, 61, 169, 41, 19, 58, 161];
+pub const CLOSE_POOL: [u8; 8] = [78, 253, 165, 27, 159, 185, 29, 236];
+pub const WITHDRAW_MERCANTI_FEE: [u8; 8] = [9, 63, 114, 166, 104, 156, 8, 156];
+pub const ADD_SUPPLY: [u8; 8] = [208, 22, 199, 241, 3, 135, 81, 50];
+pub const UPDATE_FEES: [u8; 8] = [1, 7, 208, 119, 69, 167, 97, 219];
+pub const RESET_FARM: [u8; 8] = [245, 17, 148, 220, 55, 229, 71, 86];
+pub const UPDATE_REWARD_TOKENS: [u8; 8] = [156, 68, 147, 116, 29, 57, 159, 114];
 
 // -----------------------------------------------------------------------------
 // Instruction enumeration
 // -----------------------------------------------------------------------------
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BonkSwapInstruction {
+    CreatePool(CreatePoolInstruction),
+    CreateProvider(CreateProviderInstruction),
+    CreateState(CreateStateInstruction),
+    AddTokens(AddTokensInstruction),
+    WithdrawBuyback,
     Swap(SwapInstruction),
+    WithdrawShares(WithdrawSharesInstruction),
+    WithdrawLpFee,
+    WithdrawProjectFee,
+    CreateFarm(CreateFarmInstruction),
+    CreateDualFarm(CreateDualFarmInstruction),
+    CreateTripleFarm(CreateTripleFarmInstruction),
+    WithdrawRewards,
+    ClosePool,
+    WithdrawMercantiFee,
+    AddSupply(AddSupplyInstruction),
+    UpdateFees(UpdateFeesInstruction),
+    ResetFarm,
+    UpdateRewardTokens,
     Unknown,
 }
 
@@ -22,10 +71,84 @@ pub enum BonkSwapInstruction {
 // Payload structs
 // -----------------------------------------------------------------------------
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CreatePoolInstruction {
+    pub lp_fee: FixedPoint,
+    pub buyback_fee: FixedPoint,
+    pub project_fee: FixedPoint,
+    pub mercanti_fee: FixedPoint,
+    pub initial_token_x: Token,
+    pub initial_token_y: Token,
+    pub bump: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CreateProviderInstruction {
+    pub token_x_amount: Token,
+    pub token_y_amount: Token,
+    pub bump: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CreateStateInstruction {
+    pub nonce: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct AddTokensInstruction {
+    pub delta_x: Token,
+    pub delta_y: Token,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
 pub struct SwapInstruction {
-    pub delta_in: u64,
-    pub price_limit: u128,
+    pub delta_in: Token,
+    pub price_limit: FixedPoint,
     pub x_to_y: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct WithdrawSharesInstruction {
+    pub shares: Token,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CreateFarmInstruction {
+    pub supply: Token,
+    pub duration: u64,
+    pub bump: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CreateDualFarmInstruction {
+    pub supply_marco: Token,
+    pub supply_project_first: Token,
+    pub duration: u64,
+    pub bump: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CreateTripleFarmInstruction {
+    pub supply_marco: Token,
+    pub supply_project_first: Token,
+    pub supply_project_second: Token,
+    pub duration: u64,
+    pub bump: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct AddSupplyInstruction {
+    pub supply_marco: Token,
+    pub supply_project_first: Token,
+    pub supply_project_second: Token,
+    pub duration: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct UpdateFeesInstruction {
+    pub new_buyback_fee: FixedPoint,
+    pub new_project_fee: FixedPoint,
+    pub new_provider_fee: FixedPoint,
+    pub new_mercanti_fee: FixedPoint,
 }
 
 // -----------------------------------------------------------------------------
@@ -43,7 +166,25 @@ impl<'a> TryFrom<&'a [u8]> for BonkSwapInstruction {
         let discriminator: [u8; 8] = disc.try_into().expect("slice len 8");
 
         Ok(match discriminator {
+            CREATE_POOL => Self::CreatePool(CreatePoolInstruction::try_from_slice(payload)?),
+            CREATE_PROVIDER => Self::CreateProvider(CreateProviderInstruction::try_from_slice(payload)?),
+            CREATE_STATE => Self::CreateState(CreateStateInstruction::try_from_slice(payload)?),
+            ADD_TOKENS => Self::AddTokens(AddTokensInstruction::try_from_slice(payload)?),
+            WITHDRAW_BUYBACK => Self::WithdrawBuyback,
             SWAP => Self::Swap(SwapInstruction::try_from_slice(payload)?),
+            WITHDRAW_SHARES => Self::WithdrawShares(WithdrawSharesInstruction::try_from_slice(payload)?),
+            WITHDRAW_LP_FEE => Self::WithdrawLpFee,
+            WITHDRAW_PROJECT_FEE => Self::WithdrawProjectFee,
+            CREATE_FARM => Self::CreateFarm(CreateFarmInstruction::try_from_slice(payload)?),
+            CREATE_DUAL_FARM => Self::CreateDualFarm(CreateDualFarmInstruction::try_from_slice(payload)?),
+            CREATE_TRIPLE_FARM => Self::CreateTripleFarm(CreateTripleFarmInstruction::try_from_slice(payload)?),
+            WITHDRAW_REWARDS => Self::WithdrawRewards,
+            CLOSE_POOL => Self::ClosePool,
+            WITHDRAW_MERCANTI_FEE => Self::WithdrawMercantiFee,
+            ADD_SUPPLY => Self::AddSupply(AddSupplyInstruction::try_from_slice(payload)?),
+            UPDATE_FEES => Self::UpdateFees(UpdateFeesInstruction::try_from_slice(payload)?),
+            RESET_FARM => Self::ResetFarm,
+            UPDATE_REWARD_TOKENS => Self::UpdateRewardTokens,
             other => return Err(ParseError::Unknown(other)),
         })
     }
@@ -53,3 +194,4 @@ impl<'a> TryFrom<&'a [u8]> for BonkSwapInstruction {
 pub fn unpack(data: &[u8]) -> Result<BonkSwapInstruction, ParseError> {
     BonkSwapInstruction::try_from(data)
 }
+

--- a/tests/bonkswap.rs
+++ b/tests/bonkswap.rs
@@ -13,8 +13,10 @@ mod tests {
                 assert_eq!(
                     event,
                     bonkswap::instructions::SwapInstruction {
-                        delta_in: 155544178,
-                        price_limit: 340282366920938463463374607431768211455,
+                        delta_in: bonkswap::instructions::Token { v: 155544178 },
+                        price_limit: bonkswap::instructions::FixedPoint {
+                            v: 340282366920938463463374607431768211455,
+                        },
                         x_to_y: false
                     }
                 );


### PR DESCRIPTION
## Summary
- add BonkSwap instruction enum variants and data structs for all IDL instructions
- expose account parsers for every instruction with updated swap accounts
- adjust BonkSwap tests for new Token and FixedPoint types

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_68b2e208f6e4832881f02000a08184fc