### PR TITLE
Add Jupiter v6 accounts and instruction helpers

### DIFF
--- a/src/jupiter/v6/accounts.rs
+++ b/src/jupiter/v6/accounts.rs
@@ -1,0 +1,447 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+use solana_program::pubkey::Pubkey;
+use substreams_solana::block_view::InstructionView;
+use thiserror::Error;
+
+// -----------------------------------------------------------------------------
+// Error type
+// -----------------------------------------------------------------------------
+#[derive(Debug, Error)]
+pub enum AccountsError {
+    #[error("missing required account `{name}` at index {index}")]
+    Missing { name: &'static str, index: usize },
+    #[error("invalid key length for `{name}` at index {index}: got {got}, want 32")]
+    InvalidLen { name: &'static str, index: usize, got: usize },
+}
+
+#[inline]
+fn to_pubkey(name: &'static str, index: usize, bytes: &[u8]) -> Result<Pubkey, AccountsError> {
+    let arr: [u8; 32] = bytes.try_into().map_err(|_| AccountsError::InvalidLen { name, index, got: bytes.len() })?;
+    Ok(Pubkey::new_from_array(arr))
+}
+
+// -----------------------------------------------------------------------------
+// Helper macro for required-only account structs
+// -----------------------------------------------------------------------------
+macro_rules! accounts {
+    ($name:ident, $getter:ident, { $($field:ident),+ $(,)? }) => {
+        #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+        pub struct $name {
+            $(pub $field: Pubkey,)+
+        }
+
+        impl<'ix> TryFrom<&InstructionView<'ix>> for $name {
+            type Error = AccountsError;
+
+            fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+                let accounts = ix.accounts();
+                let mut idx = 0;
+                $(
+                    let $field = {
+                        let name = stringify!($field);
+                        let a = accounts
+                            .get(idx)
+                            .ok_or(AccountsError::Missing { name, index: idx })?;
+                        let pk = to_pubkey(name, idx, &a.0)?;
+                        idx += 1;
+                        pk
+                    };
+                )+
+                let _ = idx;
+                Ok(Self { $($field,)+ })
+            }
+        }
+
+        pub fn $getter(ix: &InstructionView) -> Result<$name, AccountsError> {
+            $name::try_from(ix)
+        }
+    };
+}
+
+// -----------------------------------------------------------------------------
+// Simple instructions
+// -----------------------------------------------------------------------------
+accounts!(
+    ClaimAccounts,
+    get_claim_accounts,
+    { wallet, program_authority, system_program }
+);
+
+accounts!(
+    ClaimTokenAccounts,
+    get_claim_token_accounts,
+    { payer, wallet, program_authority, program_token_account, destination_token_account, mint, token_program, associated_token_program, system_program }
+);
+
+accounts!(
+    CloseTokenAccounts,
+    get_close_token_accounts,
+    { operator, wallet, program_authority, program_token_account, mint, token_program }
+);
+
+accounts!(
+    CreateOpenOrdersAccounts,
+    get_create_open_orders_accounts,
+    { open_orders, payer, dex_program, system_program, rent, market }
+);
+
+accounts!(
+    CreateProgramOpenOrdersAccounts,
+    get_create_program_open_orders_accounts,
+    { open_orders, payer, program_authority, dex_program, system_program, rent, market }
+);
+
+accounts!(
+    CreateTokenLedgerAccounts,
+    get_create_token_ledger_accounts,
+    { token_ledger, payer, system_program }
+);
+
+accounts!(
+    CreateTokenAccountAccounts,
+    get_create_token_account_accounts,
+    { token_account, user, mint, token_program, system_program }
+);
+
+accounts!(
+    SetTokenLedgerAccounts,
+    get_set_token_ledger_accounts,
+    { token_ledger, token_account }
+);
+
+// -----------------------------------------------------------------------------
+// Instructions with optional accounts
+// -----------------------------------------------------------------------------
+const IDX_TOKEN_PROGRAM: usize = 0;
+const IDX_USER_TRANSFER_AUTHORITY: usize = 1;
+const IDX_USER_SOURCE_TOKEN_ACCOUNT: usize = 2;
+const IDX_USER_DESTINATION_TOKEN_ACCOUNT: usize = 3;
+const IDX_DESTINATION_TOKEN_ACCOUNT: usize = 4;
+const IDX_SOURCE_MINT: usize = 5;
+const IDX_DESTINATION_MINT: usize = 6;
+const IDX_PLATFORM_FEE_ACCOUNT: usize = 7;
+const IDX_TOKEN_2022_PROGRAM: usize = 8;
+const IDX_EVENT_AUTHORITY: usize = 9;
+const IDX_PROGRAM: usize = 10;
+
+/// Accounts for the `exact_out_route` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct ExactOutRouteAccounts {
+    pub token_program: Pubkey,
+    pub user_transfer_authority: Pubkey,
+    pub user_source_token_account: Pubkey,
+    pub user_destination_token_account: Pubkey,
+    pub destination_token_account: Option<Pubkey>,
+    pub source_mint: Pubkey,
+    pub destination_mint: Pubkey,
+    pub platform_fee_account: Option<Pubkey>,
+    pub token_2022_program: Option<Pubkey>,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for ExactOutRouteAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        let get_opt = |index: usize| -> Option<Pubkey> { accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(ExactOutRouteAccounts {
+            token_program: get_req(IDX_TOKEN_PROGRAM, "token_program")?,
+            user_transfer_authority: get_req(IDX_USER_TRANSFER_AUTHORITY, "user_transfer_authority")?,
+            user_source_token_account: get_req(IDX_USER_SOURCE_TOKEN_ACCOUNT, "user_source_token_account")?,
+            user_destination_token_account: get_req(IDX_USER_DESTINATION_TOKEN_ACCOUNT, "user_destination_token_account")?,
+            destination_token_account: get_opt(IDX_DESTINATION_TOKEN_ACCOUNT),
+            source_mint: get_req(IDX_SOURCE_MINT, "source_mint")?,
+            destination_mint: get_req(IDX_DESTINATION_MINT, "destination_mint")?,
+            platform_fee_account: get_opt(IDX_PLATFORM_FEE_ACCOUNT),
+            token_2022_program: get_opt(IDX_TOKEN_2022_PROGRAM),
+            event_authority: get_req(IDX_EVENT_AUTHORITY, "event_authority")?,
+            program: get_req(IDX_PROGRAM, "program")?,
+        })
+    }
+}
+
+pub fn get_exact_out_route_accounts(ix: &InstructionView) -> Result<ExactOutRouteAccounts, AccountsError> {
+    ExactOutRouteAccounts::try_from(ix)
+}
+
+const IDX_RT_TOKEN_PROGRAM: usize = 0;
+const IDX_RT_USER_TRANSFER_AUTHORITY: usize = 1;
+const IDX_RT_USER_SOURCE_TOKEN_ACCOUNT: usize = 2;
+const IDX_RT_USER_DESTINATION_TOKEN_ACCOUNT: usize = 3;
+const IDX_RT_DESTINATION_TOKEN_ACCOUNT: usize = 4;
+const IDX_RT_DESTINATION_MINT: usize = 5;
+const IDX_RT_PLATFORM_FEE_ACCOUNT: usize = 6;
+const IDX_RT_EVENT_AUTHORITY: usize = 7;
+const IDX_RT_PROGRAM: usize = 8;
+
+/// Accounts for the `route` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct RouteAccounts {
+    pub token_program: Pubkey,
+    pub user_transfer_authority: Pubkey,
+    pub user_source_token_account: Pubkey,
+    pub user_destination_token_account: Pubkey,
+    pub destination_token_account: Option<Pubkey>,
+    pub destination_mint: Pubkey,
+    pub platform_fee_account: Option<Pubkey>,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for RouteAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        let get_opt = |index: usize| -> Option<Pubkey> { accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(RouteAccounts {
+            token_program: get_req(IDX_RT_TOKEN_PROGRAM, "token_program")?,
+            user_transfer_authority: get_req(IDX_RT_USER_TRANSFER_AUTHORITY, "user_transfer_authority")?,
+            user_source_token_account: get_req(IDX_RT_USER_SOURCE_TOKEN_ACCOUNT, "user_source_token_account")?,
+            user_destination_token_account: get_req(IDX_RT_USER_DESTINATION_TOKEN_ACCOUNT, "user_destination_token_account")?,
+            destination_token_account: get_opt(IDX_RT_DESTINATION_TOKEN_ACCOUNT),
+            destination_mint: get_req(IDX_RT_DESTINATION_MINT, "destination_mint")?,
+            platform_fee_account: get_opt(IDX_RT_PLATFORM_FEE_ACCOUNT),
+            event_authority: get_req(IDX_RT_EVENT_AUTHORITY, "event_authority")?,
+            program: get_req(IDX_RT_PROGRAM, "program")?,
+        })
+    }
+}
+
+pub fn get_route_accounts(ix: &InstructionView) -> Result<RouteAccounts, AccountsError> {
+    RouteAccounts::try_from(ix)
+}
+
+const IDX_RTL_TOKEN_PROGRAM: usize = 0;
+const IDX_RTL_USER_TRANSFER_AUTHORITY: usize = 1;
+const IDX_RTL_USER_SOURCE_TOKEN_ACCOUNT: usize = 2;
+const IDX_RTL_USER_DESTINATION_TOKEN_ACCOUNT: usize = 3;
+const IDX_RTL_DESTINATION_TOKEN_ACCOUNT: usize = 4;
+const IDX_RTL_DESTINATION_MINT: usize = 5;
+const IDX_RTL_PLATFORM_FEE_ACCOUNT: usize = 6;
+const IDX_RTL_TOKEN_LEDGER: usize = 7;
+const IDX_RTL_EVENT_AUTHORITY: usize = 8;
+const IDX_RTL_PROGRAM: usize = 9;
+
+/// Accounts for the `route_with_token_ledger` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct RouteWithTokenLedgerAccounts {
+    pub token_program: Pubkey,
+    pub user_transfer_authority: Pubkey,
+    pub user_source_token_account: Pubkey,
+    pub user_destination_token_account: Pubkey,
+    pub destination_token_account: Option<Pubkey>,
+    pub destination_mint: Pubkey,
+    pub platform_fee_account: Option<Pubkey>,
+    pub token_ledger: Pubkey,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for RouteWithTokenLedgerAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        let get_opt = |index: usize| -> Option<Pubkey> { accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(RouteWithTokenLedgerAccounts {
+            token_program: get_req(IDX_RTL_TOKEN_PROGRAM, "token_program")?,
+            user_transfer_authority: get_req(IDX_RTL_USER_TRANSFER_AUTHORITY, "user_transfer_authority")?,
+            user_source_token_account: get_req(IDX_RTL_USER_SOURCE_TOKEN_ACCOUNT, "user_source_token_account")?,
+            user_destination_token_account: get_req(IDX_RTL_USER_DESTINATION_TOKEN_ACCOUNT, "user_destination_token_account")?,
+            destination_token_account: get_opt(IDX_RTL_DESTINATION_TOKEN_ACCOUNT),
+            destination_mint: get_req(IDX_RTL_DESTINATION_MINT, "destination_mint")?,
+            platform_fee_account: get_opt(IDX_RTL_PLATFORM_FEE_ACCOUNT),
+            token_ledger: get_req(IDX_RTL_TOKEN_LEDGER, "token_ledger")?,
+            event_authority: get_req(IDX_RTL_EVENT_AUTHORITY, "event_authority")?,
+            program: get_req(IDX_RTL_PROGRAM, "program")?,
+        })
+    }
+}
+
+pub fn get_route_with_token_ledger_accounts(ix: &InstructionView) -> Result<RouteWithTokenLedgerAccounts, AccountsError> {
+    RouteWithTokenLedgerAccounts::try_from(ix)
+}
+
+const IDX_SA_TOKEN_PROGRAM: usize = 0;
+const IDX_SA_PROGRAM_AUTHORITY: usize = 1;
+const IDX_SA_USER_TRANSFER_AUTHORITY: usize = 2;
+const IDX_SA_SOURCE_TOKEN_ACCOUNT: usize = 3;
+const IDX_SA_PROGRAM_SOURCE_TOKEN_ACCOUNT: usize = 4;
+const IDX_SA_PROGRAM_DESTINATION_TOKEN_ACCOUNT: usize = 5;
+const IDX_SA_DESTINATION_TOKEN_ACCOUNT: usize = 6;
+const IDX_SA_SOURCE_MINT: usize = 7;
+const IDX_SA_DESTINATION_MINT: usize = 8;
+const IDX_SA_PLATFORM_FEE_ACCOUNT: usize = 9;
+const IDX_SA_TOKEN_2022_PROGRAM: usize = 10;
+const IDX_SA_EVENT_AUTHORITY: usize = 11;
+const IDX_SA_PROGRAM: usize = 12;
+
+/// Accounts for the `shared_accounts_exact_out_route` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SharedAccountsExactOutRouteAccounts {
+    pub token_program: Pubkey,
+    pub program_authority: Pubkey,
+    pub user_transfer_authority: Pubkey,
+    pub source_token_account: Pubkey,
+    pub program_source_token_account: Pubkey,
+    pub program_destination_token_account: Pubkey,
+    pub destination_token_account: Pubkey,
+    pub source_mint: Pubkey,
+    pub destination_mint: Pubkey,
+    pub platform_fee_account: Option<Pubkey>,
+    pub token_2022_program: Option<Pubkey>,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for SharedAccountsExactOutRouteAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        let get_opt = |index: usize| -> Option<Pubkey> { accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(SharedAccountsExactOutRouteAccounts {
+            token_program: get_req(IDX_SA_TOKEN_PROGRAM, "token_program")?,
+            program_authority: get_req(IDX_SA_PROGRAM_AUTHORITY, "program_authority")?,
+            user_transfer_authority: get_req(IDX_SA_USER_TRANSFER_AUTHORITY, "user_transfer_authority")?,
+            source_token_account: get_req(IDX_SA_SOURCE_TOKEN_ACCOUNT, "source_token_account")?,
+            program_source_token_account: get_req(IDX_SA_PROGRAM_SOURCE_TOKEN_ACCOUNT, "program_source_token_account")?,
+            program_destination_token_account: get_req(IDX_SA_PROGRAM_DESTINATION_TOKEN_ACCOUNT, "program_destination_token_account")?,
+            destination_token_account: get_req(IDX_SA_DESTINATION_TOKEN_ACCOUNT, "destination_token_account")?,
+            source_mint: get_req(IDX_SA_SOURCE_MINT, "source_mint")?,
+            destination_mint: get_req(IDX_SA_DESTINATION_MINT, "destination_mint")?,
+            platform_fee_account: get_opt(IDX_SA_PLATFORM_FEE_ACCOUNT),
+            token_2022_program: get_opt(IDX_SA_TOKEN_2022_PROGRAM),
+            event_authority: get_req(IDX_SA_EVENT_AUTHORITY, "event_authority")?,
+            program: get_req(IDX_SA_PROGRAM, "program")?,
+        })
+    }
+}
+
+pub fn get_shared_accounts_exact_out_route_accounts(ix: &InstructionView) -> Result<SharedAccountsExactOutRouteAccounts, AccountsError> {
+    SharedAccountsExactOutRouteAccounts::try_from(ix)
+}
+
+/// Accounts for the `shared_accounts_route` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SharedAccountsRouteAccounts {
+    pub token_program: Pubkey,
+    pub program_authority: Pubkey,
+    pub user_transfer_authority: Pubkey,
+    pub source_token_account: Pubkey,
+    pub program_source_token_account: Pubkey,
+    pub program_destination_token_account: Pubkey,
+    pub destination_token_account: Pubkey,
+    pub source_mint: Pubkey,
+    pub destination_mint: Pubkey,
+    pub platform_fee_account: Option<Pubkey>,
+    pub token_2022_program: Option<Pubkey>,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for SharedAccountsRouteAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        let get_opt = |index: usize| -> Option<Pubkey> { accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(SharedAccountsRouteAccounts {
+            token_program: get_req(IDX_SA_TOKEN_PROGRAM, "token_program")?,
+            program_authority: get_req(IDX_SA_PROGRAM_AUTHORITY, "program_authority")?,
+            user_transfer_authority: get_req(IDX_SA_USER_TRANSFER_AUTHORITY, "user_transfer_authority")?,
+            source_token_account: get_req(IDX_SA_SOURCE_TOKEN_ACCOUNT, "source_token_account")?,
+            program_source_token_account: get_req(IDX_SA_PROGRAM_SOURCE_TOKEN_ACCOUNT, "program_source_token_account")?,
+            program_destination_token_account: get_req(IDX_SA_PROGRAM_DESTINATION_TOKEN_ACCOUNT, "program_destination_token_account")?,
+            destination_token_account: get_req(IDX_SA_DESTINATION_TOKEN_ACCOUNT, "destination_token_account")?,
+            source_mint: get_req(IDX_SA_SOURCE_MINT, "source_mint")?,
+            destination_mint: get_req(IDX_SA_DESTINATION_MINT, "destination_mint")?,
+            platform_fee_account: get_opt(IDX_SA_PLATFORM_FEE_ACCOUNT),
+            token_2022_program: get_opt(IDX_SA_TOKEN_2022_PROGRAM),
+            event_authority: get_req(IDX_SA_EVENT_AUTHORITY, "event_authority")?,
+            program: get_req(IDX_SA_PROGRAM, "program")?,
+        })
+    }
+}
+
+pub fn get_shared_accounts_route_accounts(ix: &InstructionView) -> Result<SharedAccountsRouteAccounts, AccountsError> {
+    SharedAccountsRouteAccounts::try_from(ix)
+}
+
+const IDX_SAL_TOKEN_LEDGER: usize = 11; // for with_token_ledger variant, before event_authority
+
+/// Accounts for the `shared_accounts_route_with_token_ledger` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SharedAccountsRouteWithTokenLedgerAccounts {
+    pub token_program: Pubkey,
+    pub program_authority: Pubkey,
+    pub user_transfer_authority: Pubkey,
+    pub source_token_account: Pubkey,
+    pub program_source_token_account: Pubkey,
+    pub program_destination_token_account: Pubkey,
+    pub destination_token_account: Pubkey,
+    pub source_mint: Pubkey,
+    pub destination_mint: Pubkey,
+    pub platform_fee_account: Option<Pubkey>,
+    pub token_2022_program: Option<Pubkey>,
+    pub token_ledger: Pubkey,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for SharedAccountsRouteWithTokenLedgerAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, &a.0)
+        };
+        let get_opt = |index: usize| -> Option<Pubkey> { accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(SharedAccountsRouteWithTokenLedgerAccounts {
+            token_program: get_req(IDX_SA_TOKEN_PROGRAM, "token_program")?,
+            program_authority: get_req(IDX_SA_PROGRAM_AUTHORITY, "program_authority")?,
+            user_transfer_authority: get_req(IDX_SA_USER_TRANSFER_AUTHORITY, "user_transfer_authority")?,
+            source_token_account: get_req(IDX_SA_SOURCE_TOKEN_ACCOUNT, "source_token_account")?,
+            program_source_token_account: get_req(IDX_SA_PROGRAM_SOURCE_TOKEN_ACCOUNT, "program_source_token_account")?,
+            program_destination_token_account: get_req(IDX_SA_PROGRAM_DESTINATION_TOKEN_ACCOUNT, "program_destination_token_account")?,
+            destination_token_account: get_req(IDX_SA_DESTINATION_TOKEN_ACCOUNT, "destination_token_account")?,
+            source_mint: get_req(IDX_SA_SOURCE_MINT, "source_mint")?,
+            destination_mint: get_req(IDX_SA_DESTINATION_MINT, "destination_mint")?,
+            platform_fee_account: get_opt(IDX_SA_PLATFORM_FEE_ACCOUNT),
+            token_2022_program: get_opt(IDX_SA_TOKEN_2022_PROGRAM),
+            token_ledger: get_req(IDX_SAL_TOKEN_LEDGER, "token_ledger")?,
+            event_authority: get_req(IDX_SA_EVENT_AUTHORITY, "event_authority")?,
+            program: get_req(IDX_SA_PROGRAM, "program")?,
+        })
+    }
+}
+
+pub fn get_shared_accounts_route_with_token_ledger_accounts(ix: &InstructionView) -> Result<SharedAccountsRouteWithTokenLedgerAccounts, AccountsError> {
+    SharedAccountsRouteWithTokenLedgerAccounts::try_from(ix)
+}

--- a/src/jupiter/v6/events.rs
+++ b/src/jupiter/v6/events.rs
@@ -1,4 +1,4 @@
-//! Pump.fun on-chain **events** and their Borsh-deserialisation helpers.
+//! Jupiter v6 on-chain **events** and their Borsh-deserialisation helpers.
 
 use crate::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};

--- a/src/jupiter/v6/instructions.rs
+++ b/src/jupiter/v6/instructions.rs
@@ -1,0 +1,176 @@
+//! Jupiter v6 on-chain instructions.
+
+use crate::ParseError;
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+
+// -----------------------------------------------------------------------------
+// Payload structs
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct ClaimInstruction {
+    pub id: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct ClaimTokenInstruction {
+    pub id: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CloseTokenInstruction {
+    pub id: u8,
+    pub burn_all: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CreateProgramOpenOrdersInstruction {
+    pub id: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CreateTokenAccountInstruction {
+    pub bump: u8,
+}
+
+/// Route by using program owned token accounts and open orders accounts.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SharedAccountsExactOutRouteInstruction {
+    pub id: u8,
+    /// Raw remaining instruction data (route plan and amounts).
+    pub data: Vec<u8>,
+}
+
+/// Route by using program owned token accounts and open orders accounts.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SharedAccountsRouteInstruction {
+    pub id: u8,
+    /// Raw remaining instruction data (route plan and amounts).
+    pub data: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SharedAccountsRouteWithTokenLedgerInstruction {
+    pub id: u8,
+    /// Raw remaining instruction data (route plan and amounts).
+    pub data: Vec<u8>,
+}
+
+/// `route_plan` Topologically sorted trade DAG
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RouteInstruction {
+    pub data: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExactOutRouteInstruction {
+    /// Raw route plan and arguments.
+    pub data: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RouteWithTokenLedgerInstruction {
+    /// Raw route plan and arguments.
+    pub data: Vec<u8>,
+}
+
+// -----------------------------------------------------------------------------
+// Discriminators
+// -----------------------------------------------------------------------------
+pub const CLAIM: [u8; 8] = [62, 198, 214, 193, 213, 159, 108, 210];
+pub const CLAIM_TOKEN: [u8; 8] = [116, 206, 27, 191, 166, 19, 0, 73];
+pub const CLOSE_TOKEN: [u8; 8] = [26, 74, 236, 151, 104, 64, 183, 249];
+pub const CREATE_OPEN_ORDERS: [u8; 8] = [229, 194, 212, 172, 8, 10, 134, 147];
+pub const CREATE_PROGRAM_OPEN_ORDERS: [u8; 8] = [28, 226, 32, 148, 188, 136, 113, 171];
+pub const CREATE_TOKEN_LEDGER: [u8; 8] = [232, 242, 197, 253, 240, 143, 129, 52];
+pub const CREATE_TOKEN_ACCOUNT: [u8; 8] = [147, 241, 123, 100, 244, 132, 174, 118];
+pub const EXACT_OUT_ROUTE: [u8; 8] = [208, 51, 239, 151, 123, 43, 237, 92];
+pub const ROUTE: [u8; 8] = [229, 23, 203, 151, 122, 227, 173, 42];
+pub const ROUTE_WITH_TOKEN_LEDGER: [u8; 8] = [150, 86, 71, 116, 167, 93, 14, 104];
+pub const SET_TOKEN_LEDGER: [u8; 8] = [228, 85, 185, 112, 78, 79, 77, 2];
+pub const SHARED_ACCOUNTS_EXACT_OUT_ROUTE: [u8; 8] = [176, 209, 105, 168, 154, 125, 69, 62];
+pub const SHARED_ACCOUNTS_ROUTE: [u8; 8] = [193, 32, 155, 51, 65, 214, 156, 129];
+pub const SHARED_ACCOUNTS_ROUTE_WITH_TOKEN_LEDGER: [u8; 8] = [230, 121, 143, 80, 119, 159, 106, 170];
+
+// -----------------------------------------------------------------------------
+// Instruction enumeration
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum JupiterV6Instruction {
+    Claim(ClaimInstruction),
+    ClaimToken(ClaimTokenInstruction),
+    CloseToken(CloseTokenInstruction),
+    CreateOpenOrders,
+    CreateProgramOpenOrders(CreateProgramOpenOrdersInstruction),
+    CreateTokenLedger,
+    CreateTokenAccount(CreateTokenAccountInstruction),
+    ExactOutRoute(ExactOutRouteInstruction),
+    /// route_plan Topologically sorted trade DAG
+    Route(RouteInstruction),
+    RouteWithTokenLedger(RouteWithTokenLedgerInstruction),
+    SetTokenLedger,
+    SharedAccountsExactOutRoute(SharedAccountsExactOutRouteInstruction),
+    SharedAccountsRoute(SharedAccountsRouteInstruction),
+    SharedAccountsRouteWithTokenLedger(SharedAccountsRouteWithTokenLedgerInstruction),
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for JupiterV6Instruction {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.len() < 8 {
+            return Err(ParseError::TooShort(data.len()));
+        }
+
+        let (disc, payload) = data.split_at(8);
+        let discriminator: [u8; 8] = disc.try_into().expect("slice len 8");
+
+        Ok(match discriminator {
+            CLAIM => Self::Claim(ClaimInstruction::try_from_slice(payload)?),
+            CLAIM_TOKEN => Self::ClaimToken(ClaimTokenInstruction::try_from_slice(payload)?),
+            CLOSE_TOKEN => Self::CloseToken(CloseTokenInstruction::try_from_slice(payload)?),
+            CREATE_OPEN_ORDERS => Self::CreateOpenOrders,
+            CREATE_PROGRAM_OPEN_ORDERS => Self::CreateProgramOpenOrders(CreateProgramOpenOrdersInstruction::try_from_slice(payload)?),
+            CREATE_TOKEN_LEDGER => Self::CreateTokenLedger,
+            CREATE_TOKEN_ACCOUNT => Self::CreateTokenAccount(CreateTokenAccountInstruction::try_from_slice(payload)?),
+            EXACT_OUT_ROUTE => Self::ExactOutRoute(ExactOutRouteInstruction { data: payload.to_vec() }),
+            ROUTE => Self::Route(RouteInstruction { data: payload.to_vec() }),
+            ROUTE_WITH_TOKEN_LEDGER => Self::RouteWithTokenLedger(RouteWithTokenLedgerInstruction { data: payload.to_vec() }),
+            SET_TOKEN_LEDGER => Self::SetTokenLedger,
+            SHARED_ACCOUNTS_EXACT_OUT_ROUTE => {
+                if payload.is_empty() {
+                    return Err(ParseError::InvalidLength { expected: 1, got: 0 });
+                }
+                let id = payload[0];
+                let data = payload[1..].to_vec();
+                Self::SharedAccountsExactOutRoute(SharedAccountsExactOutRouteInstruction { id, data })
+            }
+            SHARED_ACCOUNTS_ROUTE => {
+                if payload.is_empty() {
+                    return Err(ParseError::InvalidLength { expected: 1, got: 0 });
+                }
+                let id = payload[0];
+                let data = payload[1..].to_vec();
+                Self::SharedAccountsRoute(SharedAccountsRouteInstruction { id, data })
+            }
+            SHARED_ACCOUNTS_ROUTE_WITH_TOKEN_LEDGER => {
+                if payload.is_empty() {
+                    return Err(ParseError::InvalidLength { expected: 1, got: 0 });
+                }
+                let id = payload[0];
+                let data = payload[1..].to_vec();
+                Self::SharedAccountsRouteWithTokenLedger(SharedAccountsRouteWithTokenLedgerInstruction { id, data })
+            }
+            other => return Err(ParseError::Unknown(other)),
+        })
+    }
+}
+
+/// Convenience wrapper that forwards to `TryFrom`.
+pub fn unpack(data: &[u8]) -> Result<JupiterV6Instruction, ParseError> {
+    JupiterV6Instruction::try_from(data)
+}

--- a/src/jupiter/v6/mod.rs
+++ b/src/jupiter/v6/mod.rs
@@ -1,5 +1,7 @@
 use substreams_solana::b58;
+pub mod accounts;
 pub mod events;
+pub mod instructions;
 
 /// Jupiter Aggregator v6
 ///


### PR DESCRIPTION
## Summary
- implement account parsers for all Jupiter v6 instructions
- add Jupiter v6 instruction enum with raw route handling
- document Jupiter v6 events and wire new modules

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_68b42fd934548328baa5401c6c9288dd