### PR TITLE
Add Raydium Launchpad accounts and events

### DIFF
--- a/src/raydium/launchpad/accounts.rs
+++ b/src/raydium/launchpad/accounts.rs
@@ -1,0 +1,220 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+use solana_program::pubkey::Pubkey;
+use substreams_solana::block_view::InstructionView;
+use thiserror::Error;
+
+// -----------------------------------------------------------------------------
+// Error type
+// -----------------------------------------------------------------------------
+#[derive(Debug, Error)]
+pub enum AccountsError {
+    #[error("missing required account `{name}` at index {index}")]
+    Missing { name: &'static str, index: usize },
+    #[error("invalid key length for `{name}` at index {index}: got {got}, want 32")]
+    InvalidLen { name: &'static str, index: usize, got: usize },
+}
+
+#[inline]
+fn to_pubkey(name: &'static str, index: usize, bytes: &[u8]) -> Result<Pubkey, AccountsError> {
+    let arr: [u8; 32] = bytes.try_into().map_err(|_| AccountsError::InvalidLen { name, index, got: bytes.len() })?;
+    Ok(Pubkey::new_from_array(arr))
+}
+
+// -----------------------------------------------------------------------------
+// Helper macro with doc comments
+// -----------------------------------------------------------------------------
+macro_rules! accounts {
+    ($name:ident, $getter:ident, { $( $(#[$meta:meta])* $field:ident ),+ $(,)? }) => {
+        #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+        pub struct $name {
+            $( $(#[$meta])* pub $field: Pubkey,)+
+        }
+
+        impl<'ix> TryFrom<&InstructionView<'ix>> for $name {
+            type Error = AccountsError;
+
+            fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+                let accounts = ix.accounts();
+                let mut idx = 0;
+                $(
+                    let $field = {
+                        let name = stringify!($field);
+                        let a = accounts
+                            .get(idx)
+                            .ok_or(AccountsError::Missing { name, index: idx })?;
+                        let pk = to_pubkey(name, idx, &a.0)?;
+                        idx += 1;
+                        pk
+                    };
+                )+
+                let _ = idx;
+                Ok(Self { $( $field, )+ })
+            }
+        }
+
+        pub fn $getter(ix: &InstructionView) -> Result<$name, AccountsError> {
+            $name::try_from(ix)
+        }
+    };
+}
+
+// -----------------------------------------------------------------------------
+// Buy exact in accounts
+// -----------------------------------------------------------------------------
+accounts!(
+    BuyExactInAccounts,
+    get_buy_exact_in_accounts,
+    {
+        /// The user performing the swap operation
+        payer,
+        /// PDA that acts as the authority for pool vault operations
+        authority,
+        /// Global configuration account containing protocol-wide settings
+        global_config,
+        /// Platform configuration account containing platform-wide settings
+        platform_config,
+        /// The pool state account where the swap will be performed
+        pool_state,
+        /// The user's token account for base tokens (tokens being bought)
+        user_base_token,
+        /// The user's token account for quote tokens (tokens being sold)
+        user_quote_token,
+        /// The pool's vault for base tokens
+        base_vault,
+        /// The pool's vault for quote tokens
+        quote_vault,
+        /// The mint of the base token
+        base_token_mint,
+        /// The mint of the quote token
+        quote_token_mint,
+        /// SPL Token program for base token transfers
+        base_token_program,
+        /// SPL Token program for quote token transfers
+        quote_token_program,
+        /// Program-derived address authorising event emissions
+        event_authority,
+        /// The raydium launchpad program id
+        program
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Buy exact out accounts
+// -----------------------------------------------------------------------------
+accounts!(
+    BuyExactOutAccounts,
+    get_buy_exact_out_accounts,
+    {
+        /// The user performing the swap operation
+        payer,
+        /// PDA that acts as the authority for pool vault operations
+        authority,
+        /// Global configuration account containing protocol-wide settings
+        global_config,
+        /// Platform configuration account containing platform-wide settings
+        platform_config,
+        /// The pool state account where the swap will be performed
+        pool_state,
+        /// The user's token account for base tokens (tokens being bought)
+        user_base_token,
+        /// The user's token account for quote tokens (tokens being sold)
+        user_quote_token,
+        /// The pool's vault for base tokens
+        base_vault,
+        /// The pool's vault for quote tokens
+        quote_vault,
+        /// The mint of the base token
+        base_token_mint,
+        /// The mint of the quote token
+        quote_token_mint,
+        /// SPL Token program for base token transfers
+        base_token_program,
+        /// SPL Token program for quote token transfers
+        quote_token_program,
+        /// Program-derived address authorising event emissions
+        event_authority,
+        /// The raydium launchpad program id
+        program
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Sell exact in accounts
+// -----------------------------------------------------------------------------
+accounts!(
+    SellExactInAccounts,
+    get_sell_exact_in_accounts,
+    {
+        /// The user performing the swap operation
+        payer,
+        /// PDA that acts as the authority for pool vault operations
+        authority,
+        /// Global configuration account containing protocol-wide settings
+        global_config,
+        /// Platform configuration account containing platform-wide settings
+        platform_config,
+        /// The pool state account where the swap will be performed
+        pool_state,
+        /// The user's token account for base tokens (tokens being sold)
+        user_base_token,
+        /// The user's token account for quote tokens (tokens being bought)
+        user_quote_token,
+        /// The pool's vault for base tokens
+        base_vault,
+        /// The pool's vault for quote tokens
+        quote_vault,
+        /// The mint of the base token
+        base_token_mint,
+        /// The mint of the quote token
+        quote_token_mint,
+        /// SPL Token program for base token transfers
+        base_token_program,
+        /// SPL Token program for quote token transfers
+        quote_token_program,
+        /// Program-derived address authorising event emissions
+        event_authority,
+        /// The raydium launchpad program id
+        program
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Sell exact out accounts
+// -----------------------------------------------------------------------------
+accounts!(
+    SellExactOutAccounts,
+    get_sell_exact_out_accounts,
+    {
+        /// The user performing the swap operation
+        payer,
+        /// PDA that acts as the authority for pool vault operations
+        authority,
+        /// Global configuration account containing protocol-wide settings
+        global_config,
+        /// Platform configuration account containing platform-wide settings
+        platform_config,
+        /// The pool state account where the swap will be performed
+        pool_state,
+        /// The user's token account for base tokens (tokens being sold)
+        user_base_token,
+        /// The user's token account for quote tokens (tokens being bought)
+        user_quote_token,
+        /// The pool's vault for base tokens
+        base_vault,
+        /// The pool's vault for quote tokens
+        quote_vault,
+        /// The mint of the base token
+        base_token_mint,
+        /// The mint of the quote token
+        quote_token_mint,
+        /// SPL Token program for base token transfers
+        base_token_program,
+        /// SPL Token program for quote token transfers
+        quote_token_program,
+        /// Program-derived address authorising event emissions
+        event_authority,
+        /// The raydium launchpad program id
+        program
+    }
+);

--- a/src/raydium/launchpad/events.rs
+++ b/src/raydium/launchpad/events.rs
@@ -1,0 +1,172 @@
+//! Raydium Launchpad events.
+
+use crate::ParseError;
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+use solana_program::pubkey::Pubkey;
+
+// -----------------------------------------------------------------------------
+// Discriminators
+// -----------------------------------------------------------------------------
+pub const CLAIM_VESTED_EVENT: [u8; 8] = [21, 194, 114, 87, 120, 211, 226, 32];
+pub const CREATE_VESTING_EVENT: [u8; 8] = [201, 216, 28, 169, 227, 76, 208, 95];
+pub const POOL_CREATE_EVENT: [u8; 8] = [35, 19, 27, 213, 21, 36, 194, 123];
+pub const TRADE_EVENT: [u8; 8] = [189, 219, 127, 211, 78, 230, 97, 238];
+
+// -----------------------------------------------------------------------------
+// Event enumeration
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RaydiumLaunchpadEvent {
+    ClaimVestedEvent(ClaimVestedEvent),
+    CreateVestingEvent(CreateVestingEvent),
+    PoolCreateEvent(PoolCreateEvent),
+    TradeEvent(TradeEvent),
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Payload structs
+// -----------------------------------------------------------------------------
+/// Emitted when vesting token claimed by beneficiary
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct ClaimVestedEvent {
+    pub pool_state: Pubkey,
+    pub beneficiary: Pubkey,
+    pub claim_amount: u64,
+}
+
+/// Emitted when vest_account created
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CreateVestingEvent {
+    pub pool_state: Pubkey,
+    pub beneficiary: Pubkey,
+    pub share_amount: u64,
+}
+
+/// Emitted when pool created
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct PoolCreateEvent {
+    pub pool_state: Pubkey,
+    pub creator: Pubkey,
+    pub config: Pubkey,
+    pub base_mint_param: MintParams,
+    pub curve_param: CurveParams,
+    pub vesting_param: VestingParams,
+    pub amm_fee_on: AmmCreatorFeeOn,
+}
+
+/// Emitted when trade process
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct TradeEvent {
+    pub pool_state: Pubkey,
+    pub total_base_sell: u64,
+    pub virtual_base: u64,
+    pub virtual_quote: u64,
+    pub real_base_before: u64,
+    pub real_quote_before: u64,
+    pub real_base_after: u64,
+    pub real_quote_after: u64,
+    pub amount_in: u64,
+    pub amount_out: u64,
+    pub protocol_fee: u64,
+    pub platform_fee: u64,
+    pub creator_fee: u64,
+    pub share_fee: u64,
+    pub trade_direction: TradeDirection,
+    pub pool_status: PoolStatus,
+    pub exact_in: bool,
+}
+
+// -----------------------------------------------------------------------------
+// Additional types
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct MintParams {
+    pub decimals: u8,
+    pub name: String,
+    pub symbol: String,
+    pub uri: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub enum CurveParams {
+    Constant { data: ConstantCurve },
+    Fixed { data: FixedCurve },
+    Linear { data: LinearCurve },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct ConstantCurve {
+    pub supply: u64,
+    pub total_base_sell: u64,
+    pub total_quote_fund_raising: u64,
+    pub migrate_type: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct FixedCurve {
+    pub supply: u64,
+    pub total_quote_fund_raising: u64,
+    pub migrate_type: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct LinearCurve {
+    pub supply: u64,
+    pub total_quote_fund_raising: u64,
+    pub migrate_type: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct VestingParams {
+    pub total_locked_amount: u64,
+    pub cliff_period: u64,
+    pub unlock_period: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub enum AmmCreatorFeeOn {
+    QuoteToken,
+    BothToken,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub enum TradeDirection {
+    Buy,
+    Sell,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub enum PoolStatus {
+    Fund,
+    Migrate,
+    Trade,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for RaydiumLaunchpadEvent {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.len() < 8 {
+            return Err(ParseError::TooShort(data.len()));
+        }
+        let (disc, payload) = data.split_at(8);
+        let discriminator: [u8; 8] = disc.try_into().expect("slice len 8");
+        Ok(match discriminator {
+            CLAIM_VESTED_EVENT => Self::ClaimVestedEvent(ClaimVestedEvent::try_from_slice(payload)?),
+            CREATE_VESTING_EVENT => Self::CreateVestingEvent(CreateVestingEvent::try_from_slice(payload)?),
+            POOL_CREATE_EVENT => Self::PoolCreateEvent(PoolCreateEvent::try_from_slice(payload)?),
+            TRADE_EVENT => Self::TradeEvent(TradeEvent::try_from_slice(payload)?),
+            other => return Err(ParseError::Unknown(other)),
+        })
+    }
+}
+
+/// Convenience wrapper that forwards to `TryFrom`.
+pub fn unpack(data: &[u8]) -> Result<RaydiumLaunchpadEvent, ParseError> {
+    RaydiumLaunchpadEvent::try_from(data)
+}

--- a/src/raydium/launchpad/instructions.rs
+++ b/src/raydium/launchpad/instructions.rs
@@ -27,31 +27,47 @@ pub enum RaydiumLaunchpadInstruction {
 // -----------------------------------------------------------------------------
 // Payload structs
 // -----------------------------------------------------------------------------
+/// Use the given amount of quote tokens to purchase base tokens.
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
 pub struct BuyExactInInstruction {
+    /// Amount of quote token to purchase
     pub amount_in: u64,
+    /// Minimum amount of base token to receive (slippage protection)
     pub minimum_amount_out: u64,
+    /// Fee rate for the share
     pub share_fee_rate: u64,
 }
 
+/// Use quote tokens to purchase the given amount of base tokens.
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
 pub struct BuyExactOutInstruction {
+    /// Amount of base token to receive
     pub amount_out: u64,
+    /// Maximum amount of quote token to purchase (slippage protection)
     pub maximum_amount_in: u64,
+    /// Fee rate for the share
     pub share_fee_rate: u64,
 }
 
+/// Use the given amount of base tokens to sell for quote tokens.
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
 pub struct SellExactInInstruction {
+    /// Amount of base token to sell
     pub amount_in: u64,
+    /// Minimum amount of quote token to receive (slippage protection)
     pub minimum_amount_out: u64,
+    /// Fee rate for the share
     pub share_fee_rate: u64,
 }
 
+/// Sell base tokens for the given amount of quote tokens.
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
 pub struct SellExactOutInstruction {
+    /// Amount of quote token to receive
     pub amount_out: u64,
+    /// Maximum amount of base token to purchase (slippage protection)
     pub maximum_amount_in: u64,
+    /// Fee rate for the share
     pub share_fee_rate: u64,
 }
 

--- a/src/raydium/launchpad/mod.rs
+++ b/src/raydium/launchpad/mod.rs
@@ -1,5 +1,7 @@
 use substreams_solana::b58;
 
+pub mod accounts;
+pub mod events;
 pub mod instructions;
 
 /// Raydium Launchpad program


### PR DESCRIPTION
## Summary
- add account parsers for Raydium Launchpad swap instructions
- document instruction payloads and provide event types
- wire up launchpad module exports

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_68b42e9b27948328861699d029ff539a