### PR TITLE
feat(raydium): add full clmm v3 idl support

### DIFF
--- a/src/raydium/clmm/v3/accounts.rs
+++ b/src/raydium/clmm/v3/accounts.rs
@@ -1,0 +1,1254 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+use solana_program::pubkey::Pubkey;
+use substreams_solana::block_view::InstructionView;
+use thiserror::Error;
+
+// -----------------------------------------------------------------------------
+// Error type
+// -----------------------------------------------------------------------------
+#[derive(Debug, Error)]
+pub enum AccountsError {
+    #[error("missing required account `{name}` at index {index}")]
+    Missing { name: &'static str, index: usize },
+    #[error("invalid key length for `{name}` at index {index}: got {got}, want 32")]
+    InvalidLen { name: &'static str, index: usize, got: usize },
+}
+
+#[inline]
+fn to_pubkey(name: &'static str, index: usize, bytes: &[u8]) -> Result<Pubkey, AccountsError> {
+    let arr: [u8; 32] = bytes.try_into().map_err(|_| AccountsError::InvalidLen { name, index, got: bytes.len() })?;
+    Ok(Pubkey::new_from_array(arr))
+}
+
+/// Accounts for the `close_position` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct ClosePositionAccounts {
+    /// The position nft owner
+    pub nft_owner: Pubkey,
+    /// Mint address bound to the personal position.
+    pub position_nft_mint: Pubkey,
+    /// User token account where position NFT be minted to
+    pub position_nft_account: Pubkey,
+    pub personal_position: Pubkey,
+    /// System program to close the position state account
+    pub system_program: Pubkey,
+    /// Token/Token2022 program to close token/mint account
+    pub token_program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for ClosePositionAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(ClosePositionAccounts {
+            nft_owner: get_req(0, "nft_owner")?,
+            position_nft_mint: get_req(1, "position_nft_mint")?,
+            position_nft_account: get_req(2, "position_nft_account")?,
+            personal_position: get_req(3, "personal_position")?,
+            system_program: get_req(4, "system_program")?,
+            token_program: get_req(5, "token_program")?,
+        })
+    }
+}
+
+pub fn get_close_position_accounts(ix: &InstructionView) -> Result<ClosePositionAccounts, AccountsError> {
+    ClosePositionAccounts::try_from(ix)
+}
+
+/// Accounts for the `collect_fund_fee` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CollectFundFeeAccounts {
+    /// Only admin or fund_owner can collect fee now
+    pub owner: Pubkey,
+    /// Pool state stores accumulated protocol fee amount
+    pub pool_state: Pubkey,
+    /// Amm config account stores fund_owner
+    pub amm_config: Pubkey,
+    /// The address that holds pool tokens for token_0
+    pub token_vault_0: Pubkey,
+    /// The address that holds pool tokens for token_1
+    pub token_vault_1: Pubkey,
+    /// The mint of token vault 0
+    pub vault_0_mint: Pubkey,
+    /// The mint of token vault 1
+    pub vault_1_mint: Pubkey,
+    /// The address that receives the collected token_0 protocol fees
+    pub recipient_token_account_0: Pubkey,
+    /// The address that receives the collected token_1 protocol fees
+    pub recipient_token_account_1: Pubkey,
+    /// The SPL program to perform token transfers
+    pub token_program: Pubkey,
+    /// The SPL program 2022 to perform token transfers
+    pub token_program_2022: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for CollectFundFeeAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(CollectFundFeeAccounts {
+            owner: get_req(0, "owner")?,
+            pool_state: get_req(1, "pool_state")?,
+            amm_config: get_req(2, "amm_config")?,
+            token_vault_0: get_req(3, "token_vault_0")?,
+            token_vault_1: get_req(4, "token_vault_1")?,
+            vault_0_mint: get_req(5, "vault_0_mint")?,
+            vault_1_mint: get_req(6, "vault_1_mint")?,
+            recipient_token_account_0: get_req(7, "recipient_token_account_0")?,
+            recipient_token_account_1: get_req(8, "recipient_token_account_1")?,
+            token_program: get_req(9, "token_program")?,
+            token_program_2022: get_req(10, "token_program_2022")?,
+        })
+    }
+}
+
+pub fn get_collect_fund_fee_accounts(ix: &InstructionView) -> Result<CollectFundFeeAccounts, AccountsError> {
+    CollectFundFeeAccounts::try_from(ix)
+}
+
+/// Accounts for the `collect_protocol_fee` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CollectProtocolFeeAccounts {
+    /// Only admin or config owner can collect fee now
+    pub owner: Pubkey,
+    /// Pool state stores accumulated protocol fee amount
+    pub pool_state: Pubkey,
+    /// Amm config account stores owner
+    pub amm_config: Pubkey,
+    /// The address that holds pool tokens for token_0
+    pub token_vault_0: Pubkey,
+    /// The address that holds pool tokens for token_1
+    pub token_vault_1: Pubkey,
+    /// The mint of token vault 0
+    pub vault_0_mint: Pubkey,
+    /// The mint of token vault 1
+    pub vault_1_mint: Pubkey,
+    /// The address that receives the collected token_0 protocol fees
+    pub recipient_token_account_0: Pubkey,
+    /// The address that receives the collected token_1 protocol fees
+    pub recipient_token_account_1: Pubkey,
+    /// The SPL program to perform token transfers
+    pub token_program: Pubkey,
+    /// The SPL program 2022 to perform token transfers
+    pub token_program_2022: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for CollectProtocolFeeAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(CollectProtocolFeeAccounts {
+            owner: get_req(0, "owner")?,
+            pool_state: get_req(1, "pool_state")?,
+            amm_config: get_req(2, "amm_config")?,
+            token_vault_0: get_req(3, "token_vault_0")?,
+            token_vault_1: get_req(4, "token_vault_1")?,
+            vault_0_mint: get_req(5, "vault_0_mint")?,
+            vault_1_mint: get_req(6, "vault_1_mint")?,
+            recipient_token_account_0: get_req(7, "recipient_token_account_0")?,
+            recipient_token_account_1: get_req(8, "recipient_token_account_1")?,
+            token_program: get_req(9, "token_program")?,
+            token_program_2022: get_req(10, "token_program_2022")?,
+        })
+    }
+}
+
+pub fn get_collect_protocol_fee_accounts(ix: &InstructionView) -> Result<CollectProtocolFeeAccounts, AccountsError> {
+    CollectProtocolFeeAccounts::try_from(ix)
+}
+
+/// Accounts for the `collect_remaining_rewards` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CollectRemainingRewardsAccounts {
+    /// The founder who init reward info previously
+    pub reward_funder: Pubkey,
+    /// The funder's reward token account
+    pub funder_token_account: Pubkey,
+    /// Set reward for this pool
+    pub pool_state: Pubkey,
+    /// Reward vault transfer remaining token to founder token account
+    pub reward_token_vault: Pubkey,
+    /// The mint of reward token vault
+    pub reward_vault_mint: Pubkey,
+    pub token_program: Pubkey,
+    /// Token program 2022
+    pub token_program_2022: Pubkey,
+    /// memo program
+    pub memo_program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for CollectRemainingRewardsAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(CollectRemainingRewardsAccounts {
+            reward_funder: get_req(0, "reward_funder")?,
+            funder_token_account: get_req(1, "funder_token_account")?,
+            pool_state: get_req(2, "pool_state")?,
+            reward_token_vault: get_req(3, "reward_token_vault")?,
+            reward_vault_mint: get_req(4, "reward_vault_mint")?,
+            token_program: get_req(5, "token_program")?,
+            token_program_2022: get_req(6, "token_program_2022")?,
+            memo_program: get_req(7, "memo_program")?,
+        })
+    }
+}
+
+pub fn get_collect_remaining_rewards_accounts(ix: &InstructionView) -> Result<CollectRemainingRewardsAccounts, AccountsError> {
+    CollectRemainingRewardsAccounts::try_from(ix)
+}
+
+/// Accounts for the `create_amm_config` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CreateAmmConfigAccounts {
+    /// Address to be set as protocol owner.
+    pub owner: Pubkey,
+    /// Initialize config state account to store protocol owner address and fee rates.
+    pub amm_config: Pubkey,
+    pub system_program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for CreateAmmConfigAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(CreateAmmConfigAccounts {
+            owner: get_req(0, "owner")?,
+            amm_config: get_req(1, "amm_config")?,
+            system_program: get_req(2, "system_program")?,
+        })
+    }
+}
+
+pub fn get_create_amm_config_accounts(ix: &InstructionView) -> Result<CreateAmmConfigAccounts, AccountsError> {
+    CreateAmmConfigAccounts::try_from(ix)
+}
+
+/// Accounts for the `create_operation_account` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CreateOperationAccountAccounts {
+    /// Address to be set as operation account owner.
+    pub owner: Pubkey,
+    /// Initialize operation state account to store operation owner address and white list mint.
+    pub operation_state: Pubkey,
+    pub system_program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for CreateOperationAccountAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(CreateOperationAccountAccounts {
+            owner: get_req(0, "owner")?,
+            operation_state: get_req(1, "operation_state")?,
+            system_program: get_req(2, "system_program")?,
+        })
+    }
+}
+
+pub fn get_create_operation_account_accounts(ix: &InstructionView) -> Result<CreateOperationAccountAccounts, AccountsError> {
+    CreateOperationAccountAccounts::try_from(ix)
+}
+
+/// Accounts for the `create_pool` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CreatePoolAccounts {
+    /// Address paying to create the pool. Can be anyone
+    pub pool_creator: Pubkey,
+    /// Which config the pool belongs to.
+    pub amm_config: Pubkey,
+    /// Initialize an account to store the pool state
+    pub pool_state: Pubkey,
+    /// Token_0 mint, the key must be smaller then token_1 mint.
+    pub token_mint_0: Pubkey,
+    /// Token_1 mint
+    pub token_mint_1: Pubkey,
+    /// Token_0 vault for the pool
+    pub token_vault_0: Pubkey,
+    /// Token_1 vault for the pool
+    pub token_vault_1: Pubkey,
+    /// Initialize an account to store oracle observations
+    pub observation_state: Pubkey,
+    /// Initialize an account to store if a tick array is initialized.
+    pub tick_array_bitmap: Pubkey,
+    /// Spl token program or token program 2022
+    pub token_program_0: Pubkey,
+    /// Spl token program or token program 2022
+    pub token_program_1: Pubkey,
+    /// To create a new program account
+    pub system_program: Pubkey,
+    /// Sysvar for program account
+    pub rent: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for CreatePoolAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(CreatePoolAccounts {
+            pool_creator: get_req(0, "pool_creator")?,
+            amm_config: get_req(1, "amm_config")?,
+            pool_state: get_req(2, "pool_state")?,
+            token_mint_0: get_req(3, "token_mint_0")?,
+            token_mint_1: get_req(4, "token_mint_1")?,
+            token_vault_0: get_req(5, "token_vault_0")?,
+            token_vault_1: get_req(6, "token_vault_1")?,
+            observation_state: get_req(7, "observation_state")?,
+            tick_array_bitmap: get_req(8, "tick_array_bitmap")?,
+            token_program_0: get_req(9, "token_program_0")?,
+            token_program_1: get_req(10, "token_program_1")?,
+            system_program: get_req(11, "system_program")?,
+            rent: get_req(12, "rent")?,
+        })
+    }
+}
+
+pub fn get_create_pool_accounts(ix: &InstructionView) -> Result<CreatePoolAccounts, AccountsError> {
+    CreatePoolAccounts::try_from(ix)
+}
+
+/// Accounts for the `create_support_mint_associated` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CreateSupportMintAssociatedAccounts {
+    /// Address to be set as protocol owner.
+    pub owner: Pubkey,
+    /// Support token mint
+    pub token_mint: Pubkey,
+    /// Initialize support mint state account to store support mint address and bump.
+    pub support_mint_associated: Pubkey,
+    pub system_program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for CreateSupportMintAssociatedAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(CreateSupportMintAssociatedAccounts {
+            owner: get_req(0, "owner")?,
+            token_mint: get_req(1, "token_mint")?,
+            support_mint_associated: get_req(2, "support_mint_associated")?,
+            system_program: get_req(3, "system_program")?,
+        })
+    }
+}
+
+pub fn get_create_support_mint_associated_accounts(ix: &InstructionView) -> Result<CreateSupportMintAssociatedAccounts, AccountsError> {
+    CreateSupportMintAssociatedAccounts::try_from(ix)
+}
+
+/// Accounts for the `decrease_liquidity` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct DecreaseLiquidityAccounts {
+    /// The position owner or delegated authority
+    pub nft_owner: Pubkey,
+    /// The token account for the tokenized position
+    pub nft_account: Pubkey,
+    /// Decrease liquidity for this position
+    pub personal_position: Pubkey,
+    pub pool_state: Pubkey,
+    pub protocol_position: Pubkey,
+    /// Token_0 vault
+    pub token_vault_0: Pubkey,
+    /// Token_1 vault
+    pub token_vault_1: Pubkey,
+    /// Stores init state for the lower tick
+    pub tick_array_lower: Pubkey,
+    /// Stores init state for the upper tick
+    pub tick_array_upper: Pubkey,
+    /// The destination token account for receive amount_0
+    pub recipient_token_account_0: Pubkey,
+    /// The destination token account for receive amount_1
+    pub recipient_token_account_1: Pubkey,
+    /// SPL program to transfer out tokens
+    pub token_program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for DecreaseLiquidityAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(DecreaseLiquidityAccounts {
+            nft_owner: get_req(0, "nft_owner")?,
+            nft_account: get_req(1, "nft_account")?,
+            personal_position: get_req(2, "personal_position")?,
+            pool_state: get_req(3, "pool_state")?,
+            protocol_position: get_req(4, "protocol_position")?,
+            token_vault_0: get_req(5, "token_vault_0")?,
+            token_vault_1: get_req(6, "token_vault_1")?,
+            tick_array_lower: get_req(7, "tick_array_lower")?,
+            tick_array_upper: get_req(8, "tick_array_upper")?,
+            recipient_token_account_0: get_req(9, "recipient_token_account_0")?,
+            recipient_token_account_1: get_req(10, "recipient_token_account_1")?,
+            token_program: get_req(11, "token_program")?,
+        })
+    }
+}
+
+pub fn get_decrease_liquidity_accounts(ix: &InstructionView) -> Result<DecreaseLiquidityAccounts, AccountsError> {
+    DecreaseLiquidityAccounts::try_from(ix)
+}
+
+/// Accounts for the `decrease_liquidity_v2` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct DecreaseLiquidityV2Accounts {
+    /// The position owner or delegated authority
+    pub nft_owner: Pubkey,
+    /// The token account for the tokenized position
+    pub nft_account: Pubkey,
+    /// Decrease liquidity for this position
+    pub personal_position: Pubkey,
+    pub pool_state: Pubkey,
+    pub protocol_position: Pubkey,
+    /// Token_0 vault
+    pub token_vault_0: Pubkey,
+    /// Token_1 vault
+    pub token_vault_1: Pubkey,
+    /// Stores init state for the lower tick
+    pub tick_array_lower: Pubkey,
+    /// Stores init state for the upper tick
+    pub tick_array_upper: Pubkey,
+    /// The destination token account for receive amount_0
+    pub recipient_token_account_0: Pubkey,
+    /// The destination token account for receive amount_1
+    pub recipient_token_account_1: Pubkey,
+    /// SPL program to transfer out tokens
+    pub token_program: Pubkey,
+    /// Token program 2022
+    pub token_program_2022: Pubkey,
+    /// memo program
+    pub memo_program: Pubkey,
+    /// The mint of token vault 0
+    pub vault_0_mint: Pubkey,
+    /// The mint of token vault 1
+    pub vault_1_mint: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for DecreaseLiquidityV2Accounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(DecreaseLiquidityV2Accounts {
+            nft_owner: get_req(0, "nft_owner")?,
+            nft_account: get_req(1, "nft_account")?,
+            personal_position: get_req(2, "personal_position")?,
+            pool_state: get_req(3, "pool_state")?,
+            protocol_position: get_req(4, "protocol_position")?,
+            token_vault_0: get_req(5, "token_vault_0")?,
+            token_vault_1: get_req(6, "token_vault_1")?,
+            tick_array_lower: get_req(7, "tick_array_lower")?,
+            tick_array_upper: get_req(8, "tick_array_upper")?,
+            recipient_token_account_0: get_req(9, "recipient_token_account_0")?,
+            recipient_token_account_1: get_req(10, "recipient_token_account_1")?,
+            token_program: get_req(11, "token_program")?,
+            token_program_2022: get_req(12, "token_program_2022")?,
+            memo_program: get_req(13, "memo_program")?,
+            vault_0_mint: get_req(14, "vault_0_mint")?,
+            vault_1_mint: get_req(15, "vault_1_mint")?,
+        })
+    }
+}
+
+pub fn get_decrease_liquidity_v2_accounts(ix: &InstructionView) -> Result<DecreaseLiquidityV2Accounts, AccountsError> {
+    DecreaseLiquidityV2Accounts::try_from(ix)
+}
+
+/// Accounts for the `increase_liquidity` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct IncreaseLiquidityAccounts {
+    /// Pays to mint the position
+    pub nft_owner: Pubkey,
+    /// The token account for nft
+    pub nft_account: Pubkey,
+    pub pool_state: Pubkey,
+    pub protocol_position: Pubkey,
+    /// Increase liquidity for this position
+    pub personal_position: Pubkey,
+    /// Stores init state for the lower tick
+    pub tick_array_lower: Pubkey,
+    /// Stores init state for the upper tick
+    pub tick_array_upper: Pubkey,
+    /// The payer's token account for token_0
+    pub token_account_0: Pubkey,
+    /// The token account spending token_1 to mint the position
+    pub token_account_1: Pubkey,
+    /// The address that holds pool tokens for token_0
+    pub token_vault_0: Pubkey,
+    /// The address that holds pool tokens for token_1
+    pub token_vault_1: Pubkey,
+    /// Program to create mint account and mint tokens
+    pub token_program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for IncreaseLiquidityAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(IncreaseLiquidityAccounts {
+            nft_owner: get_req(0, "nft_owner")?,
+            nft_account: get_req(1, "nft_account")?,
+            pool_state: get_req(2, "pool_state")?,
+            protocol_position: get_req(3, "protocol_position")?,
+            personal_position: get_req(4, "personal_position")?,
+            tick_array_lower: get_req(5, "tick_array_lower")?,
+            tick_array_upper: get_req(6, "tick_array_upper")?,
+            token_account_0: get_req(7, "token_account_0")?,
+            token_account_1: get_req(8, "token_account_1")?,
+            token_vault_0: get_req(9, "token_vault_0")?,
+            token_vault_1: get_req(10, "token_vault_1")?,
+            token_program: get_req(11, "token_program")?,
+        })
+    }
+}
+
+pub fn get_increase_liquidity_accounts(ix: &InstructionView) -> Result<IncreaseLiquidityAccounts, AccountsError> {
+    IncreaseLiquidityAccounts::try_from(ix)
+}
+
+/// Accounts for the `increase_liquidity_v2` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct IncreaseLiquidityV2Accounts {
+    /// Pays to mint the position
+    pub nft_owner: Pubkey,
+    /// The token account for nft
+    pub nft_account: Pubkey,
+    pub pool_state: Pubkey,
+    pub protocol_position: Pubkey,
+    /// Increase liquidity for this position
+    pub personal_position: Pubkey,
+    /// Stores init state for the lower tick
+    pub tick_array_lower: Pubkey,
+    /// Stores init state for the upper tick
+    pub tick_array_upper: Pubkey,
+    /// The payer's token account for token_0
+    pub token_account_0: Pubkey,
+    /// The token account spending token_1 to mint the position
+    pub token_account_1: Pubkey,
+    /// The address that holds pool tokens for token_0
+    pub token_vault_0: Pubkey,
+    /// The address that holds pool tokens for token_1
+    pub token_vault_1: Pubkey,
+    /// Program to create mint account and mint tokens
+    pub token_program: Pubkey,
+    /// Token program 2022
+    pub token_program_2022: Pubkey,
+    /// The mint of token vault 0
+    pub vault_0_mint: Pubkey,
+    /// The mint of token vault 1
+    pub vault_1_mint: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for IncreaseLiquidityV2Accounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(IncreaseLiquidityV2Accounts {
+            nft_owner: get_req(0, "nft_owner")?,
+            nft_account: get_req(1, "nft_account")?,
+            pool_state: get_req(2, "pool_state")?,
+            protocol_position: get_req(3, "protocol_position")?,
+            personal_position: get_req(4, "personal_position")?,
+            tick_array_lower: get_req(5, "tick_array_lower")?,
+            tick_array_upper: get_req(6, "tick_array_upper")?,
+            token_account_0: get_req(7, "token_account_0")?,
+            token_account_1: get_req(8, "token_account_1")?,
+            token_vault_0: get_req(9, "token_vault_0")?,
+            token_vault_1: get_req(10, "token_vault_1")?,
+            token_program: get_req(11, "token_program")?,
+            token_program_2022: get_req(12, "token_program_2022")?,
+            vault_0_mint: get_req(13, "vault_0_mint")?,
+            vault_1_mint: get_req(14, "vault_1_mint")?,
+        })
+    }
+}
+
+pub fn get_increase_liquidity_v2_accounts(ix: &InstructionView) -> Result<IncreaseLiquidityV2Accounts, AccountsError> {
+    IncreaseLiquidityV2Accounts::try_from(ix)
+}
+
+/// Accounts for the `initialize_reward` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct InitializeRewardAccounts {
+    /// The founder deposit reward token to vault
+    pub reward_funder: Pubkey,
+    pub funder_token_account: Pubkey,
+    /// For check the reward_funder authority
+    pub amm_config: Pubkey,
+    /// Set reward for this pool
+    pub pool_state: Pubkey,
+    /// load info from the account to judge reward permission
+    pub operation_state: Pubkey,
+    /// Reward mint
+    pub reward_token_mint: Pubkey,
+    /// A pda, reward vault
+    pub reward_token_vault: Pubkey,
+    pub reward_token_program: Pubkey,
+    pub system_program: Pubkey,
+    pub rent: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for InitializeRewardAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(InitializeRewardAccounts {
+            reward_funder: get_req(0, "reward_funder")?,
+            funder_token_account: get_req(1, "funder_token_account")?,
+            amm_config: get_req(2, "amm_config")?,
+            pool_state: get_req(3, "pool_state")?,
+            operation_state: get_req(4, "operation_state")?,
+            reward_token_mint: get_req(5, "reward_token_mint")?,
+            reward_token_vault: get_req(6, "reward_token_vault")?,
+            reward_token_program: get_req(7, "reward_token_program")?,
+            system_program: get_req(8, "system_program")?,
+            rent: get_req(9, "rent")?,
+        })
+    }
+}
+
+pub fn get_initialize_reward_accounts(ix: &InstructionView) -> Result<InitializeRewardAccounts, AccountsError> {
+    InitializeRewardAccounts::try_from(ix)
+}
+
+/// Accounts for the `open_position` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct OpenPositionAccounts {
+    /// Pays to mint the position
+    pub payer: Pubkey,
+    pub position_nft_owner: Pubkey,
+    /// Unique token mint address
+    pub position_nft_mint: Pubkey,
+    /// Token account where position NFT will be minted
+    /// This account created in the contract by cpi to avoid large stack variables
+    pub position_nft_account: Pubkey,
+    /// To store metaplex metadata
+    pub metadata_account: Pubkey,
+    /// Add liquidity for this pool
+    pub pool_state: Pubkey,
+    /// Store the information of market marking in range
+    pub protocol_position: Pubkey,
+    pub tick_array_lower: Pubkey,
+    pub tick_array_upper: Pubkey,
+    /// personal position state
+    pub personal_position: Pubkey,
+    /// The token_0 account deposit token to the pool
+    pub token_account_0: Pubkey,
+    /// The token_1 account deposit token to the pool
+    pub token_account_1: Pubkey,
+    /// The address that holds pool tokens for token_0
+    pub token_vault_0: Pubkey,
+    /// The address that holds pool tokens for token_1
+    pub token_vault_1: Pubkey,
+    /// Sysvar for token mint and ATA creation
+    pub rent: Pubkey,
+    /// Program to create the position manager state account
+    pub system_program: Pubkey,
+    /// Program to create mint account and mint tokens
+    pub token_program: Pubkey,
+    /// Program to create an ATA for receiving position NFT
+    pub associated_token_program: Pubkey,
+    /// Program to create NFT metadata
+    pub metadata_program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for OpenPositionAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(OpenPositionAccounts {
+            payer: get_req(0, "payer")?,
+            position_nft_owner: get_req(1, "position_nft_owner")?,
+            position_nft_mint: get_req(2, "position_nft_mint")?,
+            position_nft_account: get_req(3, "position_nft_account")?,
+            metadata_account: get_req(4, "metadata_account")?,
+            pool_state: get_req(5, "pool_state")?,
+            protocol_position: get_req(6, "protocol_position")?,
+            tick_array_lower: get_req(7, "tick_array_lower")?,
+            tick_array_upper: get_req(8, "tick_array_upper")?,
+            personal_position: get_req(9, "personal_position")?,
+            token_account_0: get_req(10, "token_account_0")?,
+            token_account_1: get_req(11, "token_account_1")?,
+            token_vault_0: get_req(12, "token_vault_0")?,
+            token_vault_1: get_req(13, "token_vault_1")?,
+            rent: get_req(14, "rent")?,
+            system_program: get_req(15, "system_program")?,
+            token_program: get_req(16, "token_program")?,
+            associated_token_program: get_req(17, "associated_token_program")?,
+            metadata_program: get_req(18, "metadata_program")?,
+        })
+    }
+}
+
+pub fn get_open_position_accounts(ix: &InstructionView) -> Result<OpenPositionAccounts, AccountsError> {
+    OpenPositionAccounts::try_from(ix)
+}
+
+/// Accounts for the `open_position_v2` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct OpenPositionV2Accounts {
+    /// Pays to mint the position
+    pub payer: Pubkey,
+    pub position_nft_owner: Pubkey,
+    /// Unique token mint address
+    pub position_nft_mint: Pubkey,
+    /// Token account where position NFT will be minted
+    pub position_nft_account: Pubkey,
+    /// To store metaplex metadata
+    pub metadata_account: Pubkey,
+    /// Add liquidity for this pool
+    pub pool_state: Pubkey,
+    /// Store the information of market marking in range
+    pub protocol_position: Pubkey,
+    pub tick_array_lower: Pubkey,
+    pub tick_array_upper: Pubkey,
+    /// personal position state
+    pub personal_position: Pubkey,
+    /// The token_0 account deposit token to the pool
+    pub token_account_0: Pubkey,
+    /// The token_1 account deposit token to the pool
+    pub token_account_1: Pubkey,
+    /// The address that holds pool tokens for token_0
+    pub token_vault_0: Pubkey,
+    /// The address that holds pool tokens for token_1
+    pub token_vault_1: Pubkey,
+    /// Sysvar for token mint and ATA creation
+    pub rent: Pubkey,
+    /// Program to create the position manager state account
+    pub system_program: Pubkey,
+    /// Program to create mint account and mint tokens
+    pub token_program: Pubkey,
+    /// Program to create an ATA for receiving position NFT
+    pub associated_token_program: Pubkey,
+    /// Program to create NFT metadata
+    pub metadata_program: Pubkey,
+    /// Program to create mint account and mint tokens
+    pub token_program_2022: Pubkey,
+    /// The mint of token vault 0
+    pub vault_0_mint: Pubkey,
+    /// The mint of token vault 1
+    pub vault_1_mint: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for OpenPositionV2Accounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(OpenPositionV2Accounts {
+            payer: get_req(0, "payer")?,
+            position_nft_owner: get_req(1, "position_nft_owner")?,
+            position_nft_mint: get_req(2, "position_nft_mint")?,
+            position_nft_account: get_req(3, "position_nft_account")?,
+            metadata_account: get_req(4, "metadata_account")?,
+            pool_state: get_req(5, "pool_state")?,
+            protocol_position: get_req(6, "protocol_position")?,
+            tick_array_lower: get_req(7, "tick_array_lower")?,
+            tick_array_upper: get_req(8, "tick_array_upper")?,
+            personal_position: get_req(9, "personal_position")?,
+            token_account_0: get_req(10, "token_account_0")?,
+            token_account_1: get_req(11, "token_account_1")?,
+            token_vault_0: get_req(12, "token_vault_0")?,
+            token_vault_1: get_req(13, "token_vault_1")?,
+            rent: get_req(14, "rent")?,
+            system_program: get_req(15, "system_program")?,
+            token_program: get_req(16, "token_program")?,
+            associated_token_program: get_req(17, "associated_token_program")?,
+            metadata_program: get_req(18, "metadata_program")?,
+            token_program_2022: get_req(19, "token_program_2022")?,
+            vault_0_mint: get_req(20, "vault_0_mint")?,
+            vault_1_mint: get_req(21, "vault_1_mint")?,
+        })
+    }
+}
+
+pub fn get_open_position_v2_accounts(ix: &InstructionView) -> Result<OpenPositionV2Accounts, AccountsError> {
+    OpenPositionV2Accounts::try_from(ix)
+}
+
+/// Accounts for the `open_position_with_token22_nft` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct OpenPositionWithToken22NftAccounts {
+    /// Pays to mint the position
+    pub payer: Pubkey,
+    pub position_nft_owner: Pubkey,
+    /// Unique token mint address, initialize in contract
+    pub position_nft_mint: Pubkey,
+    pub position_nft_account: Pubkey,
+    /// Add liquidity for this pool
+    pub pool_state: Pubkey,
+    /// Store the information of market marking in range
+    pub protocol_position: Pubkey,
+    pub tick_array_lower: Pubkey,
+    pub tick_array_upper: Pubkey,
+    /// personal position state
+    pub personal_position: Pubkey,
+    /// The token_0 account deposit token to the pool
+    pub token_account_0: Pubkey,
+    /// The token_1 account deposit token to the pool
+    pub token_account_1: Pubkey,
+    /// The address that holds pool tokens for token_0
+    pub token_vault_0: Pubkey,
+    /// The address that holds pool tokens for token_1
+    pub token_vault_1: Pubkey,
+    /// Sysvar for token mint and ATA creation
+    pub rent: Pubkey,
+    /// Program to create the position manager state account
+    pub system_program: Pubkey,
+    /// Program to transfer for token account
+    pub token_program: Pubkey,
+    /// Program to create an ATA for receiving position NFT
+    pub associated_token_program: Pubkey,
+    /// Program to create NFT mint/token account and transfer for token22 account
+    pub token_program_2022: Pubkey,
+    /// The mint of token vault 0
+    pub vault_0_mint: Pubkey,
+    /// The mint of token vault 1
+    pub vault_1_mint: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for OpenPositionWithToken22NftAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(OpenPositionWithToken22NftAccounts {
+            payer: get_req(0, "payer")?,
+            position_nft_owner: get_req(1, "position_nft_owner")?,
+            position_nft_mint: get_req(2, "position_nft_mint")?,
+            position_nft_account: get_req(3, "position_nft_account")?,
+            pool_state: get_req(4, "pool_state")?,
+            protocol_position: get_req(5, "protocol_position")?,
+            tick_array_lower: get_req(6, "tick_array_lower")?,
+            tick_array_upper: get_req(7, "tick_array_upper")?,
+            personal_position: get_req(8, "personal_position")?,
+            token_account_0: get_req(9, "token_account_0")?,
+            token_account_1: get_req(10, "token_account_1")?,
+            token_vault_0: get_req(11, "token_vault_0")?,
+            token_vault_1: get_req(12, "token_vault_1")?,
+            rent: get_req(13, "rent")?,
+            system_program: get_req(14, "system_program")?,
+            token_program: get_req(15, "token_program")?,
+            associated_token_program: get_req(16, "associated_token_program")?,
+            token_program_2022: get_req(17, "token_program_2022")?,
+            vault_0_mint: get_req(18, "vault_0_mint")?,
+            vault_1_mint: get_req(19, "vault_1_mint")?,
+        })
+    }
+}
+
+pub fn get_open_position_with_token22_nft_accounts(ix: &InstructionView) -> Result<OpenPositionWithToken22NftAccounts, AccountsError> {
+    OpenPositionWithToken22NftAccounts::try_from(ix)
+}
+
+/// Accounts for the `set_reward_params` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SetRewardParamsAccounts {
+    /// Address to be set as protocol owner. It pays to create factory state account.
+    pub authority: Pubkey,
+    pub amm_config: Pubkey,
+    pub pool_state: Pubkey,
+    /// load info from the account to judge reward permission
+    pub operation_state: Pubkey,
+    /// Token program
+    pub token_program: Pubkey,
+    /// Token program 2022
+    pub token_program_2022: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for SetRewardParamsAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(SetRewardParamsAccounts {
+            authority: get_req(0, "authority")?,
+            amm_config: get_req(1, "amm_config")?,
+            pool_state: get_req(2, "pool_state")?,
+            operation_state: get_req(3, "operation_state")?,
+            token_program: get_req(4, "token_program")?,
+            token_program_2022: get_req(5, "token_program_2022")?,
+        })
+    }
+}
+
+pub fn get_set_reward_params_accounts(ix: &InstructionView) -> Result<SetRewardParamsAccounts, AccountsError> {
+    SetRewardParamsAccounts::try_from(ix)
+}
+
+/// Accounts for the `swap` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SwapAccounts {
+    /// The user performing the swap
+    pub payer: Pubkey,
+    /// The factory state to read protocol fees
+    pub amm_config: Pubkey,
+    /// The program account of the pool in which the swap will be performed
+    pub pool_state: Pubkey,
+    /// The user token account for input token
+    pub input_token_account: Pubkey,
+    /// The user token account for output token
+    pub output_token_account: Pubkey,
+    /// The vault token account for input token
+    pub input_vault: Pubkey,
+    /// The vault token account for output token
+    pub output_vault: Pubkey,
+    /// The program account for the most recent oracle observation
+    pub observation_state: Pubkey,
+    /// SPL program for token transfers
+    pub token_program: Pubkey,
+    pub tick_array: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for SwapAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(SwapAccounts {
+            payer: get_req(0, "payer")?,
+            amm_config: get_req(1, "amm_config")?,
+            pool_state: get_req(2, "pool_state")?,
+            input_token_account: get_req(3, "input_token_account")?,
+            output_token_account: get_req(4, "output_token_account")?,
+            input_vault: get_req(5, "input_vault")?,
+            output_vault: get_req(6, "output_vault")?,
+            observation_state: get_req(7, "observation_state")?,
+            token_program: get_req(8, "token_program")?,
+            tick_array: get_req(9, "tick_array")?,
+        })
+    }
+}
+
+pub fn get_swap_accounts(ix: &InstructionView) -> Result<SwapAccounts, AccountsError> {
+    SwapAccounts::try_from(ix)
+}
+
+/// Accounts for the `swap_router_base_in` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SwapRouterBaseInAccounts {
+    /// The user performing the swap
+    pub payer: Pubkey,
+    /// The token account that pays input tokens for the swap
+    pub input_token_account: Pubkey,
+    /// The mint of input token
+    pub input_token_mint: Pubkey,
+    /// SPL program for token transfers
+    pub token_program: Pubkey,
+    /// SPL program 2022 for token transfers
+    pub token_program_2022: Pubkey,
+    /// Memo program
+    pub memo_program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for SwapRouterBaseInAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(SwapRouterBaseInAccounts {
+            payer: get_req(0, "payer")?,
+            input_token_account: get_req(1, "input_token_account")?,
+            input_token_mint: get_req(2, "input_token_mint")?,
+            token_program: get_req(3, "token_program")?,
+            token_program_2022: get_req(4, "token_program_2022")?,
+            memo_program: get_req(5, "memo_program")?,
+        })
+    }
+}
+
+pub fn get_swap_router_base_in_accounts(ix: &InstructionView) -> Result<SwapRouterBaseInAccounts, AccountsError> {
+    SwapRouterBaseInAccounts::try_from(ix)
+}
+
+/// Accounts for the `swap_v2` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SwapV2Accounts {
+    /// The user performing the swap
+    pub payer: Pubkey,
+    /// The factory state to read protocol fees
+    pub amm_config: Pubkey,
+    /// The program account of the pool in which the swap will be performed
+    pub pool_state: Pubkey,
+    /// The user token account for input token
+    pub input_token_account: Pubkey,
+    /// The user token account for output token
+    pub output_token_account: Pubkey,
+    /// The vault token account for input token
+    pub input_vault: Pubkey,
+    /// The vault token account for output token
+    pub output_vault: Pubkey,
+    /// The program account for the most recent oracle observation
+    pub observation_state: Pubkey,
+    /// SPL program for token transfers
+    pub token_program: Pubkey,
+    /// SPL program 2022 for token transfers
+    pub token_program_2022: Pubkey,
+    /// Memo program
+    pub memo_program: Pubkey,
+    /// The mint of token vault 0
+    pub input_vault_mint: Pubkey,
+    /// The mint of token vault 1
+    pub output_vault_mint: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for SwapV2Accounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(SwapV2Accounts {
+            payer: get_req(0, "payer")?,
+            amm_config: get_req(1, "amm_config")?,
+            pool_state: get_req(2, "pool_state")?,
+            input_token_account: get_req(3, "input_token_account")?,
+            output_token_account: get_req(4, "output_token_account")?,
+            input_vault: get_req(5, "input_vault")?,
+            output_vault: get_req(6, "output_vault")?,
+            observation_state: get_req(7, "observation_state")?,
+            token_program: get_req(8, "token_program")?,
+            token_program_2022: get_req(9, "token_program_2022")?,
+            memo_program: get_req(10, "memo_program")?,
+            input_vault_mint: get_req(11, "input_vault_mint")?,
+            output_vault_mint: get_req(12, "output_vault_mint")?,
+        })
+    }
+}
+
+pub fn get_swap_v2_accounts(ix: &InstructionView) -> Result<SwapV2Accounts, AccountsError> {
+    SwapV2Accounts::try_from(ix)
+}
+
+/// Accounts for the `transfer_reward_owner` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct TransferRewardOwnerAccounts {
+    /// Address to be set as operation account owner.
+    pub authority: Pubkey,
+    pub pool_state: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for TransferRewardOwnerAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(TransferRewardOwnerAccounts {
+            authority: get_req(0, "authority")?,
+            pool_state: get_req(1, "pool_state")?,
+        })
+    }
+}
+
+pub fn get_transfer_reward_owner_accounts(ix: &InstructionView) -> Result<TransferRewardOwnerAccounts, AccountsError> {
+    TransferRewardOwnerAccounts::try_from(ix)
+}
+
+/// Accounts for the `update_amm_config` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct UpdateAmmConfigAccounts {
+    /// The amm config owner or admin
+    pub owner: Pubkey,
+    /// Amm config account to be changed
+    pub amm_config: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for UpdateAmmConfigAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(UpdateAmmConfigAccounts {
+            owner: get_req(0, "owner")?,
+            amm_config: get_req(1, "amm_config")?,
+        })
+    }
+}
+
+pub fn get_update_amm_config_accounts(ix: &InstructionView) -> Result<UpdateAmmConfigAccounts, AccountsError> {
+    UpdateAmmConfigAccounts::try_from(ix)
+}
+
+/// Accounts for the `update_operation_account` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct UpdateOperationAccountAccounts {
+    /// Address to be set as operation account owner.
+    pub owner: Pubkey,
+    /// Initialize operation state account to store operation owner address and white list mint.
+    pub operation_state: Pubkey,
+    pub system_program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for UpdateOperationAccountAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(UpdateOperationAccountAccounts {
+            owner: get_req(0, "owner")?,
+            operation_state: get_req(1, "operation_state")?,
+            system_program: get_req(2, "system_program")?,
+        })
+    }
+}
+
+pub fn get_update_operation_account_accounts(ix: &InstructionView) -> Result<UpdateOperationAccountAccounts, AccountsError> {
+    UpdateOperationAccountAccounts::try_from(ix)
+}
+
+/// Accounts for the `update_pool_status` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct UpdatePoolStatusAccounts {
+    pub authority: Pubkey,
+    pub pool_state: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for UpdatePoolStatusAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(UpdatePoolStatusAccounts {
+            authority: get_req(0, "authority")?,
+            pool_state: get_req(1, "pool_state")?,
+        })
+    }
+}
+
+pub fn get_update_pool_status_accounts(ix: &InstructionView) -> Result<UpdatePoolStatusAccounts, AccountsError> {
+    UpdatePoolStatusAccounts::try_from(ix)
+}
+
+/// Accounts for the `update_reward_infos` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct UpdateRewardInfosAccounts {
+    /// The liquidity pool for which reward info to update
+    pub pool_state: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for UpdateRewardInfosAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(UpdateRewardInfosAccounts {
+            pool_state: get_req(0, "pool_state")?,
+        })
+    }
+}
+
+pub fn get_update_reward_infos_accounts(ix: &InstructionView) -> Result<UpdateRewardInfosAccounts, AccountsError> {
+    UpdateRewardInfosAccounts::try_from(ix)
+}

--- a/src/raydium/clmm/v3/events.rs
+++ b/src/raydium/clmm/v3/events.rs
@@ -1,4 +1,4 @@
-//! Raydium CLMM swap events.
+//! Raydium CLMM events.
 
 use crate::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -6,36 +6,245 @@ use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
 // -----------------------------------------------------------------------------
-// Discriminator
+// Discriminators
 // -----------------------------------------------------------------------------
+pub const COLLECT_PERSONAL_FEE_EVENT: [u8; 8] = [166, 174, 105, 192, 81, 161, 83, 105];
+pub const COLLECT_PROTOCOL_FEE_EVENT: [u8; 8] = [206, 87, 17, 79, 45, 41, 213, 61];
+pub const CONFIG_CHANGE_EVENT: [u8; 8] = [247, 189, 7, 119, 106, 112, 95, 151];
+pub const CREATE_PERSONAL_POSITION_EVENT: [u8; 8] = [100, 30, 87, 249, 196, 223, 154, 206];
+pub const DECREASE_LIQUIDITY_EVENT: [u8; 8] = [58, 222, 86, 58, 68, 50, 85, 56];
+pub const INCREASE_LIQUIDITY_EVENT: [u8; 8] = [49, 79, 105, 212, 32, 34, 30, 84];
+pub const LIQUIDITY_CALCULATE_EVENT: [u8; 8] = [237, 112, 148, 230, 57, 84, 180, 162];
+pub const LIQUIDITY_CHANGE_EVENT: [u8; 8] = [126, 240, 175, 206, 158, 88, 153, 107];
+pub const POOL_CREATED_EVENT: [u8; 8] = [25, 94, 75, 47, 112, 99, 53, 63];
 pub const SWAP_EVENT: [u8; 8] = [64, 198, 205, 232, 38, 8, 113, 226];
+pub const UPDATE_REWARD_INFOS_EVENT: [u8; 8] = [109, 127, 186, 78, 114, 65, 37, 236];
 
 // -----------------------------------------------------------------------------
 // Event enumeration
 // -----------------------------------------------------------------------------
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RaydiumClmmEvent {
+    CollectPersonalFeeEvent(CollectPersonalFeeEvent),
+    CollectProtocolFeeEvent(CollectProtocolFeeEvent),
+    ConfigChangeEvent(ConfigChangeEvent),
+    CreatePersonalPositionEvent(CreatePersonalPositionEvent),
+    DecreaseLiquidityEvent(DecreaseLiquidityEvent),
+    IncreaseLiquidityEvent(IncreaseLiquidityEvent),
+    LiquidityCalculateEvent(LiquidityCalculateEvent),
+    LiquidityChangeEvent(LiquidityChangeEvent),
+    PoolCreatedEvent(PoolCreatedEvent),
     SwapEvent(SwapEvent),
+    UpdateRewardInfosEvent(UpdateRewardInfosEvent),
     Unknown,
 }
 
 // -----------------------------------------------------------------------------
-// Payload struct
+// Payload structs
 // -----------------------------------------------------------------------------
+/// Emitted when tokens are collected for a position
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CollectPersonalFeeEvent {
+    /// The ID of the token for which underlying tokens were collected
+    pub position_nft_mint: Pubkey,
+    /// The token account that received the collected token_0 tokens
+    pub recipient_token_account_0: Pubkey,
+    /// The token account that received the collected token_1 tokens
+    pub recipient_token_account_1: Pubkey,
+    /// The amount of token_0 owed to the position that was collected
+    pub amount_0: u64,
+    /// The amount of token_1 owed to the position that was collected
+    pub amount_1: u64,
+}
+
+/// Emitted when the collected protocol fees are withdrawn by the factory owner
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CollectProtocolFeeEvent {
+    /// The pool whose protocol fee is collected
+    pub pool_state: Pubkey,
+    /// The address that receives the collected token_0 protocol fees
+    pub recipient_token_account_0: Pubkey,
+    /// The address that receives the collected token_1 protocol fees
+    pub recipient_token_account_1: Pubkey,
+    /// The amount of token_0 protocol fees that is withdrawn
+    pub amount_0: u64,
+    /// The amount of token_0 protocol fees that is withdrawn
+    pub amount_1: u64,
+}
+
+/// Emitted when create or update a config
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct ConfigChangeEvent {
+    pub index: u16,
+    pub owner: Pubkey,
+    pub protocol_fee_rate: u32,
+    pub trade_fee_rate: u32,
+    pub tick_spacing: u16,
+    pub fund_fee_rate: u32,
+    pub fund_owner: Pubkey,
+}
+
+/// Emitted when create a new position
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CreatePersonalPositionEvent {
+    /// The pool for which liquidity was added
+    pub pool_state: Pubkey,
+    /// The address that create the position
+    pub minter: Pubkey,
+    /// The owner of the position and recipient of any minted liquidity
+    pub nft_owner: Pubkey,
+    /// The lower tick of the position
+    pub tick_lower_index: i32,
+    /// The upper tick of the position
+    pub tick_upper_index: i32,
+    /// The amount of liquidity minted to the position range
+    pub liquidity: u128,
+    /// The amount of token_0 was deposit for the liquidity
+    pub deposit_amount_0: u64,
+    /// The amount of token_1 was deposit for the liquidity
+    pub deposit_amount_1: u64,
+    /// The token transfer fee for deposit_amount_0
+    pub deposit_amount_0_transfer_fee: u64,
+    /// The token transfer fee for deposit_amount_1
+    pub deposit_amount_1_transfer_fee: u64,
+}
+
+/// Emitted when liquidity is decreased.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct DecreaseLiquidityEvent {
+    /// The ID of the token for which liquidity was decreased
+    pub position_nft_mint: Pubkey,
+    /// The amount by which liquidity for the position was decreased
+    pub liquidity: u128,
+    /// The amount of token_0 that was paid for the decrease in liquidity
+    pub decrease_amount_0: u64,
+    /// The amount of token_1 that was paid for the decrease in liquidity
+    pub decrease_amount_1: u64,
+    pub fee_amount_0: u64,
+    /// The amount of token_1 fee
+    pub fee_amount_1: u64,
+    /// The amount of rewards
+    pub reward_amounts: [u64; 3],
+    /// The amount of token_0 transfer fee
+    pub transfer_fee_0: u64,
+    /// The amount of token_1 transfer fee
+    pub transfer_fee_1: u64,
+}
+
+/// Emitted when liquidity is increased.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct IncreaseLiquidityEvent {
+    /// The ID of the token for which liquidity was increased
+    pub position_nft_mint: Pubkey,
+    /// The amount by which liquidity for the NFT position was increased
+    pub liquidity: u128,
+    /// The amount of token_0 that was paid for the increase in liquidity
+    pub amount_0: u64,
+    /// The amount of token_1 that was paid for the increase in liquidity
+    pub amount_1: u64,
+    /// The token transfer fee for amount_0
+    pub amount_0_transfer_fee: u64,
+    /// The token transfer fee for amount_1
+    pub amount_1_transfer_fee: u64,
+}
+
+/// Emitted when liquidity decreased or increase.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct LiquidityCalculateEvent {
+    /// The pool liquidity before decrease or increase
+    pub pool_liquidity: u128,
+    /// The pool price when decrease or increase in liquidity
+    pub pool_sqrt_price_x64: u128,
+    /// The pool tick when decrease or increase in liquidity
+    pub pool_tick: i32,
+    /// The amount of token_0 that was calculated for the decrease or increase in liquidity
+    pub calc_amount_0: u64,
+    /// The amount of token_1 that was calculated for the decrease or increase in liquidity
+    pub calc_amount_1: u64,
+    pub trade_fee_owed_0: u64,
+    /// The amount of token_1 fee
+    pub trade_fee_owed_1: u64,
+    /// The amount of token_0 transfer fee without trade_fee_amount_0
+    pub transfer_fee_0: u64,
+    /// The amount of token_1 transfer fee without trade_fee_amount_0
+    pub transfer_fee_1: u64,
+}
+
+/// Emitted pool liquidity change when increase and decrease liquidity
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct LiquidityChangeEvent {
+    /// The pool for swap
+    pub pool_state: Pubkey,
+    /// The tick of the pool
+    pub tick: i32,
+    /// The tick lower of position
+    pub tick_lower: i32,
+    /// The tick lower of position
+    pub tick_upper: i32,
+    /// The liquidity of the pool before liquidity change
+    pub liquidity_before: u128,
+    /// The liquidity of the pool after liquidity change
+    pub liquidity_after: u128,
+}
+
+/// Emitted when a pool is created and initialized with a starting price
+///
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct PoolCreatedEvent {
+    /// The first token of the pool by address sort order
+    pub token_mint_0: Pubkey,
+    /// The second token of the pool by address sort order
+    pub token_mint_1: Pubkey,
+    /// The minimum number of ticks between initialized ticks
+    pub tick_spacing: u16,
+    /// The address of the created pool
+    pub pool_state: Pubkey,
+    /// The initial sqrt price of the pool, as a Q64.64
+    pub sqrt_price_x64: u128,
+    /// The initial tick of the pool, i.e. log base 1.0001 of the starting price of the pool
+    pub tick: i32,
+    /// Vault of token_0
+    pub token_vault_0: Pubkey,
+    /// Vault of token_1
+    pub token_vault_1: Pubkey,
+}
+
+/// Emitted by when a swap is performed for a pool
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
 pub struct SwapEvent {
+    /// The pool for which token_0 and token_1 were swapped
     pub pool_state: Pubkey,
+    /// The address that initiated the swap call, and that received the callback
     pub sender: Pubkey,
+    /// The payer token account in zero for one swaps, or the recipient token account
+    /// in one for zero swaps
     pub token_account_0: Pubkey,
+    /// The payer token account in one for zero swaps, or the recipient token account
+    /// in zero for one swaps
     pub token_account_1: Pubkey,
+    /// The real delta amount of the token_0 of the pool or user
     pub amount_0: u64,
+    /// The transfer fee charged by the withheld_amount of the token_0
     pub transfer_fee_0: u64,
+    /// The real delta of the token_1 of the pool or user
     pub amount_1: u64,
+    /// The transfer fee charged by the withheld_amount of the token_1
     pub transfer_fee_1: u64,
+    /// if true, amount_0 is negtive and amount_1 is positive
     pub zero_for_one: bool,
+    /// The sqrt(price) of the pool after the swap, as a Q64.64
     pub sqrt_price_x64: u128,
+    /// The liquidity of the pool after the swap
     pub liquidity: u128,
+    /// The log base 1.0001 of price of the pool after the swap
     pub tick: i32,
+}
+
+/// Emitted when Reward are updated for a pool
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct UpdateRewardInfosEvent {
+    /// Reward info
+    pub reward_growth_global_x64: [u128; 3],
 }
 
 // -----------------------------------------------------------------------------
@@ -48,12 +257,20 @@ impl<'a> TryFrom<&'a [u8]> for RaydiumClmmEvent {
         if data.len() < 8 {
             return Err(ParseError::TooShort(data.len()));
         }
-
         let disc: [u8; 8] = data[0..8].try_into().expect("slice len 8");
         let payload = &data[8..];
-
         Ok(match disc {
+            COLLECT_PERSONAL_FEE_EVENT => Self::CollectPersonalFeeEvent(CollectPersonalFeeEvent::try_from_slice(payload)?),
+            COLLECT_PROTOCOL_FEE_EVENT => Self::CollectProtocolFeeEvent(CollectProtocolFeeEvent::try_from_slice(payload)?),
+            CONFIG_CHANGE_EVENT => Self::ConfigChangeEvent(ConfigChangeEvent::try_from_slice(payload)?),
+            CREATE_PERSONAL_POSITION_EVENT => Self::CreatePersonalPositionEvent(CreatePersonalPositionEvent::try_from_slice(payload)?),
+            DECREASE_LIQUIDITY_EVENT => Self::DecreaseLiquidityEvent(DecreaseLiquidityEvent::try_from_slice(payload)?),
+            INCREASE_LIQUIDITY_EVENT => Self::IncreaseLiquidityEvent(IncreaseLiquidityEvent::try_from_slice(payload)?),
+            LIQUIDITY_CALCULATE_EVENT => Self::LiquidityCalculateEvent(LiquidityCalculateEvent::try_from_slice(payload)?),
+            LIQUIDITY_CHANGE_EVENT => Self::LiquidityChangeEvent(LiquidityChangeEvent::try_from_slice(payload)?),
+            POOL_CREATED_EVENT => Self::PoolCreatedEvent(PoolCreatedEvent::try_from_slice(payload)?),
             SWAP_EVENT => Self::SwapEvent(SwapEvent::try_from_slice(payload)?),
+            UPDATE_REWARD_INFOS_EVENT => Self::UpdateRewardInfosEvent(UpdateRewardInfosEvent::try_from_slice(payload)?),
             other => return Err(ParseError::Unknown(other)),
         })
     }

--- a/src/raydium/clmm/v3/instructions.rs
+++ b/src/raydium/clmm/v3/instructions.rs
@@ -1,36 +1,431 @@
-//! Raydium CLMM swap instructions.
+//! Raydium CLMM instructions.
 
 use crate::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
+use solana_program::pubkey::Pubkey;
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct InitializeRewardParam {
+    /// Reward open time
+    pub open_time: u64,
+    /// Reward end time
+    pub end_time: u64,
+    /// Token reward per second are earned per unit of liquidity
+    pub emissions_per_second_x64: u128,
+}
 
 // -----------------------------------------------------------------------------
-// Discriminator
+// Discriminators
 // -----------------------------------------------------------------------------
-#[deprecated = "Use SWAP_V2 instead"]
+pub const CLOSE_POSITION: [u8; 8] = [123, 134, 81, 0, 49, 68, 98, 98];
+pub const COLLECT_FUND_FEE: [u8; 8] = [167, 138, 78, 149, 223, 194, 6, 126];
+pub const COLLECT_PROTOCOL_FEE: [u8; 8] = [136, 136, 252, 221, 194, 66, 126, 89];
+pub const COLLECT_REMAINING_REWARDS: [u8; 8] = [18, 237, 166, 197, 34, 16, 213, 144];
+pub const CREATE_AMM_CONFIG: [u8; 8] = [137, 52, 237, 212, 215, 117, 108, 104];
+pub const CREATE_OPERATION_ACCOUNT: [u8; 8] = [63, 87, 148, 33, 109, 35, 8, 104];
+pub const CREATE_POOL: [u8; 8] = [233, 146, 209, 142, 207, 104, 64, 188];
+pub const CREATE_SUPPORT_MINT_ASSOCIATED: [u8; 8] = [17, 251, 65, 92, 136, 242, 14, 169];
+pub const DECREASE_LIQUIDITY: [u8; 8] = [160, 38, 208, 111, 104, 91, 44, 1];
+pub const DECREASE_LIQUIDITY_V2: [u8; 8] = [58, 127, 188, 62, 79, 82, 196, 96];
+pub const INCREASE_LIQUIDITY: [u8; 8] = [46, 156, 243, 118, 13, 205, 251, 178];
+pub const INCREASE_LIQUIDITY_V2: [u8; 8] = [133, 29, 89, 223, 69, 238, 176, 10];
+pub const INITIALIZE_REWARD: [u8; 8] = [95, 135, 192, 196, 242, 129, 230, 68];
+pub const OPEN_POSITION: [u8; 8] = [135, 128, 47, 77, 15, 152, 240, 49];
+pub const OPEN_POSITION_V2: [u8; 8] = [77, 184, 74, 214, 112, 86, 241, 199];
+pub const OPEN_POSITION_WITH_TOKEN22_NFT: [u8; 8] = [77, 255, 174, 82, 125, 29, 201, 46];
+pub const SET_REWARD_PARAMS: [u8; 8] = [112, 52, 167, 75, 32, 201, 211, 137];
 pub const SWAP: [u8; 8] = [248, 198, 158, 145, 225, 117, 135, 200];
+pub const SWAP_ROUTER_BASE_IN: [u8; 8] = [69, 125, 115, 218, 245, 186, 242, 196];
 pub const SWAP_V2: [u8; 8] = [43, 4, 237, 11, 26, 201, 30, 98];
+pub const TRANSFER_REWARD_OWNER: [u8; 8] = [7, 22, 12, 83, 242, 43, 48, 121];
+pub const UPDATE_AMM_CONFIG: [u8; 8] = [49, 60, 174, 136, 154, 28, 116, 200];
+pub const UPDATE_OPERATION_ACCOUNT: [u8; 8] = [127, 70, 119, 40, 188, 227, 61, 7];
+pub const UPDATE_POOL_STATUS: [u8; 8] = [130, 87, 108, 6, 46, 224, 117, 123];
+pub const UPDATE_REWARD_INFOS: [u8; 8] = [163, 172, 224, 52, 11, 154, 106, 223];
 
 // -----------------------------------------------------------------------------
-// Event enumeration
+// Instruction enumeration
 // -----------------------------------------------------------------------------
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RaydiumClmmInstruction {
-    #[deprecated = "Use SwapV2 instead"]
+    ClosePosition,
+    CollectFundFee(CollectFundFeeInstruction),
+    CollectProtocolFee(CollectProtocolFeeInstruction),
+    CollectRemainingRewards(CollectRemainingRewardsInstruction),
+    CreateAmmConfig(CreateAmmConfigInstruction),
+    CreateOperationAccount,
+    CreatePool(CreatePoolInstruction),
+    CreateSupportMintAssociated,
+    DecreaseLiquidity(DecreaseLiquidityInstruction),
+    DecreaseLiquidityV2(DecreaseLiquidityV2Instruction),
+    IncreaseLiquidity(IncreaseLiquidityInstruction),
+    IncreaseLiquidityV2(IncreaseLiquidityV2Instruction),
+    InitializeReward(InitializeRewardInstruction),
+    OpenPosition(OpenPositionInstruction),
+    OpenPositionV2(OpenPositionV2Instruction),
+    OpenPositionWithToken22Nft(OpenPositionWithToken22NftInstruction),
+    SetRewardParams(SetRewardParamsInstruction),
     Swap(SwapInstruction),
+    SwapRouterBaseIn(SwapRouterBaseInInstruction),
     SwapV2(SwapInstruction),
+    TransferRewardOwner(TransferRewardOwnerInstruction),
+    UpdateAmmConfig(UpdateAmmConfigInstruction),
+    UpdateOperationAccount(UpdateOperationAccountInstruction),
+    UpdatePoolStatus(UpdatePoolStatusInstruction),
+    UpdateRewardInfos,
     Unknown,
 }
 
 // -----------------------------------------------------------------------------
-// Payload struct
+// Payload structs
 // -----------------------------------------------------------------------------
+/// Collect the fund fee accrued to the pool
+///
+/// # Arguments
+///
+/// * `ctx` - The context of accounts
+/// * `amount_0_requested` - The maximum amount of token_0 to send, can be 0 to collect fees in only token_1
+/// * `amount_1_requested` - The maximum amount of token_1 to send, can be 0 to collect fees in only token_0
+///
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CollectFundFeeInstruction {
+    pub amount_0_requested: u64,
+    pub amount_1_requested: u64,
+}
+
+/// Collect the protocol fee accrued to the pool
+///
+/// # Arguments
+///
+/// * `ctx` - The context of accounts
+/// * `amount_0_requested` - The maximum amount of token_0 to send, can be 0 to collect fees in only token_1
+/// * `amount_1_requested` - The maximum amount of token_1 to send, can be 0 to collect fees in only token_0
+///
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CollectProtocolFeeInstruction {
+    pub amount_0_requested: u64,
+    pub amount_1_requested: u64,
+}
+
+/// Collect remaining reward token for reward founder
+///
+/// # Arguments
+///
+/// * `ctx`- The context of accounts
+/// * `reward_index` - the index to reward info
+///
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CollectRemainingRewardsInstruction {
+    pub reward_index: u8,
+}
+
+/// # Arguments
+///
+/// * `ctx`- The accounts needed by instruction.
+/// * `index` - The index of amm config, there may be multiple config.
+/// * `tick_spacing` - The tickspacing binding with config, cannot be changed.
+/// * `trade_fee_rate` - Trade fee rate, can be changed.
+/// * `protocol_fee_rate` - The rate of protocol fee within trade fee.
+/// * `fund_fee_rate` - The rate of fund fee within trade fee.
+///
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CreateAmmConfigInstruction {
+    pub index: u16,
+    pub tick_spacing: u16,
+    pub trade_fee_rate: u32,
+    pub protocol_fee_rate: u32,
+    pub fund_fee_rate: u32,
+}
+
+/// Creates a pool for the given token pair and the initial price
+///
+/// # Arguments
+///
+/// * `ctx`- The context of accounts
+/// * `sqrt_price_x64` - the initial sqrt price (amount_token_1 / amount_token_0) of the pool as a Q64.64
+/// Note: The open_time must be smaller than the current block_timestamp on chain.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CreatePoolInstruction {
+    pub sqrt_price_x64: u128,
+    pub open_time: u64,
+}
+
+/// #[deprecated(note = "Use `decrease_liquidity_v2` instead.")]
+/// Decreases liquidity for an existing position
+///
+/// # Arguments
+///
+/// * `ctx` -  The context of accounts
+/// * `liquidity` - The amount by which liquidity will be decreased
+/// * `amount_0_min` - The minimum amount of token_0 that should be accounted for the burned liquidity
+/// * `amount_1_min` - The minimum amount of token_1 that should be accounted for the burned liquidity
+///
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct DecreaseLiquidityInstruction {
+    pub liquidity: u128,
+    pub amount_0_min: u64,
+    pub amount_1_min: u64,
+}
+
+/// Decreases liquidity for an existing position, support Token2022
+///
+/// # Arguments
+///
+/// * `ctx` -  The context of accounts
+/// * `liquidity` - The amount by which liquidity will be decreased
+/// * `amount_0_min` - The minimum amount of token_0 that should be accounted for the burned liquidity
+/// * `amount_1_min` - The minimum amount of token_1 that should be accounted for the burned liquidity
+///
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct DecreaseLiquidityV2Instruction {
+    pub liquidity: u128,
+    pub amount_0_min: u64,
+    pub amount_1_min: u64,
+}
+
+/// #[deprecated(note = "Use `increase_liquidity_v2` instead.")]
+/// Increases liquidity for an existing position, with amount paid by `payer`
+///
+/// # Arguments
+///
+/// * `ctx` - The context of accounts
+/// * `liquidity` - The desired liquidity to be added, can't be zero
+/// * `amount_0_max` - The max amount of token_0 to spend, which serves as a slippage check
+/// * `amount_1_max` - The max amount of token_1 to spend, which serves as a slippage check
+///
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct IncreaseLiquidityInstruction {
+    pub liquidity: u128,
+    pub amount_0_max: u64,
+    pub amount_1_max: u64,
+}
+
+/// Increases liquidity for an existing position, with amount paid by `payer`, support Token2022
+///
+/// # Arguments
+///
+/// * `ctx` - The context of accounts
+/// * `liquidity` - The desired liquidity to be added, if zero, calculate liquidity base amount_0 or amount_1 according base_flag
+/// * `amount_0_max` - The max amount of token_0 to spend, which serves as a slippage check
+/// * `amount_1_max` - The max amount of token_1 to spend, which serves as a slippage check
+/// * `base_flag` - must be specified if liquidity is zero, true: calculate liquidity base amount_0_max otherwise base amount_1_max
+///
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct IncreaseLiquidityV2Instruction {
+    pub liquidity: u128,
+    pub amount_0_max: u64,
+    pub amount_1_max: u64,
+    pub base_flag: Option<bool>,
+}
+
+/// Initialize a reward info for a given pool and reward index
+///
+/// # Arguments
+///
+/// * `ctx`- The context of accounts
+/// * `reward_index` - the index to reward info
+/// * `open_time` - reward open timestamp
+/// * `end_time` - reward end timestamp
+/// * `emissions_per_second_x64` - Token reward per second are earned per unit of liquidity.
+///
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct InitializeRewardInstruction {
+    pub param: InitializeRewardParam,
+}
+
+/// #[deprecated(note = "Use `open_position_with_token22_nft` instead.")]
+/// Creates a new position wrapped in a NFT
+///
+/// # Arguments
+///
+/// * `ctx` - The context of accounts
+/// * `tick_lower_index` - The low boundary of market
+/// * `tick_upper_index` - The upper boundary of market
+/// * `tick_array_lower_start_index` - The start index of tick array which include tick low
+/// * `tick_array_upper_start_index` - The start index of tick array which include tick upper
+/// * `liquidity` - The liquidity to be added
+/// * `amount_0_max` - The max amount of token_0 to spend, which serves as a slippage check
+/// * `amount_1_max` - The max amount of token_1 to spend, which serves as a slippage check
+///
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct OpenPositionInstruction {
+    pub tick_lower_index: i32,
+    pub tick_upper_index: i32,
+    pub tick_array_lower_start_index: i32,
+    pub tick_array_upper_start_index: i32,
+    pub liquidity: u128,
+    pub amount_0_max: u64,
+    pub amount_1_max: u64,
+}
+
+/// #[deprecated(note = "Use `open_position_with_token22_nft` instead.")]
+/// Creates a new position wrapped in a NFT, support Token2022
+///
+/// # Arguments
+///
+/// * `ctx` - The context of accounts
+/// * `tick_lower_index` - The low boundary of market
+/// * `tick_upper_index` - The upper boundary of market
+/// * `tick_array_lower_start_index` - The start index of tick array which include tick low
+/// * `tick_array_upper_start_index` - The start index of tick array which include tick upper
+/// * `liquidity` - The liquidity to be added, if zero, and the base_flag is specified, calculate liquidity base amount_0_max or amount_1_max according base_flag, otherwise open position with zero liquidity
+/// * `amount_0_max` - The max amount of token_0 to spend, which serves as a slippage check
+/// * `amount_1_max` - The max amount of token_1 to spend, which serves as a slippage check
+/// * `with_metadata` - The flag indicating whether to create NFT mint metadata
+/// * `base_flag` - if the liquidity specified as zero, true: calculate liquidity base amount_0_max otherwise base amount_1_max
+///
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct OpenPositionV2Instruction {
+    pub tick_lower_index: i32,
+    pub tick_upper_index: i32,
+    pub tick_array_lower_start_index: i32,
+    pub tick_array_upper_start_index: i32,
+    pub liquidity: u128,
+    pub amount_0_max: u64,
+    pub amount_1_max: u64,
+    pub with_metadata: bool,
+    pub base_flag: Option<bool>,
+}
+
+/// Creates a new position wrapped in a Token2022 NFT without relying on metadata_program and metadata_account, reduce the cost for user to create a personal position.
+///
+/// # Arguments
+///
+/// * `ctx` - The context of accounts
+/// * `tick_lower_index` - The low boundary of market
+/// * `tick_upper_index` - The upper boundary of market
+/// * `tick_array_lower_start_index` - The start index of tick array which include tick low
+/// * `tick_array_upper_start_index` - The start index of tick array which include tick upper
+/// * `liquidity` - The liquidity to be added, if zero, and the base_flag is specified, calculate liquidity base amount_0_max or amount_1_max according base_flag, otherwise open position with zero liquidity
+/// * `amount_0_max` - The max amount of token_0 to spend, which serves as a slippage check
+/// * `amount_1_max` - The max amount of token_1 to spend, which serves as a slippage check
+/// * `with_metadata` - The flag indicating whether to create NFT mint metadata
+/// * `base_flag` - if the liquidity specified as zero, true: calculate liquidity base amount_0_max otherwise base amount_1_max
+///
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct OpenPositionWithToken22NftInstruction {
+    pub tick_lower_index: i32,
+    pub tick_upper_index: i32,
+    pub tick_array_lower_start_index: i32,
+    pub tick_array_upper_start_index: i32,
+    pub liquidity: u128,
+    pub amount_0_max: u64,
+    pub amount_1_max: u64,
+    pub with_metadata: bool,
+    pub base_flag: Option<bool>,
+}
+
+/// Reset reward param, start a new reward cycle or extend the current cycle.
+///
+/// # Arguments
+///
+/// * `ctx` - The context of accounts
+/// * `reward_index` - The index of reward token in the pool.
+/// * `emissions_per_second_x64` - The per second emission reward, when extend the current cycle,
+/// new value can't be less than old value
+/// * `open_time` - reward open timestamp, must be set when starting a new cycle
+/// * `end_time` - reward end timestamp
+///
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SetRewardParamsInstruction {
+    pub reward_index: u8,
+    pub emissions_per_second_x64: u128,
+    pub open_time: u64,
+    pub end_time: u64,
+}
+
+/// #[deprecated(note = "Use `swap_v2` instead.")]
+/// Swaps one token for as much as possible of another token across a single pool
+///
+/// # Arguments
+///
+/// * `ctx` - The context of accounts
+/// * `amount` - Arranged in pairs with other_amount_threshold. (amount_in, amount_out_minimum) or (amount_out, amount_in_maximum)
+/// * `other_amount_threshold` - For slippage check
+/// * `sqrt_price_limit` - The Q64.64 sqrt price √P limit. If zero for one, the price cannot
+/// * `is_base_input` - swap base input or swap base output
+///
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
 pub struct SwapInstruction {
     pub amount: u64,
     pub other_amount_threshold: u64,
     pub sqrt_price_limit_x64: u128,
     pub is_base_input: bool,
+}
+
+/// Swap token for as much as possible of another token across the path provided, base input
+///
+/// # Arguments
+///
+/// * `ctx` - The context of accounts
+/// * `amount_in` - Token amount to be swapped in
+/// * `amount_out_minimum` - Panic if output amount is below minimum amount. For slippage.
+///
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SwapRouterBaseInInstruction {
+    pub amount_in: u64,
+    pub amount_out_minimum: u64,
+}
+
+/// Transfer reward owner
+///
+/// # Arguments
+///
+/// * `ctx`- The context of accounts
+/// * `new_owner`- new owner pubkey
+///
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct TransferRewardOwnerInstruction {
+    pub new_owner: Pubkey,
+}
+
+/// Updates the owner of the amm config
+/// Must be called by the current owner or admin
+///
+/// # Arguments
+///
+/// * `ctx`- The context of accounts
+/// * `trade_fee_rate`- The new trade fee rate of amm config, be set when `param` is 0
+/// * `protocol_fee_rate`- The new protocol fee rate of amm config, be set when `param` is 1
+/// * `fund_fee_rate`- The new fund fee rate of amm config, be set when `param` is 2
+/// * `new_owner`- The config's new owner, be set when `param` is 3
+/// * `new_fund_owner`- The config's new fund owner, be set when `param` is 4
+/// * `param`- The value can be 0 | 1 | 2 | 3 | 4, otherwise will report a error
+///
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct UpdateAmmConfigInstruction {
+    pub param: u8,
+    pub value: u32,
+}
+
+/// Update the operation account
+///
+/// # Arguments
+///
+/// * `ctx`- The context of accounts
+/// * `param`- The value can be 0 | 1 | 2 | 3, otherwise will report a error
+/// * `keys`- update operation owner when the `param` is 0
+/// remove operation owner when the `param` is 1
+/// update whitelist mint when the `param` is 2
+/// remove whitelist mint when the `param` is 3
+///
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct UpdateOperationAccountInstruction {
+    pub param: u8,
+    pub keys: Vec<Pubkey>,
+}
+
+/// Update pool status for given value
+///
+/// # Arguments
+///
+/// * `ctx`- The context of accounts
+/// * `status` - The value of status
+///
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct UpdatePoolStatusInstruction {
+    pub status: u8,
 }
 
 // -----------------------------------------------------------------------------
@@ -44,12 +439,35 @@ impl<'a> TryFrom<&'a [u8]> for RaydiumClmmInstruction {
             return Err(ParseError::TooShort(data.len()));
         }
 
-        let disc: [u8; 8] = data[0..8].try_into().expect("slice len 8");
-        let payload = &data[8..];
+        let (disc, payload) = data.split_at(8);
+        let discriminator: [u8; 8] = disc.try_into().expect("slice len 8");
 
-        Ok(match disc {
+        Ok(match discriminator {
+            CLOSE_POSITION => Self::ClosePosition,
+            COLLECT_FUND_FEE => Self::CollectFundFee(CollectFundFeeInstruction::try_from_slice(payload)?),
+            COLLECT_PROTOCOL_FEE => Self::CollectProtocolFee(CollectProtocolFeeInstruction::try_from_slice(payload)?),
+            COLLECT_REMAINING_REWARDS => Self::CollectRemainingRewards(CollectRemainingRewardsInstruction::try_from_slice(payload)?),
+            CREATE_AMM_CONFIG => Self::CreateAmmConfig(CreateAmmConfigInstruction::try_from_slice(payload)?),
+            CREATE_OPERATION_ACCOUNT => Self::CreateOperationAccount,
+            CREATE_POOL => Self::CreatePool(CreatePoolInstruction::try_from_slice(payload)?),
+            CREATE_SUPPORT_MINT_ASSOCIATED => Self::CreateSupportMintAssociated,
+            DECREASE_LIQUIDITY => Self::DecreaseLiquidity(DecreaseLiquidityInstruction::try_from_slice(payload)?),
+            DECREASE_LIQUIDITY_V2 => Self::DecreaseLiquidityV2(DecreaseLiquidityV2Instruction::try_from_slice(payload)?),
+            INCREASE_LIQUIDITY => Self::IncreaseLiquidity(IncreaseLiquidityInstruction::try_from_slice(payload)?),
+            INCREASE_LIQUIDITY_V2 => Self::IncreaseLiquidityV2(IncreaseLiquidityV2Instruction::try_from_slice(payload)?),
+            INITIALIZE_REWARD => Self::InitializeReward(InitializeRewardInstruction::try_from_slice(payload)?),
+            OPEN_POSITION => Self::OpenPosition(OpenPositionInstruction::try_from_slice(payload)?),
+            OPEN_POSITION_V2 => Self::OpenPositionV2(OpenPositionV2Instruction::try_from_slice(payload)?),
+            OPEN_POSITION_WITH_TOKEN22_NFT => Self::OpenPositionWithToken22Nft(OpenPositionWithToken22NftInstruction::try_from_slice(payload)?),
+            SET_REWARD_PARAMS => Self::SetRewardParams(SetRewardParamsInstruction::try_from_slice(payload)?),
             SWAP => Self::Swap(SwapInstruction::try_from_slice(payload)?),
+            SWAP_ROUTER_BASE_IN => Self::SwapRouterBaseIn(SwapRouterBaseInInstruction::try_from_slice(payload)?),
             SWAP_V2 => Self::SwapV2(SwapInstruction::try_from_slice(payload)?),
+            TRANSFER_REWARD_OWNER => Self::TransferRewardOwner(TransferRewardOwnerInstruction::try_from_slice(payload)?),
+            UPDATE_AMM_CONFIG => Self::UpdateAmmConfig(UpdateAmmConfigInstruction::try_from_slice(payload)?),
+            UPDATE_OPERATION_ACCOUNT => Self::UpdateOperationAccount(UpdateOperationAccountInstruction::try_from_slice(payload)?),
+            UPDATE_POOL_STATUS => Self::UpdatePoolStatus(UpdatePoolStatusInstruction::try_from_slice(payload)?),
+            UPDATE_REWARD_INFOS => Self::UpdateRewardInfos,
             other => return Err(ParseError::Unknown(other)),
         })
     }

--- a/src/raydium/clmm/v3/mod.rs
+++ b/src/raydium/clmm/v3/mod.rs
@@ -1,5 +1,6 @@
 use substreams_solana::b58;
 
+pub mod accounts;
 pub mod events;
 pub mod instructions;
 


### PR DESCRIPTION
## Summary
- add account parsing for all Raydium CLMM v3 instructions
- expand CLMM instruction enum and payloads
- add CLMM event discriminators and payload structs

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_68b2f6b2e4f8832896a00c4498d78acd