### PR TITLE
feat: add jupiter v4 accounts, instructions, events

### DIFF
--- a/src/jupiter/v4/accounts.rs
+++ b/src/jupiter/v4/accounts.rs
@@ -1,0 +1,803 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+use solana_program::pubkey::Pubkey;
+use substreams_solana::block_view::InstructionView;
+use thiserror::Error;
+
+// -----------------------------------------------------------------------------
+// Error type
+// -----------------------------------------------------------------------------
+#[derive(Debug, Error)]
+pub enum AccountsError {
+    #[error("missing required account `{name}` at index {index}")]
+    Missing { name: &'static str, index: usize },
+    #[error("invalid key length for `{name}` at index {index}: got {got}, want 32")]
+    InvalidLen { name: &'static str, index: usize, got: usize },
+}
+
+#[inline]
+fn to_pubkey(name: &'static str, index: usize, bytes: &[u8]) -> Result<Pubkey, AccountsError> {
+    let arr: [u8; 32] = bytes.try_into().map_err(|_| AccountsError::InvalidLen { name, index, got: bytes.len() })?;
+    Ok(Pubkey::new_from_array(arr))
+}
+
+// -----------------------------------------------------------------------------
+// Helper macro for required-only account structs
+// -----------------------------------------------------------------------------
+macro_rules! accounts {
+    ($name:ident, $getter:ident, { $( $(#[$doc:meta])* $field:ident ),+ $(,)? }) => {
+        #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+        pub struct $name {
+            $( $(#[$doc])* pub $field: Pubkey,)+
+        }
+
+        impl<'ix> TryFrom<&InstructionView<'ix>> for $name {
+            type Error = AccountsError;
+            fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+                let accounts = ix.accounts();
+                let mut idx = 0;
+                $(
+                    let $field = {
+                        let name = stringify!($field);
+                        let a = accounts
+                            .get(idx)
+                            .ok_or(AccountsError::Missing { name, index: idx })?;
+                        let pk = to_pubkey(name, idx, &a.0)?;
+                        idx += 1;
+                        pk
+                    };
+                )+
+                let _ = idx;
+                Ok(Self { $($field,)+ })
+            }
+        }
+
+        pub fn $getter(ix: &InstructionView) -> Result<$name, AccountsError> {
+            $name::try_from(ix)
+        }
+    };
+}
+
+// -----------------------------------------------------------------------------
+// Route
+// -----------------------------------------------------------------------------
+accounts!(
+    RouteAccounts,
+    get_route_accounts,
+    {
+        token_program,
+        user_transfer_authority,
+        destination_token_account,
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Whirlpoolswapexactoutput
+// -----------------------------------------------------------------------------
+accounts!(
+    WhirlpoolswapexactoutputAccounts,
+    get_whirlpool_swap_exact_output_accounts,
+    {
+        swap_program,
+        token_program,
+        token_authority,
+        whirlpool,
+        token_owner_account_a,
+        token_vault_a,
+        token_owner_account_b,
+        token_vault_b,
+        tick_array0,
+        tick_array1,
+        tick_array2,
+        /// Oracle is currently unused and will be enabled on subsequent updates
+        oracle,
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Raydiumswapexactoutput
+// -----------------------------------------------------------------------------
+accounts!(
+    RaydiumswapexactoutputAccounts,
+    get_raydium_swap_exact_output_accounts,
+    {
+        swap_program,
+        token_program,
+        amm_id,
+        amm_authority,
+        amm_open_orders,
+        pool_coin_token_account,
+        pool_pc_token_account,
+        serum_program_id,
+        serum_market,
+        serum_bids,
+        serum_asks,
+        serum_event_queue,
+        serum_coin_vault_account,
+        serum_pc_vault_account,
+        serum_vault_signer,
+        user_source_token_account,
+        user_destination_token_account,
+        user_source_owner,
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Raydiumclmmswapexactoutput
+// -----------------------------------------------------------------------------
+accounts!(
+    RaydiumclmmswapexactoutputAccounts,
+    get_raydium_clmm_swap_exact_output_accounts,
+    {
+        swap_program,
+        payer,
+        amm_config,
+        pool_state,
+        input_token_account,
+        output_token_account,
+        input_vault,
+        output_vault,
+        observation_state,
+        token_program,
+        tick_array,
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Createopenorders
+// -----------------------------------------------------------------------------
+accounts!(
+    CreateopenordersAccounts,
+    get_create_open_orders_accounts,
+    {
+        open_orders,
+        payer,
+        dex_program,
+        system_program,
+        rent,
+        market,
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Createopenorderv2
+// -----------------------------------------------------------------------------
+accounts!(
+    Createopenorderv2Accounts,
+    get_create_open_order_v2_accounts,
+    {
+        open_orders,
+        payer,
+        dex_program,
+        system_program,
+        rent,
+        market,
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Mercurialswap
+// -----------------------------------------------------------------------------
+accounts!(
+    MercurialswapAccounts,
+    get_mercurial_swap_accounts,
+    {
+        swap_program,
+        swap_state,
+        token_program,
+        pool_authority,
+        user_transfer_authority,
+        source_token_account,
+        destination_token_account,
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Cykuraswap
+// -----------------------------------------------------------------------------
+accounts!(
+    CykuraswapAccounts,
+    get_cykura_swap_accounts,
+    {
+        swap_program,
+        signer,
+        factory_state,
+        pool_state,
+        input_token_account,
+        output_token_account,
+        input_vault,
+        output_vault,
+        last_observation_state,
+        core_program,
+        token_program,
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Serumswap
+// -----------------------------------------------------------------------------
+accounts!(
+    SerumswapAccounts,
+    get_serum_swap_accounts,
+    {
+        market,
+        authority,
+        order_payer_token_account,
+        coin_wallet,
+        pc_wallet,
+        dex_program,
+        token_program,
+        rent,
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Saberswap
+// -----------------------------------------------------------------------------
+accounts!(
+    SaberswapAccounts,
+    get_saber_swap_accounts,
+    {
+        swap_program,
+        token_program,
+        swap,
+        swap_authority,
+        user_authority,
+        input_user_account,
+        input_token_account,
+        output_user_account,
+        output_token_account,
+        fees_token_account,
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Saberadddecimals
+// -----------------------------------------------------------------------------
+accounts!(
+    SaberadddecimalsAccounts,
+    get_saber_add_decimals_accounts,
+    {
+        add_decimals_program,
+        wrapper,
+        wrapper_mint,
+        wrapper_underlying_tokens,
+        owner,
+        user_underlying_tokens,
+        user_wrapped_tokens,
+        token_program,
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Tokenswap
+// -----------------------------------------------------------------------------
+accounts!(
+    TokenswapAccounts,
+    get_token_swap_accounts,
+    {
+        token_swap_program,
+        token_program,
+        swap,
+        authority,
+        user_transfer_authority,
+        source,
+        swap_source,
+        swap_destination,
+        destination,
+        pool_mint,
+        pool_fee,
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Senchaswap
+// -----------------------------------------------------------------------------
+accounts!(
+    SenchaswapAccounts,
+    get_sencha_swap_accounts,
+    {
+        swap_program,
+        token_program,
+        swap,
+        user_authority,
+        input_user_account,
+        input_token_account,
+        input_fees_account,
+        output_user_account,
+        output_token_account,
+        output_fees_account,
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Stepswap
+// -----------------------------------------------------------------------------
+accounts!(
+    StepswapAccounts,
+    get_step_swap_accounts,
+    {
+        token_swap_program,
+        token_program,
+        swap,
+        authority,
+        user_transfer_authority,
+        source,
+        swap_source,
+        swap_destination,
+        destination,
+        pool_mint,
+        pool_fee,
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Cropperswap
+// -----------------------------------------------------------------------------
+accounts!(
+    CropperswapAccounts,
+    get_cropper_swap_accounts,
+    {
+        token_swap_program,
+        token_program,
+        swap,
+        swap_state,
+        authority,
+        user_transfer_authority,
+        source,
+        swap_source,
+        swap_destination,
+        destination,
+        pool_mint,
+        pool_fee,
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Raydiumswap
+// -----------------------------------------------------------------------------
+accounts!(
+    RaydiumswapAccounts,
+    get_raydium_swap_accounts,
+    {
+        swap_program,
+        token_program,
+        amm_id,
+        amm_authority,
+        amm_open_orders,
+        pool_coin_token_account,
+        pool_pc_token_account,
+        serum_program_id,
+        serum_market,
+        serum_bids,
+        serum_asks,
+        serum_event_queue,
+        serum_coin_vault_account,
+        serum_pc_vault_account,
+        serum_vault_signer,
+        user_source_token_account,
+        user_destination_token_account,
+        user_source_owner,
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Cremaswap
+// -----------------------------------------------------------------------------
+accounts!(
+    CremaswapAccounts,
+    get_crema_swap_accounts,
+    {
+        swap_program,
+        clmm_config,
+        clmmpool,
+        token_a,
+        token_b,
+        account_a,
+        account_b,
+        token_a_vault,
+        token_b_vault,
+        tick_array_map,
+        owner,
+        partner,
+        partner_ata_a,
+        partner_ata_b,
+        token_program,
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Lifinityswap
+// -----------------------------------------------------------------------------
+accounts!(
+    LifinityswapAccounts,
+    get_lifinity_swap_accounts,
+    {
+        swap_program,
+        authority,
+        amm,
+        user_transfer_authority,
+        source_info,
+        destination_info,
+        swap_source,
+        swap_destination,
+        pool_mint,
+        fee_account,
+        token_program,
+        pyth_account,
+        pyth_pc_account,
+        config_account,
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Marinadedeposit
+// -----------------------------------------------------------------------------
+accounts!(
+    MarinadedepositAccounts,
+    get_marinade_deposit_accounts,
+    {
+        marinade_finance_program,
+        state,
+        msol_mint,
+        liq_pool_sol_leg_pda,
+        liq_pool_msol_leg,
+        liq_pool_msol_leg_authority,
+        reserve_pda,
+        transfer_from,
+        mint_to,
+        msol_mint_authority,
+        system_program,
+        token_program,
+        user_wsol_token_account,
+        temp_wsol_token_account,
+        user_transfer_authority,
+        wsol_mint,
+        rent,
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Marinadeunstake
+// -----------------------------------------------------------------------------
+accounts!(
+    MarinadeunstakeAccounts,
+    get_marinade_unstake_accounts,
+    {
+        marinade_finance_program,
+        state,
+        msol_mint,
+        liq_pool_sol_leg_pda,
+        liq_pool_msol_leg,
+        treasury_msol_account,
+        get_msol_from,
+        get_msol_from_authority,
+        transfer_sol_to,
+        system_program,
+        token_program,
+        user_wsol_token_account,
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Aldrinswap
+// -----------------------------------------------------------------------------
+accounts!(
+    AldrinswapAccounts,
+    get_aldrin_swap_accounts,
+    {
+        swap_program,
+        pool,
+        pool_signer,
+        pool_mint,
+        base_token_vault,
+        quote_token_vault,
+        fee_pool_token_account,
+        wallet_authority,
+        user_base_token_account,
+        user_quote_token_account,
+        token_program,
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Aldrinv2swap
+// -----------------------------------------------------------------------------
+accounts!(
+    Aldrinv2swapAccounts,
+    get_aldrin_v2_swap_accounts,
+    {
+        swap_program,
+        pool,
+        pool_signer,
+        pool_mint,
+        base_token_vault,
+        quote_token_vault,
+        fee_pool_token_account,
+        wallet_authority,
+        user_base_token_account,
+        user_quote_token_account,
+        curve,
+        token_program,
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Whirlpoolswap
+// -----------------------------------------------------------------------------
+accounts!(
+    WhirlpoolswapAccounts,
+    get_whirlpool_swap_accounts,
+    {
+        swap_program,
+        token_program,
+        token_authority,
+        whirlpool,
+        token_owner_account_a,
+        token_vault_a,
+        token_owner_account_b,
+        token_vault_b,
+        tick_array0,
+        tick_array1,
+        tick_array2,
+        /// Oracle is currently unused and will be enabled on subsequent updates
+        oracle,
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Invariantswap
+// -----------------------------------------------------------------------------
+accounts!(
+    InvariantswapAccounts,
+    get_invariant_swap_accounts,
+    {
+        swap_program,
+        state,
+        pool,
+        tickmap,
+        account_x,
+        account_y,
+        reserve_x,
+        reserve_y,
+        owner,
+        program_authority,
+        token_program,
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Meteoraswap
+// -----------------------------------------------------------------------------
+accounts!(
+    MeteoraswapAccounts,
+    get_meteora_swap_accounts,
+    {
+        swap_program,
+        pool,
+        user_source_token,
+        user_destination_token,
+        a_vault,
+        b_vault,
+        a_token_vault,
+        b_token_vault,
+        a_vault_lp_mint,
+        b_vault_lp_mint,
+        a_vault_lp,
+        b_vault_lp,
+        admin_token_fee,
+        user,
+        vault_program,
+        token_program,
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Goosefxswap
+// -----------------------------------------------------------------------------
+accounts!(
+    GoosefxswapAccounts,
+    get_goosefx_swap_accounts,
+    {
+        swap_program,
+        controller,
+        pair,
+        ssl_in,
+        ssl_out,
+        liability_vault_in,
+        swapped_liability_vault_in,
+        liability_vault_out,
+        swapped_liability_vault_out,
+        user_in_ata,
+        user_out_ata,
+        fee_collector_ata,
+        user_wallet,
+        fee_collector,
+        token_program,
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Deltafiswap
+// -----------------------------------------------------------------------------
+accounts!(
+    DeltafiswapAccounts,
+    get_deltafi_swap_accounts,
+    {
+        swap_program,
+        market_config,
+        swap_info,
+        user_source_token,
+        user_destination_token,
+        swap_source_token,
+        swap_destination_token,
+        deltafi_user,
+        admin_destination_token,
+        pyth_price_base,
+        pyth_price_quote,
+        user_authority,
+        token_program,
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Balansolswap
+// -----------------------------------------------------------------------------
+accounts!(
+    BalansolswapAccounts,
+    get_balansol_swap_accounts,
+    {
+        swap_program,
+        authority,
+        pool,
+        tax_man,
+        bid_mint,
+        treasurer,
+        src_treasury,
+        src_associated_token_account,
+        ask_mint,
+        dst_treasury,
+        dst_associated_token_account,
+        dst_token_account_taxman,
+        system_program,
+        token_program,
+        associated_token_program,
+        rent,
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Marcopoloswap
+// -----------------------------------------------------------------------------
+accounts!(
+    MarcopoloswapAccounts,
+    get_marco_polo_swap_accounts,
+    {
+        swap_program,
+        state,
+        pool,
+        token_x,
+        token_y,
+        pool_x_account,
+        pool_y_account,
+        swapper_x_account,
+        swapper_y_account,
+        swapper,
+        referrer_x_account,
+        referrer_y_account,
+        referrer,
+        program_authority,
+        system_program,
+        token_program,
+        associated_token_program,
+        rent,
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Dradexswap
+// -----------------------------------------------------------------------------
+accounts!(
+    DradexswapAccounts,
+    get_dradex_swap_accounts,
+    {
+        swap_program,
+        pair,
+        market,
+        event_queue,
+        dex_user,
+        market_user,
+        bids,
+        asks,
+        t0_vault,
+        t1_vault,
+        t0_user,
+        t1_user,
+        master,
+        signer,
+        system_program,
+        token_program,
+        logger,
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Lifinityv2swap
+// -----------------------------------------------------------------------------
+accounts!(
+    Lifinityv2swapAccounts,
+    get_lifinity_v2_swap_accounts,
+    {
+        swap_program,
+        authority,
+        amm,
+        user_transfer_authority,
+        source_info,
+        destination_info,
+        swap_source,
+        swap_destination,
+        pool_mint,
+        fee_account,
+        token_program,
+        oracle_main_account,
+        oracle_sub_account,
+        oracle_pc_account,
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Raydiumclmmswap
+// -----------------------------------------------------------------------------
+accounts!(
+    RaydiumclmmswapAccounts,
+    get_raydium_clmm_swap_accounts,
+    {
+        swap_program,
+        payer,
+        amm_config,
+        pool_state,
+        input_token_account,
+        output_token_account,
+        input_vault,
+        output_vault,
+        observation_state,
+        token_program,
+        tick_array,
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Phoenixswap
+// -----------------------------------------------------------------------------
+accounts!(
+    PhoenixswapAccounts,
+    get_phoenix_swap_accounts,
+    {
+        swap_program,
+        log_authority,
+        market,
+        trader,
+        base_account,
+        quote_account,
+        base_vault,
+        quote_vault,
+        token_program,
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Claimbonk
+// -----------------------------------------------------------------------------
+accounts!(
+    ClaimbonkAccounts,
+    get_claim_bonk_accounts,
+    {
+        open_orders,
+        bonk_mint,
+        open_orders_bonk_token_account,
+        market,
+        open_orders_owner,
+        claimer_token_account,
+        token_program,
+    }
+);

--- a/src/jupiter/v4/instructions.rs
+++ b/src/jupiter/v4/instructions.rs
@@ -1,0 +1,253 @@
+//! Jupiter Aggregator v4 on-chain instructions.
+
+use crate::ParseError;
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct AmountWithSlippage {
+    pub amount: u64,
+    pub slippage_bps: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SplitLegDeeper {
+    pub percent: u8,
+    pub swap_leg: SwapLegSwap,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SplitLeg {
+    pub percent: u8,
+    pub swap_leg: SwapLegDeeper,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub enum Side {
+    Bid,
+    Ask,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub enum SwapLegSwap {
+    PlaceholderOne,
+    PlaceholderTwo,
+    Swap { swap: Swap },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub enum SwapLegDeeper {
+    Chain { swap_legs: Vec<SwapLegSwap> },
+    Split { split_legs: Vec<SplitLegDeeper> },
+    Swap { swap: Swap },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub enum SwapLeg {
+    Chain { swap_legs: Vec<SwapLegDeeper> },
+    Split { split_legs: Vec<SplitLeg> },
+    Swap { swap: Swap },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub enum Swap {
+    Saber,
+    SaberAddDecimalsDeposit,
+    SaberAddDecimalsWithdraw,
+    TokenSwap,
+    Sencha,
+    Step,
+    Cropper,
+    Raydium,
+    Crema { a_to_b: bool },
+    Lifinity,
+    Mercurial,
+    Cykura,
+    Serum { side: Side },
+    MarinadeDeposit,
+    MarinadeUnstake,
+    Aldrin { side: Side },
+    AldrinV2 { side: Side },
+    Whirlpool { a_to_b: bool },
+    Invariant { x_to_y: bool },
+    Meteora,
+    GooseFX,
+    DeltaFi { stable: bool },
+    Balansol,
+    MarcoPolo { x_to_y: bool },
+    Dradex { side: Side },
+    LifinityV2,
+    RaydiumClmm,
+    Openbook { side: Side },
+    Phoenix { side: Side },
+}
+
+// -----------------------------------------------------------------------------
+// Discriminators
+// -----------------------------------------------------------------------------
+pub const ROUTE: [u8; 8] = [229, 23, 203, 151, 122, 227, 173, 42];
+pub const WHIRLPOOLSWAPEXACTOUTPUT: [u8; 8] = [202, 223, 84, 36, 215, 74, 85, 49];
+pub const RAYDIUMSWAPEXACTOUTPUT: [u8; 8] = [57, 218, 51, 159, 206, 80, 125, 49];
+pub const RAYDIUMCLMMSWAPEXACTOUTPUT: [u8; 8] = [169, 250, 54, 119, 22, 40, 144, 233];
+pub const CREATEOPENORDERS: [u8; 8] = [74, 221, 179, 211, 73, 19, 243, 196];
+pub const CREATEOPENORDERV2: [u8; 8] = [196, 152, 190, 145, 174, 166, 228, 213];
+pub const MERCURIALSWAP: [u8; 8] = [149, 185, 29, 185, 85, 17, 177, 46];
+pub const CYKURASWAP: [u8; 8] = [146, 141, 97, 210, 219, 131, 156, 229];
+pub const SERUMSWAP: [u8; 8] = [214, 156, 12, 138, 245, 125, 105, 5];
+pub const SABERSWAP: [u8; 8] = [123, 129, 154, 92, 165, 1, 191, 127];
+pub const SABERADDDECIMALS: [u8; 8] = [243, 0, 129, 241, 94, 15, 19, 183];
+pub const TOKENSWAP: [u8; 8] = [220, 69, 2, 104, 103, 131, 45, 62];
+pub const SENCHASWAP: [u8; 8] = [135, 233, 214, 130, 150, 6, 109, 189];
+pub const STEPSWAP: [u8; 8] = [153, 234, 44, 115, 254, 247, 114, 208];
+pub const CROPPERSWAP: [u8; 8] = [83, 253, 54, 152, 17, 98, 19, 240];
+pub const RAYDIUMSWAP: [u8; 8] = [112, 235, 170, 105, 219, 12, 140, 83];
+pub const CREMASWAP: [u8; 8] = [34, 127, 167, 7, 75, 249, 243, 237];
+pub const LIFINITYSWAP: [u8; 8] = [183, 166, 76, 79, 88, 200, 51, 22];
+pub const MARINADEDEPOSIT: [u8; 8] = [179, 217, 105, 11, 111, 105, 175, 19];
+pub const MARINADEUNSTAKE: [u8; 8] = [11, 163, 97, 69, 194, 144, 45, 148];
+pub const ALDRINSWAP: [u8; 8] = [47, 218, 175, 129, 237, 6, 110, 159];
+pub const ALDRINV2SWAP: [u8; 8] = [128, 98, 252, 246, 215, 95, 234, 146];
+pub const WHIRLPOOLSWAP: [u8; 8] = [77, 229, 199, 187, 92, 145, 7, 134];
+pub const INVARIANTSWAP: [u8; 8] = [7, 30, 184, 54, 247, 107, 242, 223];
+pub const METEORASWAP: [u8; 8] = [154, 10, 145, 107, 182, 195, 218, 225];
+pub const GOOSEFXSWAP: [u8; 8] = [233, 190, 87, 77, 91, 160, 139, 197];
+pub const DELTAFISWAP: [u8; 8] = [204, 130, 88, 121, 173, 173, 90, 38];
+pub const BALANSOLSWAP: [u8; 8] = [143, 149, 77, 232, 51, 84, 103, 65];
+pub const MARCOPOLOSWAP: [u8; 8] = [165, 90, 4, 22, 15, 105, 34, 114];
+pub const DRADEXSWAP: [u8; 8] = [138, 209, 181, 213, 183, 223, 202, 187];
+pub const LIFINITYV2SWAP: [u8; 8] = [15, 168, 80, 238, 128, 245, 155, 117];
+pub const RAYDIUMCLMMSWAP: [u8; 8] = [186, 235, 91, 26, 238, 128, 195, 125];
+pub const PHOENIXSWAP: [u8; 8] = [203, 194, 12, 192, 232, 82, 28, 146];
+pub const CLAIMBONK: [u8; 8] = [120, 40, 0, 162, 21, 239, 195, 164];
+
+// -----------------------------------------------------------------------------
+// Instruction enumeration
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum JupiterV4Instruction {
+    Route(RouteInstruction),
+    Whirlpoolswapexactoutput(WhirlpoolswapexactoutputInstruction),
+    Raydiumswapexactoutput(RaydiumswapexactoutputInstruction),
+    Raydiumclmmswapexactoutput(RaydiumclmmswapexactoutputInstruction),
+    Createopenorders,
+    Createopenorderv2,
+    Mercurialswap,
+    Cykuraswap,
+    Serumswap,
+    Saberswap,
+    Saberadddecimals,
+    Tokenswap,
+    Senchaswap,
+    Stepswap,
+    Cropperswap,
+    Raydiumswap,
+    Cremaswap,
+    Lifinityswap,
+    Marinadedeposit,
+    Marinadeunstake,
+    Aldrinswap,
+    Aldrinv2swap,
+    Whirlpoolswap,
+    Invariantswap,
+    Meteoraswap,
+    Goosefxswap,
+    Deltafiswap,
+    Balansolswap,
+    Marcopoloswap,
+    Dradexswap,
+    Lifinityv2swap,
+    Raydiumclmmswap,
+    Phoenixswap,
+    Claimbonk,
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Payload structs
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct RouteInstruction {
+    pub swap_leg: SwapLeg,
+    pub in_amount: u64,
+    pub quoted_out_amount: u64,
+    pub slippage_bps: u16,
+    pub platform_fee_bps: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct WhirlpoolswapexactoutputInstruction {
+    pub out_amount: u64,
+    pub in_amount_with_slippage: AmountWithSlippage,
+    pub a_to_b: bool,
+    pub platform_fee_bps: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct RaydiumswapexactoutputInstruction {
+    pub out_amount: u64,
+    pub in_amount_with_slippage: AmountWithSlippage,
+    pub platform_fee_bps: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct RaydiumclmmswapexactoutputInstruction {
+    pub out_amount: u64,
+    pub in_amount_with_slippage: AmountWithSlippage,
+    pub platform_fee_bps: u8,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for JupiterV4Instruction {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.len() < 8 {
+            return Err(ParseError::TooShort(data.len()));
+        }
+        let (disc, payload) = data.split_at(8);
+        let discriminator: [u8; 8] = disc.try_into().expect("slice len 8");
+        Ok(match discriminator {
+            ROUTE => Self::Route(RouteInstruction::try_from_slice(payload)?),
+            WHIRLPOOLSWAPEXACTOUTPUT => Self::Whirlpoolswapexactoutput(WhirlpoolswapexactoutputInstruction::try_from_slice(payload)?),
+            RAYDIUMSWAPEXACTOUTPUT => Self::Raydiumswapexactoutput(RaydiumswapexactoutputInstruction::try_from_slice(payload)?),
+            RAYDIUMCLMMSWAPEXACTOUTPUT => Self::Raydiumclmmswapexactoutput(RaydiumclmmswapexactoutputInstruction::try_from_slice(payload)?),
+            CREATEOPENORDERS => Self::Createopenorders,
+            CREATEOPENORDERV2 => Self::Createopenorderv2,
+            MERCURIALSWAP => Self::Mercurialswap,
+            CYKURASWAP => Self::Cykuraswap,
+            SERUMSWAP => Self::Serumswap,
+            SABERSWAP => Self::Saberswap,
+            SABERADDDECIMALS => Self::Saberadddecimals,
+            TOKENSWAP => Self::Tokenswap,
+            SENCHASWAP => Self::Senchaswap,
+            STEPSWAP => Self::Stepswap,
+            CROPPERSWAP => Self::Cropperswap,
+            RAYDIUMSWAP => Self::Raydiumswap,
+            CREMASWAP => Self::Cremaswap,
+            LIFINITYSWAP => Self::Lifinityswap,
+            MARINADEDEPOSIT => Self::Marinadedeposit,
+            MARINADEUNSTAKE => Self::Marinadeunstake,
+            ALDRINSWAP => Self::Aldrinswap,
+            ALDRINV2SWAP => Self::Aldrinv2swap,
+            WHIRLPOOLSWAP => Self::Whirlpoolswap,
+            INVARIANTSWAP => Self::Invariantswap,
+            METEORASWAP => Self::Meteoraswap,
+            GOOSEFXSWAP => Self::Goosefxswap,
+            DELTAFISWAP => Self::Deltafiswap,
+            BALANSOLSWAP => Self::Balansolswap,
+            MARCOPOLOSWAP => Self::Marcopoloswap,
+            DRADEXSWAP => Self::Dradexswap,
+            LIFINITYV2SWAP => Self::Lifinityv2swap,
+            RAYDIUMCLMMSWAP => Self::Raydiumclmmswap,
+            PHOENIXSWAP => Self::Phoenixswap,
+            CLAIMBONK => Self::Claimbonk,
+            other => return Err(ParseError::Unknown(other)),
+        })
+    }
+}
+
+/// Convenience wrapper that forwards to `TryFrom`.
+pub fn unpack(data: &[u8]) -> Result<JupiterV4Instruction, ParseError> {
+    JupiterV4Instruction::try_from(data)
+}

--- a/src/jupiter/v4/mod.rs
+++ b/src/jupiter/v4/mod.rs
@@ -1,5 +1,7 @@
 use substreams_solana::b58;
+pub mod accounts;
 pub mod events;
+pub mod instructions;
 
 /// Jupiter Aggregator v4
 ///


### PR DESCRIPTION
## Summary
- add account getters for all Jupiter v4 instructions
- support decoding Jupiter v4 instructions and custom types
- include Fee event and document swapping

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_68b42fd3260c8328899dad32e2ed5462