### PR TITLE
feat: add full Raydium cpmm idl

### DIFF
--- a/src/raydium/cpmm/accounts.rs
+++ b/src/raydium/cpmm/accounts.rs
@@ -1,0 +1,778 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+use solana_program::pubkey::Pubkey;
+use substreams_solana::block_view::InstructionView;
+use thiserror::Error;
+
+// -----------------------------------------------------------------------------
+// Error type
+// -----------------------------------------------------------------------------
+#[derive(Debug, Error)]
+pub enum AccountsError {
+    #[error("missing required account `{name}` at index {index}")]
+    Missing { name: &'static str, index: usize },
+    #[error("invalid key length for `{name}` at index {index}: got {got}, want 32")]
+    InvalidLen { name: &'static str, index: usize, got: usize },
+}
+
+#[inline]
+fn to_pubkey(name: &'static str, index: usize, bytes: &[u8]) -> Result<Pubkey, AccountsError> {
+    let arr: [u8; 32] = bytes.try_into().map_err(|_| AccountsError::InvalidLen { name, index, got: bytes.len() })?;
+    Ok(Pubkey::new_from_array(arr))
+}
+
+/// Accounts for the `close_permission_pda` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct ClosePermissionPdaAccounts {
+    pub owner: Pubkey,
+    pub permission_authority: Pubkey,
+    /// Initialize config state account to store protocol owner address and fee rates.
+    pub permission: Pubkey,
+    pub system_program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for ClosePermissionPdaAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(ClosePermissionPdaAccounts {
+            owner: get_req(0, "owner")?,
+            permission_authority: get_req(1, "permission_authority")?,
+            permission: get_req(2, "permission")?,
+            system_program: get_req(3, "system_program")?,
+        })
+    }
+}
+
+pub fn get_close_permission_pda_accounts(ix: &InstructionView) -> Result<ClosePermissionPdaAccounts, AccountsError> {
+    ClosePermissionPdaAccounts::try_from(ix)
+}
+
+/// Accounts for the `collect_creator_fee` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CollectCreatorFeeAccounts {
+    /// Only pool creator can collect fee
+    pub creator: Pubkey,
+    pub authority: Pubkey,
+    /// Pool state stores accumulated protocol fee amount
+    pub pool_state: Pubkey,
+    /// Amm config account stores fund_owner
+    pub amm_config: Pubkey,
+    /// The address that holds pool tokens for token_0
+    pub token_0_vault: Pubkey,
+    /// The address that holds pool tokens for token_1
+    pub token_1_vault: Pubkey,
+    /// The mint of token_0 vault
+    pub vault_0_mint: Pubkey,
+    /// The mint of token_1 vault
+    pub vault_1_mint: Pubkey,
+    /// The address that receives the collected token_0 fund fees
+    pub creator_token_0: Pubkey,
+    /// The address that receives the collected token_1 fund fees
+    pub creator_token_1: Pubkey,
+    /// Spl token program or token program 2022
+    pub token_0_program: Pubkey,
+    /// Spl token program or token program 2022
+    pub token_1_program: Pubkey,
+    /// Program to create an ATA for receiving position NFT
+    pub associated_token_program: Pubkey,
+    /// To create a new program account
+    pub system_program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for CollectCreatorFeeAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(CollectCreatorFeeAccounts {
+            creator: get_req(0, "creator")?,
+            authority: get_req(1, "authority")?,
+            pool_state: get_req(2, "pool_state")?,
+            amm_config: get_req(3, "amm_config")?,
+            token_0_vault: get_req(4, "token_0_vault")?,
+            token_1_vault: get_req(5, "token_1_vault")?,
+            vault_0_mint: get_req(6, "vault_0_mint")?,
+            vault_1_mint: get_req(7, "vault_1_mint")?,
+            creator_token_0: get_req(8, "creator_token_0")?,
+            creator_token_1: get_req(9, "creator_token_1")?,
+            token_0_program: get_req(10, "token_0_program")?,
+            token_1_program: get_req(11, "token_1_program")?,
+            associated_token_program: get_req(12, "associated_token_program")?,
+            system_program: get_req(13, "system_program")?,
+        })
+    }
+}
+
+pub fn get_collect_creator_fee_accounts(ix: &InstructionView) -> Result<CollectCreatorFeeAccounts, AccountsError> {
+    CollectCreatorFeeAccounts::try_from(ix)
+}
+
+/// Accounts for the `collect_fund_fee` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CollectFundFeeAccounts {
+    /// Only admin or fund_owner can collect fee now
+    pub owner: Pubkey,
+    pub authority: Pubkey,
+    /// Pool state stores accumulated protocol fee amount
+    pub pool_state: Pubkey,
+    /// Amm config account stores fund_owner
+    pub amm_config: Pubkey,
+    /// The address that holds pool tokens for token_0
+    pub token_0_vault: Pubkey,
+    /// The address that holds pool tokens for token_1
+    pub token_1_vault: Pubkey,
+    /// The mint of token_0 vault
+    pub vault_0_mint: Pubkey,
+    /// The mint of token_1 vault
+    pub vault_1_mint: Pubkey,
+    /// The address that receives the collected token_0 fund fees
+    pub recipient_token_0_account: Pubkey,
+    /// The address that receives the collected token_1 fund fees
+    pub recipient_token_1_account: Pubkey,
+    /// The SPL program to perform token transfers
+    pub token_program: Pubkey,
+    /// The SPL program 2022 to perform token transfers
+    pub token_program_2022: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for CollectFundFeeAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(CollectFundFeeAccounts {
+            owner: get_req(0, "owner")?,
+            authority: get_req(1, "authority")?,
+            pool_state: get_req(2, "pool_state")?,
+            amm_config: get_req(3, "amm_config")?,
+            token_0_vault: get_req(4, "token_0_vault")?,
+            token_1_vault: get_req(5, "token_1_vault")?,
+            vault_0_mint: get_req(6, "vault_0_mint")?,
+            vault_1_mint: get_req(7, "vault_1_mint")?,
+            recipient_token_0_account: get_req(8, "recipient_token_0_account")?,
+            recipient_token_1_account: get_req(9, "recipient_token_1_account")?,
+            token_program: get_req(10, "token_program")?,
+            token_program_2022: get_req(11, "token_program_2022")?,
+        })
+    }
+}
+
+pub fn get_collect_fund_fee_accounts(ix: &InstructionView) -> Result<CollectFundFeeAccounts, AccountsError> {
+    CollectFundFeeAccounts::try_from(ix)
+}
+
+/// Accounts for the `collect_protocol_fee` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CollectProtocolFeeAccounts {
+    /// Only admin or owner can collect fee now
+    pub owner: Pubkey,
+    pub authority: Pubkey,
+    /// Pool state stores accumulated protocol fee amount
+    pub pool_state: Pubkey,
+    /// Amm config account stores owner
+    pub amm_config: Pubkey,
+    /// The address that holds pool tokens for token_0
+    pub token_0_vault: Pubkey,
+    /// The address that holds pool tokens for token_1
+    pub token_1_vault: Pubkey,
+    /// The mint of token_0 vault
+    pub vault_0_mint: Pubkey,
+    /// The mint of token_1 vault
+    pub vault_1_mint: Pubkey,
+    /// The address that receives the collected token_0 protocol fees
+    pub recipient_token_0_account: Pubkey,
+    /// The address that receives the collected token_1 protocol fees
+    pub recipient_token_1_account: Pubkey,
+    /// The SPL program to perform token transfers
+    pub token_program: Pubkey,
+    /// The SPL program 2022 to perform token transfers
+    pub token_program_2022: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for CollectProtocolFeeAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(CollectProtocolFeeAccounts {
+            owner: get_req(0, "owner")?,
+            authority: get_req(1, "authority")?,
+            pool_state: get_req(2, "pool_state")?,
+            amm_config: get_req(3, "amm_config")?,
+            token_0_vault: get_req(4, "token_0_vault")?,
+            token_1_vault: get_req(5, "token_1_vault")?,
+            vault_0_mint: get_req(6, "vault_0_mint")?,
+            vault_1_mint: get_req(7, "vault_1_mint")?,
+            recipient_token_0_account: get_req(8, "recipient_token_0_account")?,
+            recipient_token_1_account: get_req(9, "recipient_token_1_account")?,
+            token_program: get_req(10, "token_program")?,
+            token_program_2022: get_req(11, "token_program_2022")?,
+        })
+    }
+}
+
+pub fn get_collect_protocol_fee_accounts(ix: &InstructionView) -> Result<CollectProtocolFeeAccounts, AccountsError> {
+    CollectProtocolFeeAccounts::try_from(ix)
+}
+
+/// Accounts for the `create_amm_config` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CreateAmmConfigAccounts {
+    /// Address to be set as protocol owner.
+    pub owner: Pubkey,
+    /// Initialize config state account to store protocol owner address and fee rates.
+    pub amm_config: Pubkey,
+    pub system_program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for CreateAmmConfigAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(CreateAmmConfigAccounts {
+            owner: get_req(0, "owner")?,
+            amm_config: get_req(1, "amm_config")?,
+            system_program: get_req(2, "system_program")?,
+        })
+    }
+}
+
+pub fn get_create_amm_config_accounts(ix: &InstructionView) -> Result<CreateAmmConfigAccounts, AccountsError> {
+    CreateAmmConfigAccounts::try_from(ix)
+}
+
+/// Accounts for the `create_permission_pda` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CreatePermissionPdaAccounts {
+    pub owner: Pubkey,
+    pub permission_authority: Pubkey,
+    /// Initialize config state account to store protocol owner address and fee rates.
+    pub permission: Pubkey,
+    pub system_program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for CreatePermissionPdaAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(CreatePermissionPdaAccounts {
+            owner: get_req(0, "owner")?,
+            permission_authority: get_req(1, "permission_authority")?,
+            permission: get_req(2, "permission")?,
+            system_program: get_req(3, "system_program")?,
+        })
+    }
+}
+
+pub fn get_create_permission_pda_accounts(ix: &InstructionView) -> Result<CreatePermissionPdaAccounts, AccountsError> {
+    CreatePermissionPdaAccounts::try_from(ix)
+}
+
+/// Accounts for the `deposit` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct DepositAccounts {
+    /// Pays to mint the position
+    pub owner: Pubkey,
+    pub authority: Pubkey,
+    pub pool_state: Pubkey,
+    /// Owner lp token account
+    pub owner_lp_token: Pubkey,
+    /// The payer's token account for token_0
+    pub token_0_account: Pubkey,
+    /// The payer's token account for token_1
+    pub token_1_account: Pubkey,
+    /// The address that holds pool tokens for token_0
+    pub token_0_vault: Pubkey,
+    /// The address that holds pool tokens for token_1
+    pub token_1_vault: Pubkey,
+    /// token Program
+    pub token_program: Pubkey,
+    /// Token program 2022
+    pub token_program_2022: Pubkey,
+    /// The mint of token_0 vault
+    pub vault_0_mint: Pubkey,
+    /// The mint of token_1 vault
+    pub vault_1_mint: Pubkey,
+    /// Lp token mint
+    pub lp_mint: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for DepositAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(DepositAccounts {
+            owner: get_req(0, "owner")?,
+            authority: get_req(1, "authority")?,
+            pool_state: get_req(2, "pool_state")?,
+            owner_lp_token: get_req(3, "owner_lp_token")?,
+            token_0_account: get_req(4, "token_0_account")?,
+            token_1_account: get_req(5, "token_1_account")?,
+            token_0_vault: get_req(6, "token_0_vault")?,
+            token_1_vault: get_req(7, "token_1_vault")?,
+            token_program: get_req(8, "token_program")?,
+            token_program_2022: get_req(9, "token_program_2022")?,
+            vault_0_mint: get_req(10, "vault_0_mint")?,
+            vault_1_mint: get_req(11, "vault_1_mint")?,
+            lp_mint: get_req(12, "lp_mint")?,
+        })
+    }
+}
+
+pub fn get_deposit_accounts(ix: &InstructionView) -> Result<DepositAccounts, AccountsError> {
+    DepositAccounts::try_from(ix)
+}
+
+/// Accounts for the `initialize` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct InitializeAccounts {
+    /// Address paying to create the pool. Can be anyone
+    pub creator: Pubkey,
+    /// Which config the pool belongs to.
+    pub amm_config: Pubkey,
+    /// pool vault and lp mint authority
+    pub authority: Pubkey,
+    /// PDA account:
+    /// seeds = [
+    /// POOL_SEED.as_bytes(),
+    /// amm_config.key().as_ref(),
+    /// token_0_mint.key().as_ref(),
+    /// token_1_mint.key().as_ref(),
+    /// ],
+    /// 
+    /// Or random account: must be signed by cli
+    pub pool_state: Pubkey,
+    /// Token_0 mint, the key must smaller than token_1 mint.
+    pub token_0_mint: Pubkey,
+    /// Token_1 mint, the key must grater then token_0 mint.
+    pub token_1_mint: Pubkey,
+    /// pool lp mint
+    pub lp_mint: Pubkey,
+    /// payer token0 account
+    pub creator_token_0: Pubkey,
+    /// creator token1 account
+    pub creator_token_1: Pubkey,
+    /// creator lp token account
+    pub creator_lp_token: Pubkey,
+    pub token_0_vault: Pubkey,
+    pub token_1_vault: Pubkey,
+    /// create pool fee account
+    pub create_pool_fee: Pubkey,
+    /// an account to store oracle observations
+    pub observation_state: Pubkey,
+    /// Program to create mint account and mint tokens
+    pub token_program: Pubkey,
+    /// Spl token program or token program 2022
+    pub token_0_program: Pubkey,
+    /// Spl token program or token program 2022
+    pub token_1_program: Pubkey,
+    /// Program to create an ATA for receiving position NFT
+    pub associated_token_program: Pubkey,
+    /// To create a new program account
+    pub system_program: Pubkey,
+    /// Sysvar for program account
+    pub rent: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for InitializeAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(InitializeAccounts {
+            creator: get_req(0, "creator")?,
+            amm_config: get_req(1, "amm_config")?,
+            authority: get_req(2, "authority")?,
+            pool_state: get_req(3, "pool_state")?,
+            token_0_mint: get_req(4, "token_0_mint")?,
+            token_1_mint: get_req(5, "token_1_mint")?,
+            lp_mint: get_req(6, "lp_mint")?,
+            creator_token_0: get_req(7, "creator_token_0")?,
+            creator_token_1: get_req(8, "creator_token_1")?,
+            creator_lp_token: get_req(9, "creator_lp_token")?,
+            token_0_vault: get_req(10, "token_0_vault")?,
+            token_1_vault: get_req(11, "token_1_vault")?,
+            create_pool_fee: get_req(12, "create_pool_fee")?,
+            observation_state: get_req(13, "observation_state")?,
+            token_program: get_req(14, "token_program")?,
+            token_0_program: get_req(15, "token_0_program")?,
+            token_1_program: get_req(16, "token_1_program")?,
+            associated_token_program: get_req(17, "associated_token_program")?,
+            system_program: get_req(18, "system_program")?,
+            rent: get_req(19, "rent")?,
+        })
+    }
+}
+
+pub fn get_initialize_accounts(ix: &InstructionView) -> Result<InitializeAccounts, AccountsError> {
+    InitializeAccounts::try_from(ix)
+}
+
+/// Accounts for the `initialize_with_permission` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct InitializeWithPermissionAccounts {
+    /// Address paying to create the pool. Can be anyone
+    pub payer: Pubkey,
+    pub creator: Pubkey,
+    /// Which config the pool belongs to.
+    pub amm_config: Pubkey,
+    /// pool vault and lp mint authority
+    pub authority: Pubkey,
+    /// PDA account:
+    /// seeds = [
+    /// POOL_SEED.as_bytes(),
+    /// amm_config.key().as_ref(),
+    /// token_0_mint.key().as_ref(),
+    /// token_1_mint.key().as_ref(),
+    /// ],
+    /// 
+    /// Or random account: must be signed by cli
+    pub pool_state: Pubkey,
+    /// Token_0 mint, the key must smaller than token_1 mint.
+    pub token_0_mint: Pubkey,
+    /// Token_1 mint, the key must grater then token_0 mint.
+    pub token_1_mint: Pubkey,
+    /// pool lp mint
+    pub lp_mint: Pubkey,
+    /// payer token0 account
+    pub payer_token_0: Pubkey,
+    /// payer token1 account
+    pub payer_token_1: Pubkey,
+    /// payer lp token account
+    pub payer_lp_token: Pubkey,
+    pub token_0_vault: Pubkey,
+    pub token_1_vault: Pubkey,
+    /// create pool fee account
+    pub create_pool_fee: Pubkey,
+    /// an account to store oracle observations
+    pub observation_state: Pubkey,
+    pub permission: Pubkey,
+    /// Program to create mint account and mint tokens
+    pub token_program: Pubkey,
+    /// Spl token program or token program 2022
+    pub token_0_program: Pubkey,
+    /// Spl token program or token program 2022
+    pub token_1_program: Pubkey,
+    /// Program to create an ATA for receiving position NFT
+    pub associated_token_program: Pubkey,
+    /// To create a new program account
+    pub system_program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for InitializeWithPermissionAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(InitializeWithPermissionAccounts {
+            payer: get_req(0, "payer")?,
+            creator: get_req(1, "creator")?,
+            amm_config: get_req(2, "amm_config")?,
+            authority: get_req(3, "authority")?,
+            pool_state: get_req(4, "pool_state")?,
+            token_0_mint: get_req(5, "token_0_mint")?,
+            token_1_mint: get_req(6, "token_1_mint")?,
+            lp_mint: get_req(7, "lp_mint")?,
+            payer_token_0: get_req(8, "payer_token_0")?,
+            payer_token_1: get_req(9, "payer_token_1")?,
+            payer_lp_token: get_req(10, "payer_lp_token")?,
+            token_0_vault: get_req(11, "token_0_vault")?,
+            token_1_vault: get_req(12, "token_1_vault")?,
+            create_pool_fee: get_req(13, "create_pool_fee")?,
+            observation_state: get_req(14, "observation_state")?,
+            permission: get_req(15, "permission")?,
+            token_program: get_req(16, "token_program")?,
+            token_0_program: get_req(17, "token_0_program")?,
+            token_1_program: get_req(18, "token_1_program")?,
+            associated_token_program: get_req(19, "associated_token_program")?,
+            system_program: get_req(20, "system_program")?,
+        })
+    }
+}
+
+pub fn get_initialize_with_permission_accounts(ix: &InstructionView) -> Result<InitializeWithPermissionAccounts, AccountsError> {
+    InitializeWithPermissionAccounts::try_from(ix)
+}
+
+/// Accounts for the `swap_base_input` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SwapBaseInputAccounts {
+    /// The user performing the swap
+    pub payer: Pubkey,
+    pub authority: Pubkey,
+    /// The factory state to read protocol fees
+    pub amm_config: Pubkey,
+    /// The program account of the pool in which the swap will be performed
+    pub pool_state: Pubkey,
+    /// The user token account for input token
+    pub input_token_account: Pubkey,
+    /// The user token account for output token
+    pub output_token_account: Pubkey,
+    /// The vault token account for input token
+    pub input_vault: Pubkey,
+    /// The vault token account for output token
+    pub output_vault: Pubkey,
+    /// SPL program for input token transfers
+    pub input_token_program: Pubkey,
+    /// SPL program for output token transfers
+    pub output_token_program: Pubkey,
+    /// The mint of input token
+    pub input_token_mint: Pubkey,
+    /// The mint of output token
+    pub output_token_mint: Pubkey,
+    /// The program account for the most recent oracle observation
+    pub observation_state: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for SwapBaseInputAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(SwapBaseInputAccounts {
+            payer: get_req(0, "payer")?,
+            authority: get_req(1, "authority")?,
+            amm_config: get_req(2, "amm_config")?,
+            pool_state: get_req(3, "pool_state")?,
+            input_token_account: get_req(4, "input_token_account")?,
+            output_token_account: get_req(5, "output_token_account")?,
+            input_vault: get_req(6, "input_vault")?,
+            output_vault: get_req(7, "output_vault")?,
+            input_token_program: get_req(8, "input_token_program")?,
+            output_token_program: get_req(9, "output_token_program")?,
+            input_token_mint: get_req(10, "input_token_mint")?,
+            output_token_mint: get_req(11, "output_token_mint")?,
+            observation_state: get_req(12, "observation_state")?,
+        })
+    }
+}
+
+pub fn get_swap_base_input_accounts(ix: &InstructionView) -> Result<SwapBaseInputAccounts, AccountsError> {
+    SwapBaseInputAccounts::try_from(ix)
+}
+
+/// Accounts for the `swap_base_output` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SwapBaseOutputAccounts {
+    /// The user performing the swap
+    pub payer: Pubkey,
+    pub authority: Pubkey,
+    /// The factory state to read protocol fees
+    pub amm_config: Pubkey,
+    /// The program account of the pool in which the swap will be performed
+    pub pool_state: Pubkey,
+    /// The user token account for input token
+    pub input_token_account: Pubkey,
+    /// The user token account for output token
+    pub output_token_account: Pubkey,
+    /// The vault token account for input token
+    pub input_vault: Pubkey,
+    /// The vault token account for output token
+    pub output_vault: Pubkey,
+    /// SPL program for input token transfers
+    pub input_token_program: Pubkey,
+    /// SPL program for output token transfers
+    pub output_token_program: Pubkey,
+    /// The mint of input token
+    pub input_token_mint: Pubkey,
+    /// The mint of output token
+    pub output_token_mint: Pubkey,
+    /// The program account for the most recent oracle observation
+    pub observation_state: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for SwapBaseOutputAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(SwapBaseOutputAccounts {
+            payer: get_req(0, "payer")?,
+            authority: get_req(1, "authority")?,
+            amm_config: get_req(2, "amm_config")?,
+            pool_state: get_req(3, "pool_state")?,
+            input_token_account: get_req(4, "input_token_account")?,
+            output_token_account: get_req(5, "output_token_account")?,
+            input_vault: get_req(6, "input_vault")?,
+            output_vault: get_req(7, "output_vault")?,
+            input_token_program: get_req(8, "input_token_program")?,
+            output_token_program: get_req(9, "output_token_program")?,
+            input_token_mint: get_req(10, "input_token_mint")?,
+            output_token_mint: get_req(11, "output_token_mint")?,
+            observation_state: get_req(12, "observation_state")?,
+        })
+    }
+}
+
+pub fn get_swap_base_output_accounts(ix: &InstructionView) -> Result<SwapBaseOutputAccounts, AccountsError> {
+    SwapBaseOutputAccounts::try_from(ix)
+}
+
+/// Accounts for the `update_amm_config` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct UpdateAmmConfigAccounts {
+    /// The amm config owner or admin
+    pub owner: Pubkey,
+    /// Amm config account to be changed
+    pub amm_config: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for UpdateAmmConfigAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(UpdateAmmConfigAccounts {
+            owner: get_req(0, "owner")?,
+            amm_config: get_req(1, "amm_config")?,
+        })
+    }
+}
+
+pub fn get_update_amm_config_accounts(ix: &InstructionView) -> Result<UpdateAmmConfigAccounts, AccountsError> {
+    UpdateAmmConfigAccounts::try_from(ix)
+}
+
+/// Accounts for the `update_pool_status` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct UpdatePoolStatusAccounts {
+    pub authority: Pubkey,
+    pub pool_state: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for UpdatePoolStatusAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(UpdatePoolStatusAccounts {
+            authority: get_req(0, "authority")?,
+            pool_state: get_req(1, "pool_state")?,
+        })
+    }
+}
+
+pub fn get_update_pool_status_accounts(ix: &InstructionView) -> Result<UpdatePoolStatusAccounts, AccountsError> {
+    UpdatePoolStatusAccounts::try_from(ix)
+}
+
+/// Accounts for the `withdraw` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct WithdrawAccounts {
+    /// Pays to mint the position
+    pub owner: Pubkey,
+    pub authority: Pubkey,
+    /// Pool state account
+    pub pool_state: Pubkey,
+    /// Owner lp token account
+    pub owner_lp_token: Pubkey,
+    /// The token account for receive token_0,
+    pub token_0_account: Pubkey,
+    /// The token account for receive token_1
+    pub token_1_account: Pubkey,
+    /// The address that holds pool tokens for token_0
+    pub token_0_vault: Pubkey,
+    /// The address that holds pool tokens for token_1
+    pub token_1_vault: Pubkey,
+    /// token Program
+    pub token_program: Pubkey,
+    /// Token program 2022
+    pub token_program_2022: Pubkey,
+    /// The mint of token_0 vault
+    pub vault_0_mint: Pubkey,
+    /// The mint of token_1 vault
+    pub vault_1_mint: Pubkey,
+    /// Pool lp token mint
+    pub lp_mint: Pubkey,
+    /// memo program
+    pub memo_program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for WithdrawAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        Ok(WithdrawAccounts {
+            owner: get_req(0, "owner")?,
+            authority: get_req(1, "authority")?,
+            pool_state: get_req(2, "pool_state")?,
+            owner_lp_token: get_req(3, "owner_lp_token")?,
+            token_0_account: get_req(4, "token_0_account")?,
+            token_1_account: get_req(5, "token_1_account")?,
+            token_0_vault: get_req(6, "token_0_vault")?,
+            token_1_vault: get_req(7, "token_1_vault")?,
+            token_program: get_req(8, "token_program")?,
+            token_program_2022: get_req(9, "token_program_2022")?,
+            vault_0_mint: get_req(10, "vault_0_mint")?,
+            vault_1_mint: get_req(11, "vault_1_mint")?,
+            lp_mint: get_req(12, "lp_mint")?,
+            memo_program: get_req(13, "memo_program")?,
+        })
+    }
+}
+
+pub fn get_withdraw_accounts(ix: &InstructionView) -> Result<WithdrawAccounts, AccountsError> {
+    WithdrawAccounts::try_from(ix)
+}

--- a/src/raydium/cpmm/events.rs
+++ b/src/raydium/cpmm/events.rs
@@ -1,0 +1,93 @@
+//! Raydium CPMM events.
+
+use crate::ParseError;
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+use solana_program::pubkey::Pubkey;
+
+// -----------------------------------------------------------------------------
+// Discriminators
+// -----------------------------------------------------------------------------
+pub const LP_CHANGE_EVENT: [u8; 8] = [121, 163, 205, 201, 57, 218, 117, 60];
+pub const SWAP_EVENT: [u8; 8] = [64, 198, 205, 232, 38, 8, 113, 226];
+
+// -----------------------------------------------------------------------------
+// Event enumeration
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RaydiumCpmmEvent {
+    LpChangeEvent(LpChangeEvent),
+    SwapEvent(SwapEvent),
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Payload structs
+// -----------------------------------------------------------------------------
+/// Emitted when deposit and withdraw
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct LpChangeEvent {
+    pub pool_id: Pubkey,
+    pub lp_amount_before: u64,
+    /// pool vault sub trade fees
+    pub token_0_vault_before: u64,
+    /// pool vault sub trade fees
+    pub token_1_vault_before: u64,
+    /// calculate result without transfer fee
+    pub token_0_amount: u64,
+    /// calculate result without transfer fee
+    pub token_1_amount: u64,
+    pub token_0_transfer_fee: u64,
+    pub token_1_transfer_fee: u64,
+    pub change_type: u8,
+}
+
+/// Emitted when swap
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SwapEvent {
+    pub pool_id: Pubkey,
+    /// pool vault sub trade fees
+    pub input_vault_before: u64,
+    /// pool vault sub trade fees
+    pub output_vault_before: u64,
+    /// calculate result without transfer fee
+    pub input_amount: u64,
+    /// calculate result without transfer fee
+    pub output_amount: u64,
+    pub input_transfer_fee: u64,
+    pub output_transfer_fee: u64,
+    pub base_input: bool,
+    pub input_mint: Pubkey,
+    pub output_mint: Pubkey,
+    pub trade_fee: u64,
+    /// Amount of fee tokens going to creator
+    pub creator_fee: u64,
+    pub creator_fee_on_input: bool,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for RaydiumCpmmEvent {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.len() < 8 {
+            return Err(ParseError::TooShort(data.len()));
+        }
+
+        let (disc, payload) = data.split_at(8);
+        let discriminator: [u8; 8] = disc.try_into().expect("slice len 8");
+
+        Ok(match discriminator {
+            LP_CHANGE_EVENT => Self::LpChangeEvent(LpChangeEvent::try_from_slice(payload)?),
+            SWAP_EVENT => Self::SwapEvent(SwapEvent::try_from_slice(payload)?),
+            _ => Self::Unknown,
+        })
+    }
+}
+
+/// Convenience wrapper that forwards to `TryFrom`.
+pub fn unpack_event(data: &[u8]) -> Result<RaydiumCpmmEvent, ParseError> {
+    RaydiumCpmmEvent::try_from(data)
+}

--- a/src/raydium/cpmm/instructions.rs
+++ b/src/raydium/cpmm/instructions.rs
@@ -1,4 +1,4 @@
-//! Raydium CPMM swap instructions.
+//! Raydium CPMM instructions.
 
 use crate::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -7,32 +7,222 @@ use serde::{Deserialize, Serialize};
 // -----------------------------------------------------------------------------
 // Discriminators
 // -----------------------------------------------------------------------------
+pub const CLOSE_PERMISSION_PDA: [u8; 8] = [156, 84, 32, 118, 69, 135, 70, 123];
+pub const COLLECT_CREATOR_FEE: [u8; 8] = [20, 22, 86, 123, 198, 28, 219, 132];
+pub const COLLECT_FUND_FEE: [u8; 8] = [167, 138, 78, 149, 223, 194, 6, 126];
+pub const COLLECT_PROTOCOL_FEE: [u8; 8] = [136, 136, 252, 221, 194, 66, 126, 89];
+pub const CREATE_AMM_CONFIG: [u8; 8] = [137, 52, 237, 212, 215, 117, 108, 104];
+pub const CREATE_PERMISSION_PDA: [u8; 8] = [135, 136, 2, 216, 137, 169, 181, 202];
+pub const DEPOSIT: [u8; 8] = [242, 35, 198, 137, 82, 225, 242, 182];
+pub const INITIALIZE: [u8; 8] = [175, 175, 109, 31, 13, 152, 155, 237];
+pub const INITIALIZE_WITH_PERMISSION: [u8; 8] = [63, 55, 254, 65, 49, 178, 89, 121];
 pub const SWAP_BASE_INPUT: [u8; 8] = [143, 190, 90, 218, 196, 30, 51, 222];
 pub const SWAP_BASE_OUTPUT: [u8; 8] = [55, 217, 98, 86, 163, 74, 180, 173];
+pub const UPDATE_AMM_CONFIG: [u8; 8] = [49, 60, 174, 136, 154, 28, 116, 200];
+pub const UPDATE_POOL_STATUS: [u8; 8] = [130, 87, 108, 6, 46, 224, 117, 123];
+pub const WITHDRAW: [u8; 8] = [183, 18, 70, 156, 148, 109, 161, 34];
 
 // -----------------------------------------------------------------------------
 // Instruction enumeration
 // -----------------------------------------------------------------------------
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RaydiumCpmmInstruction {
+    ClosePermissionPda,
+    CollectCreatorFee,
+    CollectFundFee(CollectFundFeeInstruction),
+    CollectProtocolFee(CollectProtocolFeeInstruction),
+    CreateAmmConfig(CreateAmmConfigInstruction),
+    CreatePermissionPda,
+    Deposit(DepositInstruction),
+    Initialize(InitializeInstruction),
+    InitializeWithPermission(InitializeWithPermissionInstruction),
     SwapBaseInput(SwapBaseInputInstruction),
     SwapBaseOutput(SwapBaseOutputInstruction),
+    UpdateAmmConfig(UpdateAmmConfigInstruction),
+    UpdatePoolStatus(UpdatePoolStatusInstruction),
+    Withdraw(WithdrawInstruction),
     Unknown,
 }
 
 // -----------------------------------------------------------------------------
 // Payload structs
 // -----------------------------------------------------------------------------
+/// Collect the fund fee accrued to the pool
+/// 
+/// # Arguments
+/// 
+/// * `ctx` - The context of accounts
+/// * `amount_0_requested` - The maximum amount of token_0 to send, can be 0 to collect fees in only token_1
+/// * `amount_1_requested` - The maximum amount of token_1 to send, can be 0 to collect fees in only token_0
+/// 
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CollectFundFeeInstruction {
+    pub amount_0_requested: u64,
+    pub amount_1_requested: u64,
+}
+
+/// Collect the protocol fee accrued to the pool
+/// 
+/// # Arguments
+/// 
+/// * `ctx` - The context of accounts
+/// * `amount_0_requested` - The maximum amount of token_0 to send, can be 0 to collect fees in only token_1
+/// * `amount_1_requested` - The maximum amount of token_1 to send, can be 0 to collect fees in only token_0
+/// 
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CollectProtocolFeeInstruction {
+    pub amount_0_requested: u64,
+    pub amount_1_requested: u64,
+}
+
+/// # Arguments
+/// 
+/// * `ctx`- The accounts needed by instruction.
+/// * `index` - The index of amm config, there may be multiple config.
+/// * `trade_fee_rate` - Trade fee rate, can be changed.
+/// * `protocol_fee_rate` - The rate of protocol fee within trade fee.
+/// * `fund_fee_rate` - The rate of fund fee within trade fee.
+/// 
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CreateAmmConfigInstruction {
+    pub index: u16,
+    pub trade_fee_rate: u64,
+    pub protocol_fee_rate: u64,
+    pub fund_fee_rate: u64,
+    pub create_pool_fee: u64,
+    pub creator_fee_rate: u64,
+}
+
+/// Deposit lp token to the pool
+/// 
+/// # Arguments
+/// 
+/// * `ctx`- The context of accounts
+/// * `lp_token_amount` - Increased number of LPs
+/// * `maximum_token_0_amount` -  Maximum token 0 amount to deposit, prevents excessive slippage
+/// * `maximum_token_1_amount` - Maximum token 1 amount to deposit, prevents excessive slippage
+/// 
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct DepositInstruction {
+    pub lp_token_amount: u64,
+    pub maximum_token_0_amount: u64,
+    pub maximum_token_1_amount: u64,
+}
+
+/// Creates a pool for the given token pair and the initial price
+/// 
+/// # Arguments
+/// 
+/// * `ctx`- The context of accounts
+/// * `init_amount_0` - the initial amount_0 to deposit
+/// * `init_amount_1` - the initial amount_1 to deposit
+/// * `open_time` - the timestamp allowed for swap
+/// 
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct InitializeInstruction {
+    pub init_amount_0: u64,
+    pub init_amount_1: u64,
+    pub open_time: u64,
+}
+
+/// Create a pool with permission
+/// 
+/// # Arguments
+/// 
+/// * `ctx`- The context of accounts
+/// * `init_amount_0` - the initial amount_0 to deposit
+/// * `init_amount_1` - the initial amount_1 to deposit
+/// * `open_time` - the timestamp allowed for swap
+/// * `creator_fee_on` - creator fee model, 0：both token0 and token1 (depends on the input), 1: only token0, 2: only token1
+/// 
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct InitializeWithPermissionInstruction {
+    pub init_amount_0: u64,
+    pub init_amount_1: u64,
+    pub open_time: u64,
+    pub creator_fee_on: CreatorFeeOn,
+}
+
+/// Swap the tokens in the pool base input amount
+/// 
+/// # Arguments
+/// 
+/// * `ctx`- The context of accounts
+/// * `amount_in` -  input amount to transfer, output to DESTINATION is based on the exchange rate
+/// * `minimum_amount_out` -  Minimum amount of output token, prevents excessive slippage
+/// 
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
 pub struct SwapBaseInputInstruction {
     pub amount_in: u64,
     pub minimum_amount_out: u64,
 }
 
+/// Swap the tokens in the pool base output amount
+/// 
+/// # Arguments
+/// 
+/// * `ctx`- The context of accounts
+/// * `max_amount_in` -  input amount prevents excessive slippage
+/// * `amount_out` -  amount of output token
+/// 
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
 pub struct SwapBaseOutputInstruction {
     pub max_amount_in: u64,
     pub amount_out: u64,
+}
+
+/// Updates the owner of the amm config
+/// Must be called by the current owner or admin
+/// 
+/// # Arguments
+/// 
+/// * `ctx`- The context of accounts
+/// * `trade_fee_rate`- The new trade fee rate of amm config, be set when `param` is 0
+/// * `protocol_fee_rate`- The new protocol fee rate of amm config, be set when `param` is 1
+/// * `fund_fee_rate`- The new fund fee rate of amm config, be set when `param` is 2
+/// * `new_owner`- The config's new owner, be set when `param` is 3
+/// * `new_fund_owner`- The config's new fund owner, be set when `param` is 4
+/// * `param`- The value can be 0 | 1 | 2 | 3 | 4, otherwise will report a error
+/// 
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct UpdateAmmConfigInstruction {
+    pub param: u8,
+    pub value: u64,
+}
+
+/// Update pool status for given value
+/// 
+/// # Arguments
+/// 
+/// * `ctx`- The context of accounts
+/// * `status` - The value of status
+/// 
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct UpdatePoolStatusInstruction {
+    pub status: u8,
+}
+
+/// Withdraw lp for token0 and token1
+/// 
+/// # Arguments
+/// 
+/// * `ctx`- The context of accounts
+/// * `lp_token_amount` - Amount of pool tokens to burn. User receives an output of token a and b based on the percentage of the pool tokens that are returned.
+/// * `minimum_token_0_amount` -  Minimum amount of token 0 to receive, prevents excessive slippage
+/// * `minimum_token_1_amount` -  Minimum amount of token 1 to receive, prevents excessive slippage
+/// 
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct WithdrawInstruction {
+    pub lp_token_amount: u64,
+    pub minimum_token_0_amount: u64,
+    pub minimum_token_1_amount: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub enum CreatorFeeOn {
+    BothToken,
+    OnlyToken0,
+    OnlyToken1,
 }
 
 // -----------------------------------------------------------------------------
@@ -50,8 +240,20 @@ impl<'a> TryFrom<&'a [u8]> for RaydiumCpmmInstruction {
         let discriminator: [u8; 8] = disc.try_into().expect("slice len 8");
 
         Ok(match discriminator {
+            CLOSE_PERMISSION_PDA => Self::ClosePermissionPda,
+            COLLECT_CREATOR_FEE => Self::CollectCreatorFee,
+            COLLECT_FUND_FEE => Self::CollectFundFee(CollectFundFeeInstruction::try_from_slice(payload)?),
+            COLLECT_PROTOCOL_FEE => Self::CollectProtocolFee(CollectProtocolFeeInstruction::try_from_slice(payload)?),
+            CREATE_AMM_CONFIG => Self::CreateAmmConfig(CreateAmmConfigInstruction::try_from_slice(payload)?),
+            CREATE_PERMISSION_PDA => Self::CreatePermissionPda,
+            DEPOSIT => Self::Deposit(DepositInstruction::try_from_slice(payload)?),
+            INITIALIZE => Self::Initialize(InitializeInstruction::try_from_slice(payload)?),
+            INITIALIZE_WITH_PERMISSION => Self::InitializeWithPermission(InitializeWithPermissionInstruction::try_from_slice(payload)?),
             SWAP_BASE_INPUT => Self::SwapBaseInput(SwapBaseInputInstruction::try_from_slice(payload)?),
             SWAP_BASE_OUTPUT => Self::SwapBaseOutput(SwapBaseOutputInstruction::try_from_slice(payload)?),
+            UPDATE_AMM_CONFIG => Self::UpdateAmmConfig(UpdateAmmConfigInstruction::try_from_slice(payload)?),
+            UPDATE_POOL_STATUS => Self::UpdatePoolStatus(UpdatePoolStatusInstruction::try_from_slice(payload)?),
+            WITHDRAW => Self::Withdraw(WithdrawInstruction::try_from_slice(payload)?),
             other => return Err(ParseError::Unknown(other)),
         })
     }

--- a/src/raydium/cpmm/mod.rs
+++ b/src/raydium/cpmm/mod.rs
@@ -1,5 +1,7 @@
 use substreams_solana::b58;
 
+pub mod accounts;
+pub mod events;
 pub mod instructions;
 
 /// Raydium Concentrated Pool Market Maker program


### PR DESCRIPTION
## Summary
- implement all Raydium CPMM instruction, account, and event types
- wire cpmm accounts and events modules

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_68b3580896708328b1e2951bd38e0f17