### PR TITLE
feat: add meteora dlmm idl

### DIFF
--- a/src/meteora/dllm/accounts.rs
+++ b/src/meteora/dllm/accounts.rs
@@ -1,0 +1,2025 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+use solana_program::pubkey::Pubkey;
+use substreams_solana::block_view::InstructionView;
+use thiserror::Error;
+
+// -----------------------------------------------------------------------------
+// Error type
+// -----------------------------------------------------------------------------
+#[derive(Debug, Error)]
+pub enum AccountsError {
+    #[error("missing required account `{name}` at index {index}")]
+    Missing { name: &'static str, index: usize },
+    #[error("invalid key length for `{name}` at index {index}: got {got}, want 32")]
+    InvalidLen { name: &'static str, index: usize, got: usize },
+}
+
+#[inline]
+fn to_pubkey(name: &'static str, index: usize, bytes: &[u8]) -> Result<Pubkey, AccountsError> {
+    let arr: [u8; 32] = bytes.try_into().map_err(|_| AccountsError::InvalidLen { name, index, got: bytes.len() })?;
+    Ok(Pubkey::new_from_array(arr))
+}
+
+// -----------------------------------------------------------------------------
+// Helper macro for required-only account structs
+// -----------------------------------------------------------------------------
+macro_rules! accounts {
+    ($name:ident, $getter:ident, { $( $(#[$doc:meta])* $field:ident ),+ $(,)? }) => {
+        #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+        pub struct $name {
+            $( $(#[$doc])* pub $field: Pubkey,)+
+        }
+
+        impl<'ix> TryFrom<&InstructionView<'ix>> for $name {
+            type Error = AccountsError;
+            fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+                let accounts = ix.accounts();
+                let mut idx = 0;
+                $(
+                    let $field = {
+                        let name = stringify!($field);
+                        let a = accounts.get(idx).ok_or(AccountsError::Missing { name, index: idx })?;
+                        let pk = to_pubkey(name, idx, &a.0)?;
+                        idx += 1;
+                        pk
+                    };
+                )+
+                let _ = idx;
+                Ok(Self { $($field,)+ })
+            }
+        }
+
+        pub fn $getter(ix: &InstructionView) -> Result<$name, AccountsError> {
+            $name::try_from(ix)
+        }
+    };
+}
+
+/// Accounts for the `add_liquidity` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct AddLiquidityAccounts {
+    pub position: Pubkey,
+    pub lb_pair: Pubkey,
+    pub bin_array_bitmap_extension: Option<Pubkey>,
+    pub user_token_x: Pubkey,
+    pub user_token_y: Pubkey,
+    pub reserve_x: Pubkey,
+    pub reserve_y: Pubkey,
+    pub token_x_mint: Pubkey,
+    pub token_y_mint: Pubkey,
+    pub bin_array_lower: Pubkey,
+    pub bin_array_upper: Pubkey,
+    pub sender: Pubkey,
+    pub token_x_program: Pubkey,
+    pub token_y_program: Pubkey,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for AddLiquidityAccounts {
+    type Error = AccountsError;
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |i: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(i).ok_or(AccountsError::Missing { name, index: i })?;
+            to_pubkey(name, i, &a.0)
+        };
+        let get_opt = |i: usize| -> Option<Pubkey> { accounts.get(i).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(AddLiquidityAccounts {
+            position: get_req(0, "position")?,
+            lb_pair: get_req(1, "lb_pair")?,
+            bin_array_bitmap_extension: get_opt(2),
+            user_token_x: get_req(3, "user_token_x")?,
+            user_token_y: get_req(4, "user_token_y")?,
+            reserve_x: get_req(5, "reserve_x")?,
+            reserve_y: get_req(6, "reserve_y")?,
+            token_x_mint: get_req(7, "token_x_mint")?,
+            token_y_mint: get_req(8, "token_y_mint")?,
+            bin_array_lower: get_req(9, "bin_array_lower")?,
+            bin_array_upper: get_req(10, "bin_array_upper")?,
+            sender: get_req(11, "sender")?,
+            token_x_program: get_req(12, "token_x_program")?,
+            token_y_program: get_req(13, "token_y_program")?,
+            event_authority: get_req(14, "event_authority")?,
+            program: get_req(15, "program")?,
+        })
+    }
+}
+
+pub fn get_add_liquidity_accounts(ix: &InstructionView) -> Result<AddLiquidityAccounts, AccountsError> {
+    AddLiquidityAccounts::try_from(ix)
+}
+
+/// Accounts for the `add_liquidity2` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct AddLiquidity2Accounts {
+    pub position: Pubkey,
+    pub lb_pair: Pubkey,
+    pub bin_array_bitmap_extension: Option<Pubkey>,
+    pub user_token_x: Pubkey,
+    pub user_token_y: Pubkey,
+    pub reserve_x: Pubkey,
+    pub reserve_y: Pubkey,
+    pub token_x_mint: Pubkey,
+    pub token_y_mint: Pubkey,
+    pub sender: Pubkey,
+    pub token_x_program: Pubkey,
+    pub token_y_program: Pubkey,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for AddLiquidity2Accounts {
+    type Error = AccountsError;
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |i: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(i).ok_or(AccountsError::Missing { name, index: i })?;
+            to_pubkey(name, i, &a.0)
+        };
+        let get_opt = |i: usize| -> Option<Pubkey> { accounts.get(i).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(AddLiquidity2Accounts {
+            position: get_req(0, "position")?,
+            lb_pair: get_req(1, "lb_pair")?,
+            bin_array_bitmap_extension: get_opt(2),
+            user_token_x: get_req(3, "user_token_x")?,
+            user_token_y: get_req(4, "user_token_y")?,
+            reserve_x: get_req(5, "reserve_x")?,
+            reserve_y: get_req(6, "reserve_y")?,
+            token_x_mint: get_req(7, "token_x_mint")?,
+            token_y_mint: get_req(8, "token_y_mint")?,
+            sender: get_req(9, "sender")?,
+            token_x_program: get_req(10, "token_x_program")?,
+            token_y_program: get_req(11, "token_y_program")?,
+            event_authority: get_req(12, "event_authority")?,
+            program: get_req(13, "program")?,
+        })
+    }
+}
+
+pub fn get_add_liquidity2_accounts(ix: &InstructionView) -> Result<AddLiquidity2Accounts, AccountsError> {
+    AddLiquidity2Accounts::try_from(ix)
+}
+
+/// Accounts for the `add_liquidity_by_strategy` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct AddLiquidityByStrategyAccounts {
+    pub position: Pubkey,
+    pub lb_pair: Pubkey,
+    pub bin_array_bitmap_extension: Option<Pubkey>,
+    pub user_token_x: Pubkey,
+    pub user_token_y: Pubkey,
+    pub reserve_x: Pubkey,
+    pub reserve_y: Pubkey,
+    pub token_x_mint: Pubkey,
+    pub token_y_mint: Pubkey,
+    pub bin_array_lower: Pubkey,
+    pub bin_array_upper: Pubkey,
+    pub sender: Pubkey,
+    pub token_x_program: Pubkey,
+    pub token_y_program: Pubkey,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for AddLiquidityByStrategyAccounts {
+    type Error = AccountsError;
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |i: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(i).ok_or(AccountsError::Missing { name, index: i })?;
+            to_pubkey(name, i, &a.0)
+        };
+        let get_opt = |i: usize| -> Option<Pubkey> { accounts.get(i).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(AddLiquidityByStrategyAccounts {
+            position: get_req(0, "position")?,
+            lb_pair: get_req(1, "lb_pair")?,
+            bin_array_bitmap_extension: get_opt(2),
+            user_token_x: get_req(3, "user_token_x")?,
+            user_token_y: get_req(4, "user_token_y")?,
+            reserve_x: get_req(5, "reserve_x")?,
+            reserve_y: get_req(6, "reserve_y")?,
+            token_x_mint: get_req(7, "token_x_mint")?,
+            token_y_mint: get_req(8, "token_y_mint")?,
+            bin_array_lower: get_req(9, "bin_array_lower")?,
+            bin_array_upper: get_req(10, "bin_array_upper")?,
+            sender: get_req(11, "sender")?,
+            token_x_program: get_req(12, "token_x_program")?,
+            token_y_program: get_req(13, "token_y_program")?,
+            event_authority: get_req(14, "event_authority")?,
+            program: get_req(15, "program")?,
+        })
+    }
+}
+
+pub fn get_add_liquidity_by_strategy_accounts(ix: &InstructionView) -> Result<AddLiquidityByStrategyAccounts, AccountsError> {
+    AddLiquidityByStrategyAccounts::try_from(ix)
+}
+
+/// Accounts for the `add_liquidity_by_strategy2` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct AddLiquidityByStrategy2Accounts {
+    pub position: Pubkey,
+    pub lb_pair: Pubkey,
+    pub bin_array_bitmap_extension: Option<Pubkey>,
+    pub user_token_x: Pubkey,
+    pub user_token_y: Pubkey,
+    pub reserve_x: Pubkey,
+    pub reserve_y: Pubkey,
+    pub token_x_mint: Pubkey,
+    pub token_y_mint: Pubkey,
+    pub sender: Pubkey,
+    pub token_x_program: Pubkey,
+    pub token_y_program: Pubkey,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for AddLiquidityByStrategy2Accounts {
+    type Error = AccountsError;
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |i: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(i).ok_or(AccountsError::Missing { name, index: i })?;
+            to_pubkey(name, i, &a.0)
+        };
+        let get_opt = |i: usize| -> Option<Pubkey> { accounts.get(i).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(AddLiquidityByStrategy2Accounts {
+            position: get_req(0, "position")?,
+            lb_pair: get_req(1, "lb_pair")?,
+            bin_array_bitmap_extension: get_opt(2),
+            user_token_x: get_req(3, "user_token_x")?,
+            user_token_y: get_req(4, "user_token_y")?,
+            reserve_x: get_req(5, "reserve_x")?,
+            reserve_y: get_req(6, "reserve_y")?,
+            token_x_mint: get_req(7, "token_x_mint")?,
+            token_y_mint: get_req(8, "token_y_mint")?,
+            sender: get_req(9, "sender")?,
+            token_x_program: get_req(10, "token_x_program")?,
+            token_y_program: get_req(11, "token_y_program")?,
+            event_authority: get_req(12, "event_authority")?,
+            program: get_req(13, "program")?,
+        })
+    }
+}
+
+pub fn get_add_liquidity_by_strategy2_accounts(ix: &InstructionView) -> Result<AddLiquidityByStrategy2Accounts, AccountsError> {
+    AddLiquidityByStrategy2Accounts::try_from(ix)
+}
+
+/// Accounts for the `add_liquidity_by_strategy_one_side` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct AddLiquidityByStrategyOneSideAccounts {
+    pub position: Pubkey,
+    pub lb_pair: Pubkey,
+    pub bin_array_bitmap_extension: Option<Pubkey>,
+    pub user_token: Pubkey,
+    pub reserve: Pubkey,
+    pub token_mint: Pubkey,
+    pub bin_array_lower: Pubkey,
+    pub bin_array_upper: Pubkey,
+    pub sender: Pubkey,
+    pub token_program: Pubkey,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for AddLiquidityByStrategyOneSideAccounts {
+    type Error = AccountsError;
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |i: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(i).ok_or(AccountsError::Missing { name, index: i })?;
+            to_pubkey(name, i, &a.0)
+        };
+        let get_opt = |i: usize| -> Option<Pubkey> { accounts.get(i).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(AddLiquidityByStrategyOneSideAccounts {
+            position: get_req(0, "position")?,
+            lb_pair: get_req(1, "lb_pair")?,
+            bin_array_bitmap_extension: get_opt(2),
+            user_token: get_req(3, "user_token")?,
+            reserve: get_req(4, "reserve")?,
+            token_mint: get_req(5, "token_mint")?,
+            bin_array_lower: get_req(6, "bin_array_lower")?,
+            bin_array_upper: get_req(7, "bin_array_upper")?,
+            sender: get_req(8, "sender")?,
+            token_program: get_req(9, "token_program")?,
+            event_authority: get_req(10, "event_authority")?,
+            program: get_req(11, "program")?,
+        })
+    }
+}
+
+pub fn get_add_liquidity_by_strategy_one_side_accounts(ix: &InstructionView) -> Result<AddLiquidityByStrategyOneSideAccounts, AccountsError> {
+    AddLiquidityByStrategyOneSideAccounts::try_from(ix)
+}
+
+/// Accounts for the `add_liquidity_by_weight` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct AddLiquidityByWeightAccounts {
+    pub position: Pubkey,
+    pub lb_pair: Pubkey,
+    pub bin_array_bitmap_extension: Option<Pubkey>,
+    pub user_token_x: Pubkey,
+    pub user_token_y: Pubkey,
+    pub reserve_x: Pubkey,
+    pub reserve_y: Pubkey,
+    pub token_x_mint: Pubkey,
+    pub token_y_mint: Pubkey,
+    pub bin_array_lower: Pubkey,
+    pub bin_array_upper: Pubkey,
+    pub sender: Pubkey,
+    pub token_x_program: Pubkey,
+    pub token_y_program: Pubkey,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for AddLiquidityByWeightAccounts {
+    type Error = AccountsError;
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |i: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(i).ok_or(AccountsError::Missing { name, index: i })?;
+            to_pubkey(name, i, &a.0)
+        };
+        let get_opt = |i: usize| -> Option<Pubkey> { accounts.get(i).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(AddLiquidityByWeightAccounts {
+            position: get_req(0, "position")?,
+            lb_pair: get_req(1, "lb_pair")?,
+            bin_array_bitmap_extension: get_opt(2),
+            user_token_x: get_req(3, "user_token_x")?,
+            user_token_y: get_req(4, "user_token_y")?,
+            reserve_x: get_req(5, "reserve_x")?,
+            reserve_y: get_req(6, "reserve_y")?,
+            token_x_mint: get_req(7, "token_x_mint")?,
+            token_y_mint: get_req(8, "token_y_mint")?,
+            bin_array_lower: get_req(9, "bin_array_lower")?,
+            bin_array_upper: get_req(10, "bin_array_upper")?,
+            sender: get_req(11, "sender")?,
+            token_x_program: get_req(12, "token_x_program")?,
+            token_y_program: get_req(13, "token_y_program")?,
+            event_authority: get_req(14, "event_authority")?,
+            program: get_req(15, "program")?,
+        })
+    }
+}
+
+pub fn get_add_liquidity_by_weight_accounts(ix: &InstructionView) -> Result<AddLiquidityByWeightAccounts, AccountsError> {
+    AddLiquidityByWeightAccounts::try_from(ix)
+}
+
+/// Accounts for the `add_liquidity_one_side` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct AddLiquidityOneSideAccounts {
+    pub position: Pubkey,
+    pub lb_pair: Pubkey,
+    pub bin_array_bitmap_extension: Option<Pubkey>,
+    pub user_token: Pubkey,
+    pub reserve: Pubkey,
+    pub token_mint: Pubkey,
+    pub bin_array_lower: Pubkey,
+    pub bin_array_upper: Pubkey,
+    pub sender: Pubkey,
+    pub token_program: Pubkey,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for AddLiquidityOneSideAccounts {
+    type Error = AccountsError;
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |i: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(i).ok_or(AccountsError::Missing { name, index: i })?;
+            to_pubkey(name, i, &a.0)
+        };
+        let get_opt = |i: usize| -> Option<Pubkey> { accounts.get(i).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(AddLiquidityOneSideAccounts {
+            position: get_req(0, "position")?,
+            lb_pair: get_req(1, "lb_pair")?,
+            bin_array_bitmap_extension: get_opt(2),
+            user_token: get_req(3, "user_token")?,
+            reserve: get_req(4, "reserve")?,
+            token_mint: get_req(5, "token_mint")?,
+            bin_array_lower: get_req(6, "bin_array_lower")?,
+            bin_array_upper: get_req(7, "bin_array_upper")?,
+            sender: get_req(8, "sender")?,
+            token_program: get_req(9, "token_program")?,
+            event_authority: get_req(10, "event_authority")?,
+            program: get_req(11, "program")?,
+        })
+    }
+}
+
+pub fn get_add_liquidity_one_side_accounts(ix: &InstructionView) -> Result<AddLiquidityOneSideAccounts, AccountsError> {
+    AddLiquidityOneSideAccounts::try_from(ix)
+}
+
+/// Accounts for the `add_liquidity_one_side_precise` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct AddLiquidityOneSidePreciseAccounts {
+    pub position: Pubkey,
+    pub lb_pair: Pubkey,
+    pub bin_array_bitmap_extension: Option<Pubkey>,
+    pub user_token: Pubkey,
+    pub reserve: Pubkey,
+    pub token_mint: Pubkey,
+    pub bin_array_lower: Pubkey,
+    pub bin_array_upper: Pubkey,
+    pub sender: Pubkey,
+    pub token_program: Pubkey,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for AddLiquidityOneSidePreciseAccounts {
+    type Error = AccountsError;
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |i: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(i).ok_or(AccountsError::Missing { name, index: i })?;
+            to_pubkey(name, i, &a.0)
+        };
+        let get_opt = |i: usize| -> Option<Pubkey> { accounts.get(i).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(AddLiquidityOneSidePreciseAccounts {
+            position: get_req(0, "position")?,
+            lb_pair: get_req(1, "lb_pair")?,
+            bin_array_bitmap_extension: get_opt(2),
+            user_token: get_req(3, "user_token")?,
+            reserve: get_req(4, "reserve")?,
+            token_mint: get_req(5, "token_mint")?,
+            bin_array_lower: get_req(6, "bin_array_lower")?,
+            bin_array_upper: get_req(7, "bin_array_upper")?,
+            sender: get_req(8, "sender")?,
+            token_program: get_req(9, "token_program")?,
+            event_authority: get_req(10, "event_authority")?,
+            program: get_req(11, "program")?,
+        })
+    }
+}
+
+pub fn get_add_liquidity_one_side_precise_accounts(ix: &InstructionView) -> Result<AddLiquidityOneSidePreciseAccounts, AccountsError> {
+    AddLiquidityOneSidePreciseAccounts::try_from(ix)
+}
+
+/// Accounts for the `add_liquidity_one_side_precise2` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct AddLiquidityOneSidePrecise2Accounts {
+    pub position: Pubkey,
+    pub lb_pair: Pubkey,
+    pub bin_array_bitmap_extension: Option<Pubkey>,
+    pub user_token: Pubkey,
+    pub reserve: Pubkey,
+    pub token_mint: Pubkey,
+    pub sender: Pubkey,
+    pub token_program: Pubkey,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for AddLiquidityOneSidePrecise2Accounts {
+    type Error = AccountsError;
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |i: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(i).ok_or(AccountsError::Missing { name, index: i })?;
+            to_pubkey(name, i, &a.0)
+        };
+        let get_opt = |i: usize| -> Option<Pubkey> { accounts.get(i).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(AddLiquidityOneSidePrecise2Accounts {
+            position: get_req(0, "position")?,
+            lb_pair: get_req(1, "lb_pair")?,
+            bin_array_bitmap_extension: get_opt(2),
+            user_token: get_req(3, "user_token")?,
+            reserve: get_req(4, "reserve")?,
+            token_mint: get_req(5, "token_mint")?,
+            sender: get_req(6, "sender")?,
+            token_program: get_req(7, "token_program")?,
+            event_authority: get_req(8, "event_authority")?,
+            program: get_req(9, "program")?,
+        })
+    }
+}
+
+pub fn get_add_liquidity_one_side_precise2_accounts(ix: &InstructionView) -> Result<AddLiquidityOneSidePrecise2Accounts, AccountsError> {
+    AddLiquidityOneSidePrecise2Accounts::try_from(ix)
+}
+
+accounts!(
+    ClaimFeeAccounts,
+    get_claim_fee_accounts,
+    {
+        lb_pair,
+        position,
+        bin_array_lower,
+        bin_array_upper,
+        sender,
+        reserve_x,
+        reserve_y,
+        user_token_x,
+        user_token_y,
+        token_x_mint,
+        token_y_mint,
+        token_program,
+        event_authority,
+        program,
+    }
+);
+
+accounts!(
+    ClaimFee2Accounts,
+    get_claim_fee2_accounts,
+    {
+        lb_pair,
+        position,
+        sender,
+        reserve_x,
+        reserve_y,
+        user_token_x,
+        user_token_y,
+        token_x_mint,
+        token_y_mint,
+        token_program_x,
+        token_program_y,
+        memo_program,
+        event_authority,
+        program,
+    }
+);
+
+accounts!(
+    ClaimRewardAccounts,
+    get_claim_reward_accounts,
+    {
+        lb_pair,
+        position,
+        bin_array_lower,
+        bin_array_upper,
+        sender,
+        reward_vault,
+        reward_mint,
+        user_token_account,
+        token_program,
+        event_authority,
+        program,
+    }
+);
+
+accounts!(
+    ClaimReward2Accounts,
+    get_claim_reward2_accounts,
+    {
+        lb_pair,
+        position,
+        sender,
+        reward_vault,
+        reward_mint,
+        user_token_account,
+        token_program,
+        memo_program,
+        event_authority,
+        program,
+    }
+);
+
+accounts!(
+    CloseClaimProtocolFeeOperatorAccounts,
+    get_close_claim_protocol_fee_operator_accounts,
+    {
+        claim_fee_operator,
+        rent_receiver,
+        admin,
+    }
+);
+
+accounts!(
+    ClosePositionAccounts,
+    get_close_position_accounts,
+    {
+        position,
+        lb_pair,
+        bin_array_lower,
+        bin_array_upper,
+        sender,
+        rent_receiver,
+        event_authority,
+        program,
+    }
+);
+
+accounts!(
+    ClosePosition2Accounts,
+    get_close_position2_accounts,
+    {
+        position,
+        sender,
+        rent_receiver,
+        event_authority,
+        program,
+    }
+);
+
+accounts!(
+    ClosePositionIfEmptyAccounts,
+    get_close_position_if_empty_accounts,
+    {
+        position,
+        sender,
+        rent_receiver,
+        event_authority,
+        program,
+    }
+);
+
+accounts!(
+    ClosePresetParameterAccounts,
+    get_close_preset_parameter_accounts,
+    {
+        preset_parameter,
+        admin,
+        rent_receiver,
+    }
+);
+
+accounts!(
+    ClosePresetParameter2Accounts,
+    get_close_preset_parameter2_accounts,
+    {
+        preset_parameter,
+        admin,
+        rent_receiver,
+    }
+);
+
+accounts!(
+    CreateClaimProtocolFeeOperatorAccounts,
+    get_create_claim_protocol_fee_operator_accounts,
+    {
+        claim_fee_operator,
+        operator,
+        admin,
+        system_program,
+    }
+);
+
+accounts!(
+    DecreasePositionLengthAccounts,
+    get_decrease_position_length_accounts,
+    {
+        rent_receiver,
+        position,
+        owner,
+        system_program,
+        event_authority,
+        program,
+    }
+);
+
+accounts!(
+    ForIdlTypeGenerationDoNotCallAccounts,
+    get_for_idl_type_generation_do_not_call_accounts,
+    {
+        dummy_zc_account,
+    }
+);
+
+accounts!(
+    FundRewardAccounts,
+    get_fund_reward_accounts,
+    {
+        lb_pair,
+        reward_vault,
+        reward_mint,
+        funder_token_account,
+        funder,
+        bin_array,
+        token_program,
+        event_authority,
+        program,
+    }
+);
+
+/// Accounts for the `go_to_a_bin` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct GoToABinAccounts {
+    pub lb_pair: Pubkey,
+    pub bin_array_bitmap_extension: Option<Pubkey>,
+    pub from_bin_array: Option<Pubkey>,
+    pub to_bin_array: Option<Pubkey>,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for GoToABinAccounts {
+    type Error = AccountsError;
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |i: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(i).ok_or(AccountsError::Missing { name, index: i })?;
+            to_pubkey(name, i, &a.0)
+        };
+        let get_opt = |i: usize| -> Option<Pubkey> { accounts.get(i).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(GoToABinAccounts {
+            lb_pair: get_req(0, "lb_pair")?,
+            bin_array_bitmap_extension: get_opt(1),
+            from_bin_array: get_opt(2),
+            to_bin_array: get_opt(3),
+            event_authority: get_req(4, "event_authority")?,
+            program: get_req(5, "program")?,
+        })
+    }
+}
+
+pub fn get_go_to_a_bin_accounts(ix: &InstructionView) -> Result<GoToABinAccounts, AccountsError> {
+    GoToABinAccounts::try_from(ix)
+}
+
+accounts!(
+    IncreaseOracleLengthAccounts,
+    get_increase_oracle_length_accounts,
+    {
+        oracle,
+        funder,
+        system_program,
+        event_authority,
+        program,
+    }
+);
+
+accounts!(
+    IncreasePositionLengthAccounts,
+    get_increase_position_length_accounts,
+    {
+        funder,
+        lb_pair,
+        position,
+        owner,
+        system_program,
+        event_authority,
+        program,
+    }
+);
+
+accounts!(
+    InitializeBinArrayAccounts,
+    get_initialize_bin_array_accounts,
+    {
+        lb_pair,
+        bin_array,
+        funder,
+        system_program,
+    }
+);
+
+accounts!(
+    InitializeBinArrayBitmapExtensionAccounts,
+    get_initialize_bin_array_bitmap_extension_accounts,
+    {
+        lb_pair,
+        /// Initialize an account to store if a bin array is initialized.
+        bin_array_bitmap_extension,
+        funder,
+        system_program,
+        rent,
+    }
+);
+
+/// Accounts for the `initialize_customizable_permissionless_lb_pair` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct InitializeCustomizablePermissionlessLbPairAccounts {
+    pub lb_pair: Pubkey,
+    pub bin_array_bitmap_extension: Option<Pubkey>,
+    pub token_mint_x: Pubkey,
+    pub token_mint_y: Pubkey,
+    pub reserve_x: Pubkey,
+    pub reserve_y: Pubkey,
+    pub oracle: Pubkey,
+    pub user_token_x: Pubkey,
+    pub funder: Pubkey,
+    pub token_program: Pubkey,
+    pub system_program: Pubkey,
+    pub user_token_y: Pubkey,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for InitializeCustomizablePermissionlessLbPairAccounts {
+    type Error = AccountsError;
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |i: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(i).ok_or(AccountsError::Missing { name, index: i })?;
+            to_pubkey(name, i, &a.0)
+        };
+        let get_opt = |i: usize| -> Option<Pubkey> { accounts.get(i).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(InitializeCustomizablePermissionlessLbPairAccounts {
+            lb_pair: get_req(0, "lb_pair")?,
+            bin_array_bitmap_extension: get_opt(1),
+            token_mint_x: get_req(2, "token_mint_x")?,
+            token_mint_y: get_req(3, "token_mint_y")?,
+            reserve_x: get_req(4, "reserve_x")?,
+            reserve_y: get_req(5, "reserve_y")?,
+            oracle: get_req(6, "oracle")?,
+            user_token_x: get_req(7, "user_token_x")?,
+            funder: get_req(8, "funder")?,
+            token_program: get_req(9, "token_program")?,
+            system_program: get_req(10, "system_program")?,
+            user_token_y: get_req(11, "user_token_y")?,
+            event_authority: get_req(12, "event_authority")?,
+            program: get_req(13, "program")?,
+        })
+    }
+}
+
+pub fn get_initialize_customizable_permissionless_lb_pair_accounts(
+    ix: &InstructionView,
+) -> Result<InitializeCustomizablePermissionlessLbPairAccounts, AccountsError> {
+    InitializeCustomizablePermissionlessLbPairAccounts::try_from(ix)
+}
+
+/// Accounts for the `initialize_customizable_permissionless_lb_pair2` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct InitializeCustomizablePermissionlessLbPair2Accounts {
+    pub lb_pair: Pubkey,
+    pub bin_array_bitmap_extension: Option<Pubkey>,
+    pub token_mint_x: Pubkey,
+    pub token_mint_y: Pubkey,
+    pub reserve_x: Pubkey,
+    pub reserve_y: Pubkey,
+    pub oracle: Pubkey,
+    pub user_token_x: Pubkey,
+    pub funder: Pubkey,
+    pub token_badge_x: Option<Pubkey>,
+    pub token_badge_y: Option<Pubkey>,
+    pub token_program_x: Pubkey,
+    pub token_program_y: Pubkey,
+    pub system_program: Pubkey,
+    pub user_token_y: Pubkey,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for InitializeCustomizablePermissionlessLbPair2Accounts {
+    type Error = AccountsError;
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |i: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(i).ok_or(AccountsError::Missing { name, index: i })?;
+            to_pubkey(name, i, &a.0)
+        };
+        let get_opt = |i: usize| -> Option<Pubkey> { accounts.get(i).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(InitializeCustomizablePermissionlessLbPair2Accounts {
+            lb_pair: get_req(0, "lb_pair")?,
+            bin_array_bitmap_extension: get_opt(1),
+            token_mint_x: get_req(2, "token_mint_x")?,
+            token_mint_y: get_req(3, "token_mint_y")?,
+            reserve_x: get_req(4, "reserve_x")?,
+            reserve_y: get_req(5, "reserve_y")?,
+            oracle: get_req(6, "oracle")?,
+            user_token_x: get_req(7, "user_token_x")?,
+            funder: get_req(8, "funder")?,
+            token_badge_x: get_opt(9),
+            token_badge_y: get_opt(10),
+            token_program_x: get_req(11, "token_program_x")?,
+            token_program_y: get_req(12, "token_program_y")?,
+            system_program: get_req(13, "system_program")?,
+            user_token_y: get_req(14, "user_token_y")?,
+            event_authority: get_req(15, "event_authority")?,
+            program: get_req(16, "program")?,
+        })
+    }
+}
+
+pub fn get_initialize_customizable_permissionless_lb_pair2_accounts(
+    ix: &InstructionView,
+) -> Result<InitializeCustomizablePermissionlessLbPair2Accounts, AccountsError> {
+    InitializeCustomizablePermissionlessLbPair2Accounts::try_from(ix)
+}
+
+/// Accounts for the `initialize_lb_pair` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct InitializeLbPairAccounts {
+    pub lb_pair: Pubkey,
+    pub bin_array_bitmap_extension: Option<Pubkey>,
+    pub token_mint_x: Pubkey,
+    pub token_mint_y: Pubkey,
+    pub reserve_x: Pubkey,
+    pub reserve_y: Pubkey,
+    pub oracle: Pubkey,
+    pub preset_parameter: Pubkey,
+    pub funder: Pubkey,
+    pub token_program: Pubkey,
+    pub system_program: Pubkey,
+    pub rent: Pubkey,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for InitializeLbPairAccounts {
+    type Error = AccountsError;
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |i: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(i).ok_or(AccountsError::Missing { name, index: i })?;
+            to_pubkey(name, i, &a.0)
+        };
+        let get_opt = |i: usize| -> Option<Pubkey> { accounts.get(i).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(InitializeLbPairAccounts {
+            lb_pair: get_req(0, "lb_pair")?,
+            bin_array_bitmap_extension: get_opt(1),
+            token_mint_x: get_req(2, "token_mint_x")?,
+            token_mint_y: get_req(3, "token_mint_y")?,
+            reserve_x: get_req(4, "reserve_x")?,
+            reserve_y: get_req(5, "reserve_y")?,
+            oracle: get_req(6, "oracle")?,
+            preset_parameter: get_req(7, "preset_parameter")?,
+            funder: get_req(8, "funder")?,
+            token_program: get_req(9, "token_program")?,
+            system_program: get_req(10, "system_program")?,
+            rent: get_req(11, "rent")?,
+            event_authority: get_req(12, "event_authority")?,
+            program: get_req(13, "program")?,
+        })
+    }
+}
+
+pub fn get_initialize_lb_pair_accounts(ix: &InstructionView) -> Result<InitializeLbPairAccounts, AccountsError> {
+    InitializeLbPairAccounts::try_from(ix)
+}
+
+/// Accounts for the `initialize_lb_pair2` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct InitializeLbPair2Accounts {
+    pub lb_pair: Pubkey,
+    pub bin_array_bitmap_extension: Option<Pubkey>,
+    pub token_mint_x: Pubkey,
+    pub token_mint_y: Pubkey,
+    pub reserve_x: Pubkey,
+    pub reserve_y: Pubkey,
+    pub oracle: Pubkey,
+    pub preset_parameter: Pubkey,
+    pub funder: Pubkey,
+    pub token_badge_x: Option<Pubkey>,
+    pub token_badge_y: Option<Pubkey>,
+    pub token_program_x: Pubkey,
+    pub token_program_y: Pubkey,
+    pub system_program: Pubkey,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for InitializeLbPair2Accounts {
+    type Error = AccountsError;
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |i: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(i).ok_or(AccountsError::Missing { name, index: i })?;
+            to_pubkey(name, i, &a.0)
+        };
+        let get_opt = |i: usize| -> Option<Pubkey> { accounts.get(i).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(InitializeLbPair2Accounts {
+            lb_pair: get_req(0, "lb_pair")?,
+            bin_array_bitmap_extension: get_opt(1),
+            token_mint_x: get_req(2, "token_mint_x")?,
+            token_mint_y: get_req(3, "token_mint_y")?,
+            reserve_x: get_req(4, "reserve_x")?,
+            reserve_y: get_req(5, "reserve_y")?,
+            oracle: get_req(6, "oracle")?,
+            preset_parameter: get_req(7, "preset_parameter")?,
+            funder: get_req(8, "funder")?,
+            token_badge_x: get_opt(9),
+            token_badge_y: get_opt(10),
+            token_program_x: get_req(11, "token_program_x")?,
+            token_program_y: get_req(12, "token_program_y")?,
+            system_program: get_req(13, "system_program")?,
+            event_authority: get_req(14, "event_authority")?,
+            program: get_req(15, "program")?,
+        })
+    }
+}
+
+pub fn get_initialize_lb_pair2_accounts(ix: &InstructionView) -> Result<InitializeLbPair2Accounts, AccountsError> {
+    InitializeLbPair2Accounts::try_from(ix)
+}
+
+/// Accounts for the `initialize_permission_lb_pair` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct InitializePermissionLbPairAccounts {
+    pub base: Pubkey,
+    pub lb_pair: Pubkey,
+    pub bin_array_bitmap_extension: Option<Pubkey>,
+    pub token_mint_x: Pubkey,
+    pub token_mint_y: Pubkey,
+    pub reserve_x: Pubkey,
+    pub reserve_y: Pubkey,
+    pub oracle: Pubkey,
+    pub admin: Pubkey,
+    pub token_badge_x: Option<Pubkey>,
+    pub token_badge_y: Option<Pubkey>,
+    pub token_program_x: Pubkey,
+    pub token_program_y: Pubkey,
+    pub system_program: Pubkey,
+    pub rent: Pubkey,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for InitializePermissionLbPairAccounts {
+    type Error = AccountsError;
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |i: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(i).ok_or(AccountsError::Missing { name, index: i })?;
+            to_pubkey(name, i, &a.0)
+        };
+        let get_opt = |i: usize| -> Option<Pubkey> { accounts.get(i).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(InitializePermissionLbPairAccounts {
+            base: get_req(0, "base")?,
+            lb_pair: get_req(1, "lb_pair")?,
+            bin_array_bitmap_extension: get_opt(2),
+            token_mint_x: get_req(3, "token_mint_x")?,
+            token_mint_y: get_req(4, "token_mint_y")?,
+            reserve_x: get_req(5, "reserve_x")?,
+            reserve_y: get_req(6, "reserve_y")?,
+            oracle: get_req(7, "oracle")?,
+            admin: get_req(8, "admin")?,
+            token_badge_x: get_opt(9),
+            token_badge_y: get_opt(10),
+            token_program_x: get_req(11, "token_program_x")?,
+            token_program_y: get_req(12, "token_program_y")?,
+            system_program: get_req(13, "system_program")?,
+            rent: get_req(14, "rent")?,
+            event_authority: get_req(15, "event_authority")?,
+            program: get_req(16, "program")?,
+        })
+    }
+}
+
+pub fn get_initialize_permission_lb_pair_accounts(ix: &InstructionView) -> Result<InitializePermissionLbPairAccounts, AccountsError> {
+    InitializePermissionLbPairAccounts::try_from(ix)
+}
+
+accounts!(
+    InitializePositionAccounts,
+    get_initialize_position_accounts,
+    {
+        payer,
+        position,
+        lb_pair,
+        owner,
+        system_program,
+        rent,
+        event_authority,
+        program,
+    }
+);
+
+accounts!(
+    InitializePositionByOperatorAccounts,
+    get_initialize_position_by_operator_accounts,
+    {
+        payer,
+        base,
+        position,
+        lb_pair,
+        owner,
+        /// operator
+        operator,
+        operator_token_x,
+        owner_token_x,
+        system_program,
+        event_authority,
+        program,
+    }
+);
+
+accounts!(
+    InitializePositionPdaAccounts,
+    get_initialize_position_pda_accounts,
+    {
+        payer,
+        base,
+        position,
+        lb_pair,
+        /// owner
+        owner,
+        system_program,
+        rent,
+        event_authority,
+        program,
+    }
+);
+
+accounts!(
+    InitializePresetParameterAccounts,
+    get_initialize_preset_parameter_accounts,
+    {
+        preset_parameter,
+        admin,
+        system_program,
+        rent,
+    }
+);
+
+accounts!(
+    InitializePresetParameter2Accounts,
+    get_initialize_preset_parameter2_accounts,
+    {
+        preset_parameter,
+        admin,
+        system_program,
+    }
+);
+
+/// Accounts for the `initialize_reward` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct InitializeRewardAccounts {
+    pub lb_pair: Pubkey,
+    pub reward_vault: Pubkey,
+    pub reward_mint: Pubkey,
+    pub token_badge: Option<Pubkey>,
+    pub admin: Pubkey,
+    pub token_program: Pubkey,
+    pub system_program: Pubkey,
+    pub rent: Pubkey,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for InitializeRewardAccounts {
+    type Error = AccountsError;
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |i: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(i).ok_or(AccountsError::Missing { name, index: i })?;
+            to_pubkey(name, i, &a.0)
+        };
+        let get_opt = |i: usize| -> Option<Pubkey> { accounts.get(i).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(InitializeRewardAccounts {
+            lb_pair: get_req(0, "lb_pair")?,
+            reward_vault: get_req(1, "reward_vault")?,
+            reward_mint: get_req(2, "reward_mint")?,
+            token_badge: get_opt(3),
+            admin: get_req(4, "admin")?,
+            token_program: get_req(5, "token_program")?,
+            system_program: get_req(6, "system_program")?,
+            rent: get_req(7, "rent")?,
+            event_authority: get_req(8, "event_authority")?,
+            program: get_req(9, "program")?,
+        })
+    }
+}
+
+pub fn get_initialize_reward_accounts(ix: &InstructionView) -> Result<InitializeRewardAccounts, AccountsError> {
+    InitializeRewardAccounts::try_from(ix)
+}
+
+accounts!(
+    InitializeTokenBadgeAccounts,
+    get_initialize_token_badge_accounts,
+    {
+        token_mint,
+        token_badge,
+        admin,
+        system_program,
+    }
+);
+
+accounts!(
+    MigrateBinArrayAccounts,
+    get_migrate_bin_array_accounts,
+    {
+        lb_pair,
+    }
+);
+
+accounts!(
+    MigratePositionAccounts,
+    get_migrate_position_accounts,
+    {
+        position_v2,
+        position_v1,
+        lb_pair,
+        bin_array_lower,
+        bin_array_upper,
+        owner,
+        system_program,
+        rent_receiver,
+        event_authority,
+        program,
+    }
+);
+
+/// Accounts for the `rebalance_liquidity` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct RebalanceLiquidityAccounts {
+    pub position: Pubkey,
+    pub lb_pair: Pubkey,
+    pub bin_array_bitmap_extension: Option<Pubkey>,
+    pub user_token_x: Pubkey,
+    pub user_token_y: Pubkey,
+    pub reserve_x: Pubkey,
+    pub reserve_y: Pubkey,
+    pub token_x_mint: Pubkey,
+    pub token_y_mint: Pubkey,
+    pub owner: Pubkey,
+    pub rent_payer: Pubkey,
+    pub token_x_program: Pubkey,
+    pub token_y_program: Pubkey,
+    pub memo_program: Pubkey,
+    pub system_program: Pubkey,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for RebalanceLiquidityAccounts {
+    type Error = AccountsError;
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |i: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(i).ok_or(AccountsError::Missing { name, index: i })?;
+            to_pubkey(name, i, &a.0)
+        };
+        let get_opt = |i: usize| -> Option<Pubkey> { accounts.get(i).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(RebalanceLiquidityAccounts {
+            position: get_req(0, "position")?,
+            lb_pair: get_req(1, "lb_pair")?,
+            bin_array_bitmap_extension: get_opt(2),
+            user_token_x: get_req(3, "user_token_x")?,
+            user_token_y: get_req(4, "user_token_y")?,
+            reserve_x: get_req(5, "reserve_x")?,
+            reserve_y: get_req(6, "reserve_y")?,
+            token_x_mint: get_req(7, "token_x_mint")?,
+            token_y_mint: get_req(8, "token_y_mint")?,
+            owner: get_req(9, "owner")?,
+            rent_payer: get_req(10, "rent_payer")?,
+            token_x_program: get_req(11, "token_x_program")?,
+            token_y_program: get_req(12, "token_y_program")?,
+            memo_program: get_req(13, "memo_program")?,
+            system_program: get_req(14, "system_program")?,
+            event_authority: get_req(15, "event_authority")?,
+            program: get_req(16, "program")?,
+        })
+    }
+}
+
+pub fn get_rebalance_liquidity_accounts(ix: &InstructionView) -> Result<RebalanceLiquidityAccounts, AccountsError> {
+    RebalanceLiquidityAccounts::try_from(ix)
+}
+
+/// Accounts for the `remove_all_liquidity` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct RemoveAllLiquidityAccounts {
+    pub position: Pubkey,
+    pub lb_pair: Pubkey,
+    pub bin_array_bitmap_extension: Option<Pubkey>,
+    pub user_token_x: Pubkey,
+    pub user_token_y: Pubkey,
+    pub reserve_x: Pubkey,
+    pub reserve_y: Pubkey,
+    pub token_x_mint: Pubkey,
+    pub token_y_mint: Pubkey,
+    pub bin_array_lower: Pubkey,
+    pub bin_array_upper: Pubkey,
+    pub sender: Pubkey,
+    pub token_x_program: Pubkey,
+    pub token_y_program: Pubkey,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for RemoveAllLiquidityAccounts {
+    type Error = AccountsError;
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |i: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(i).ok_or(AccountsError::Missing { name, index: i })?;
+            to_pubkey(name, i, &a.0)
+        };
+        let get_opt = |i: usize| -> Option<Pubkey> { accounts.get(i).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(RemoveAllLiquidityAccounts {
+            position: get_req(0, "position")?,
+            lb_pair: get_req(1, "lb_pair")?,
+            bin_array_bitmap_extension: get_opt(2),
+            user_token_x: get_req(3, "user_token_x")?,
+            user_token_y: get_req(4, "user_token_y")?,
+            reserve_x: get_req(5, "reserve_x")?,
+            reserve_y: get_req(6, "reserve_y")?,
+            token_x_mint: get_req(7, "token_x_mint")?,
+            token_y_mint: get_req(8, "token_y_mint")?,
+            bin_array_lower: get_req(9, "bin_array_lower")?,
+            bin_array_upper: get_req(10, "bin_array_upper")?,
+            sender: get_req(11, "sender")?,
+            token_x_program: get_req(12, "token_x_program")?,
+            token_y_program: get_req(13, "token_y_program")?,
+            event_authority: get_req(14, "event_authority")?,
+            program: get_req(15, "program")?,
+        })
+    }
+}
+
+pub fn get_remove_all_liquidity_accounts(ix: &InstructionView) -> Result<RemoveAllLiquidityAccounts, AccountsError> {
+    RemoveAllLiquidityAccounts::try_from(ix)
+}
+
+/// Accounts for the `remove_liquidity` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct RemoveLiquidityAccounts {
+    pub position: Pubkey,
+    pub lb_pair: Pubkey,
+    pub bin_array_bitmap_extension: Option<Pubkey>,
+    pub user_token_x: Pubkey,
+    pub user_token_y: Pubkey,
+    pub reserve_x: Pubkey,
+    pub reserve_y: Pubkey,
+    pub token_x_mint: Pubkey,
+    pub token_y_mint: Pubkey,
+    pub bin_array_lower: Pubkey,
+    pub bin_array_upper: Pubkey,
+    pub sender: Pubkey,
+    pub token_x_program: Pubkey,
+    pub token_y_program: Pubkey,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for RemoveLiquidityAccounts {
+    type Error = AccountsError;
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |i: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(i).ok_or(AccountsError::Missing { name, index: i })?;
+            to_pubkey(name, i, &a.0)
+        };
+        let get_opt = |i: usize| -> Option<Pubkey> { accounts.get(i).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(RemoveLiquidityAccounts {
+            position: get_req(0, "position")?,
+            lb_pair: get_req(1, "lb_pair")?,
+            bin_array_bitmap_extension: get_opt(2),
+            user_token_x: get_req(3, "user_token_x")?,
+            user_token_y: get_req(4, "user_token_y")?,
+            reserve_x: get_req(5, "reserve_x")?,
+            reserve_y: get_req(6, "reserve_y")?,
+            token_x_mint: get_req(7, "token_x_mint")?,
+            token_y_mint: get_req(8, "token_y_mint")?,
+            bin_array_lower: get_req(9, "bin_array_lower")?,
+            bin_array_upper: get_req(10, "bin_array_upper")?,
+            sender: get_req(11, "sender")?,
+            token_x_program: get_req(12, "token_x_program")?,
+            token_y_program: get_req(13, "token_y_program")?,
+            event_authority: get_req(14, "event_authority")?,
+            program: get_req(15, "program")?,
+        })
+    }
+}
+
+pub fn get_remove_liquidity_accounts(ix: &InstructionView) -> Result<RemoveLiquidityAccounts, AccountsError> {
+    RemoveLiquidityAccounts::try_from(ix)
+}
+
+/// Accounts for the `remove_liquidity2` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct RemoveLiquidity2Accounts {
+    pub position: Pubkey,
+    pub lb_pair: Pubkey,
+    pub bin_array_bitmap_extension: Option<Pubkey>,
+    pub user_token_x: Pubkey,
+    pub user_token_y: Pubkey,
+    pub reserve_x: Pubkey,
+    pub reserve_y: Pubkey,
+    pub token_x_mint: Pubkey,
+    pub token_y_mint: Pubkey,
+    pub sender: Pubkey,
+    pub token_x_program: Pubkey,
+    pub token_y_program: Pubkey,
+    pub memo_program: Pubkey,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for RemoveLiquidity2Accounts {
+    type Error = AccountsError;
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |i: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(i).ok_or(AccountsError::Missing { name, index: i })?;
+            to_pubkey(name, i, &a.0)
+        };
+        let get_opt = |i: usize| -> Option<Pubkey> { accounts.get(i).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(RemoveLiquidity2Accounts {
+            position: get_req(0, "position")?,
+            lb_pair: get_req(1, "lb_pair")?,
+            bin_array_bitmap_extension: get_opt(2),
+            user_token_x: get_req(3, "user_token_x")?,
+            user_token_y: get_req(4, "user_token_y")?,
+            reserve_x: get_req(5, "reserve_x")?,
+            reserve_y: get_req(6, "reserve_y")?,
+            token_x_mint: get_req(7, "token_x_mint")?,
+            token_y_mint: get_req(8, "token_y_mint")?,
+            sender: get_req(9, "sender")?,
+            token_x_program: get_req(10, "token_x_program")?,
+            token_y_program: get_req(11, "token_y_program")?,
+            memo_program: get_req(12, "memo_program")?,
+            event_authority: get_req(13, "event_authority")?,
+            program: get_req(14, "program")?,
+        })
+    }
+}
+
+pub fn get_remove_liquidity2_accounts(ix: &InstructionView) -> Result<RemoveLiquidity2Accounts, AccountsError> {
+    RemoveLiquidity2Accounts::try_from(ix)
+}
+
+/// Accounts for the `remove_liquidity_by_range` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct RemoveLiquidityByRangeAccounts {
+    pub position: Pubkey,
+    pub lb_pair: Pubkey,
+    pub bin_array_bitmap_extension: Option<Pubkey>,
+    pub user_token_x: Pubkey,
+    pub user_token_y: Pubkey,
+    pub reserve_x: Pubkey,
+    pub reserve_y: Pubkey,
+    pub token_x_mint: Pubkey,
+    pub token_y_mint: Pubkey,
+    pub bin_array_lower: Pubkey,
+    pub bin_array_upper: Pubkey,
+    pub sender: Pubkey,
+    pub token_x_program: Pubkey,
+    pub token_y_program: Pubkey,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for RemoveLiquidityByRangeAccounts {
+    type Error = AccountsError;
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |i: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(i).ok_or(AccountsError::Missing { name, index: i })?;
+            to_pubkey(name, i, &a.0)
+        };
+        let get_opt = |i: usize| -> Option<Pubkey> { accounts.get(i).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(RemoveLiquidityByRangeAccounts {
+            position: get_req(0, "position")?,
+            lb_pair: get_req(1, "lb_pair")?,
+            bin_array_bitmap_extension: get_opt(2),
+            user_token_x: get_req(3, "user_token_x")?,
+            user_token_y: get_req(4, "user_token_y")?,
+            reserve_x: get_req(5, "reserve_x")?,
+            reserve_y: get_req(6, "reserve_y")?,
+            token_x_mint: get_req(7, "token_x_mint")?,
+            token_y_mint: get_req(8, "token_y_mint")?,
+            bin_array_lower: get_req(9, "bin_array_lower")?,
+            bin_array_upper: get_req(10, "bin_array_upper")?,
+            sender: get_req(11, "sender")?,
+            token_x_program: get_req(12, "token_x_program")?,
+            token_y_program: get_req(13, "token_y_program")?,
+            event_authority: get_req(14, "event_authority")?,
+            program: get_req(15, "program")?,
+        })
+    }
+}
+
+pub fn get_remove_liquidity_by_range_accounts(ix: &InstructionView) -> Result<RemoveLiquidityByRangeAccounts, AccountsError> {
+    RemoveLiquidityByRangeAccounts::try_from(ix)
+}
+
+/// Accounts for the `remove_liquidity_by_range2` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct RemoveLiquidityByRange2Accounts {
+    pub position: Pubkey,
+    pub lb_pair: Pubkey,
+    pub bin_array_bitmap_extension: Option<Pubkey>,
+    pub user_token_x: Pubkey,
+    pub user_token_y: Pubkey,
+    pub reserve_x: Pubkey,
+    pub reserve_y: Pubkey,
+    pub token_x_mint: Pubkey,
+    pub token_y_mint: Pubkey,
+    pub sender: Pubkey,
+    pub token_x_program: Pubkey,
+    pub token_y_program: Pubkey,
+    pub memo_program: Pubkey,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for RemoveLiquidityByRange2Accounts {
+    type Error = AccountsError;
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |i: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(i).ok_or(AccountsError::Missing { name, index: i })?;
+            to_pubkey(name, i, &a.0)
+        };
+        let get_opt = |i: usize| -> Option<Pubkey> { accounts.get(i).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(RemoveLiquidityByRange2Accounts {
+            position: get_req(0, "position")?,
+            lb_pair: get_req(1, "lb_pair")?,
+            bin_array_bitmap_extension: get_opt(2),
+            user_token_x: get_req(3, "user_token_x")?,
+            user_token_y: get_req(4, "user_token_y")?,
+            reserve_x: get_req(5, "reserve_x")?,
+            reserve_y: get_req(6, "reserve_y")?,
+            token_x_mint: get_req(7, "token_x_mint")?,
+            token_y_mint: get_req(8, "token_y_mint")?,
+            sender: get_req(9, "sender")?,
+            token_x_program: get_req(10, "token_x_program")?,
+            token_y_program: get_req(11, "token_y_program")?,
+            memo_program: get_req(12, "memo_program")?,
+            event_authority: get_req(13, "event_authority")?,
+            program: get_req(14, "program")?,
+        })
+    }
+}
+
+pub fn get_remove_liquidity_by_range2_accounts(ix: &InstructionView) -> Result<RemoveLiquidityByRange2Accounts, AccountsError> {
+    RemoveLiquidityByRange2Accounts::try_from(ix)
+}
+
+accounts!(
+    SetActivationPointAccounts,
+    get_set_activation_point_accounts,
+    {
+        lb_pair,
+        admin,
+    }
+);
+
+accounts!(
+    SetPairStatusAccounts,
+    get_set_pair_status_accounts,
+    {
+        lb_pair,
+        admin,
+    }
+);
+
+accounts!(
+    SetPairStatusPermissionlessAccounts,
+    get_set_pair_status_permissionless_accounts,
+    {
+        lb_pair,
+        creator,
+    }
+);
+
+accounts!(
+    SetPreActivationDurationAccounts,
+    get_set_pre_activation_duration_accounts,
+    {
+        lb_pair,
+        creator,
+    }
+);
+
+accounts!(
+    SetPreActivationSwapAddressAccounts,
+    get_set_pre_activation_swap_address_accounts,
+    {
+        lb_pair,
+        creator,
+    }
+);
+
+/// Accounts for the `swap` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SwapAccounts {
+    pub lb_pair: Pubkey,
+    pub bin_array_bitmap_extension: Option<Pubkey>,
+    pub reserve_x: Pubkey,
+    pub reserve_y: Pubkey,
+    pub user_token_in: Pubkey,
+    pub user_token_out: Pubkey,
+    pub token_x_mint: Pubkey,
+    pub token_y_mint: Pubkey,
+    pub oracle: Pubkey,
+    pub host_fee_in: Option<Pubkey>,
+    pub user: Pubkey,
+    pub token_x_program: Pubkey,
+    pub token_y_program: Pubkey,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for SwapAccounts {
+    type Error = AccountsError;
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |i: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(i).ok_or(AccountsError::Missing { name, index: i })?;
+            to_pubkey(name, i, &a.0)
+        };
+        let get_opt = |i: usize| -> Option<Pubkey> { accounts.get(i).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(SwapAccounts {
+            lb_pair: get_req(0, "lb_pair")?,
+            bin_array_bitmap_extension: get_opt(1),
+            reserve_x: get_req(2, "reserve_x")?,
+            reserve_y: get_req(3, "reserve_y")?,
+            user_token_in: get_req(4, "user_token_in")?,
+            user_token_out: get_req(5, "user_token_out")?,
+            token_x_mint: get_req(6, "token_x_mint")?,
+            token_y_mint: get_req(7, "token_y_mint")?,
+            oracle: get_req(8, "oracle")?,
+            host_fee_in: get_opt(9),
+            user: get_req(10, "user")?,
+            token_x_program: get_req(11, "token_x_program")?,
+            token_y_program: get_req(12, "token_y_program")?,
+            event_authority: get_req(13, "event_authority")?,
+            program: get_req(14, "program")?,
+        })
+    }
+}
+
+pub fn get_swap_accounts(ix: &InstructionView) -> Result<SwapAccounts, AccountsError> {
+    SwapAccounts::try_from(ix)
+}
+
+/// Accounts for the `swap2` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct Swap2Accounts {
+    pub lb_pair: Pubkey,
+    pub bin_array_bitmap_extension: Option<Pubkey>,
+    pub reserve_x: Pubkey,
+    pub reserve_y: Pubkey,
+    pub user_token_in: Pubkey,
+    pub user_token_out: Pubkey,
+    pub token_x_mint: Pubkey,
+    pub token_y_mint: Pubkey,
+    pub oracle: Pubkey,
+    pub host_fee_in: Option<Pubkey>,
+    pub user: Pubkey,
+    pub token_x_program: Pubkey,
+    pub token_y_program: Pubkey,
+    pub memo_program: Pubkey,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for Swap2Accounts {
+    type Error = AccountsError;
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |i: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(i).ok_or(AccountsError::Missing { name, index: i })?;
+            to_pubkey(name, i, &a.0)
+        };
+        let get_opt = |i: usize| -> Option<Pubkey> { accounts.get(i).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(Swap2Accounts {
+            lb_pair: get_req(0, "lb_pair")?,
+            bin_array_bitmap_extension: get_opt(1),
+            reserve_x: get_req(2, "reserve_x")?,
+            reserve_y: get_req(3, "reserve_y")?,
+            user_token_in: get_req(4, "user_token_in")?,
+            user_token_out: get_req(5, "user_token_out")?,
+            token_x_mint: get_req(6, "token_x_mint")?,
+            token_y_mint: get_req(7, "token_y_mint")?,
+            oracle: get_req(8, "oracle")?,
+            host_fee_in: get_opt(9),
+            user: get_req(10, "user")?,
+            token_x_program: get_req(11, "token_x_program")?,
+            token_y_program: get_req(12, "token_y_program")?,
+            memo_program: get_req(13, "memo_program")?,
+            event_authority: get_req(14, "event_authority")?,
+            program: get_req(15, "program")?,
+        })
+    }
+}
+
+pub fn get_swap2_accounts(ix: &InstructionView) -> Result<Swap2Accounts, AccountsError> {
+    Swap2Accounts::try_from(ix)
+}
+
+/// Accounts for the `swap_exact_out` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SwapExactOutAccounts {
+    pub lb_pair: Pubkey,
+    pub bin_array_bitmap_extension: Option<Pubkey>,
+    pub reserve_x: Pubkey,
+    pub reserve_y: Pubkey,
+    pub user_token_in: Pubkey,
+    pub user_token_out: Pubkey,
+    pub token_x_mint: Pubkey,
+    pub token_y_mint: Pubkey,
+    pub oracle: Pubkey,
+    pub host_fee_in: Option<Pubkey>,
+    pub user: Pubkey,
+    pub token_x_program: Pubkey,
+    pub token_y_program: Pubkey,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for SwapExactOutAccounts {
+    type Error = AccountsError;
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |i: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(i).ok_or(AccountsError::Missing { name, index: i })?;
+            to_pubkey(name, i, &a.0)
+        };
+        let get_opt = |i: usize| -> Option<Pubkey> { accounts.get(i).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(SwapExactOutAccounts {
+            lb_pair: get_req(0, "lb_pair")?,
+            bin_array_bitmap_extension: get_opt(1),
+            reserve_x: get_req(2, "reserve_x")?,
+            reserve_y: get_req(3, "reserve_y")?,
+            user_token_in: get_req(4, "user_token_in")?,
+            user_token_out: get_req(5, "user_token_out")?,
+            token_x_mint: get_req(6, "token_x_mint")?,
+            token_y_mint: get_req(7, "token_y_mint")?,
+            oracle: get_req(8, "oracle")?,
+            host_fee_in: get_opt(9),
+            user: get_req(10, "user")?,
+            token_x_program: get_req(11, "token_x_program")?,
+            token_y_program: get_req(12, "token_y_program")?,
+            event_authority: get_req(13, "event_authority")?,
+            program: get_req(14, "program")?,
+        })
+    }
+}
+
+pub fn get_swap_exact_out_accounts(ix: &InstructionView) -> Result<SwapExactOutAccounts, AccountsError> {
+    SwapExactOutAccounts::try_from(ix)
+}
+
+/// Accounts for the `swap_exact_out2` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SwapExactOut2Accounts {
+    pub lb_pair: Pubkey,
+    pub bin_array_bitmap_extension: Option<Pubkey>,
+    pub reserve_x: Pubkey,
+    pub reserve_y: Pubkey,
+    pub user_token_in: Pubkey,
+    pub user_token_out: Pubkey,
+    pub token_x_mint: Pubkey,
+    pub token_y_mint: Pubkey,
+    pub oracle: Pubkey,
+    pub host_fee_in: Option<Pubkey>,
+    pub user: Pubkey,
+    pub token_x_program: Pubkey,
+    pub token_y_program: Pubkey,
+    pub memo_program: Pubkey,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for SwapExactOut2Accounts {
+    type Error = AccountsError;
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |i: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(i).ok_or(AccountsError::Missing { name, index: i })?;
+            to_pubkey(name, i, &a.0)
+        };
+        let get_opt = |i: usize| -> Option<Pubkey> { accounts.get(i).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(SwapExactOut2Accounts {
+            lb_pair: get_req(0, "lb_pair")?,
+            bin_array_bitmap_extension: get_opt(1),
+            reserve_x: get_req(2, "reserve_x")?,
+            reserve_y: get_req(3, "reserve_y")?,
+            user_token_in: get_req(4, "user_token_in")?,
+            user_token_out: get_req(5, "user_token_out")?,
+            token_x_mint: get_req(6, "token_x_mint")?,
+            token_y_mint: get_req(7, "token_y_mint")?,
+            oracle: get_req(8, "oracle")?,
+            host_fee_in: get_opt(9),
+            user: get_req(10, "user")?,
+            token_x_program: get_req(11, "token_x_program")?,
+            token_y_program: get_req(12, "token_y_program")?,
+            memo_program: get_req(13, "memo_program")?,
+            event_authority: get_req(14, "event_authority")?,
+            program: get_req(15, "program")?,
+        })
+    }
+}
+
+pub fn get_swap_exact_out2_accounts(ix: &InstructionView) -> Result<SwapExactOut2Accounts, AccountsError> {
+    SwapExactOut2Accounts::try_from(ix)
+}
+
+/// Accounts for the `swap_with_price_impact` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SwapWithPriceImpactAccounts {
+    pub lb_pair: Pubkey,
+    pub bin_array_bitmap_extension: Option<Pubkey>,
+    pub reserve_x: Pubkey,
+    pub reserve_y: Pubkey,
+    pub user_token_in: Pubkey,
+    pub user_token_out: Pubkey,
+    pub token_x_mint: Pubkey,
+    pub token_y_mint: Pubkey,
+    pub oracle: Pubkey,
+    pub host_fee_in: Option<Pubkey>,
+    pub user: Pubkey,
+    pub token_x_program: Pubkey,
+    pub token_y_program: Pubkey,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for SwapWithPriceImpactAccounts {
+    type Error = AccountsError;
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |i: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(i).ok_or(AccountsError::Missing { name, index: i })?;
+            to_pubkey(name, i, &a.0)
+        };
+        let get_opt = |i: usize| -> Option<Pubkey> { accounts.get(i).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(SwapWithPriceImpactAccounts {
+            lb_pair: get_req(0, "lb_pair")?,
+            bin_array_bitmap_extension: get_opt(1),
+            reserve_x: get_req(2, "reserve_x")?,
+            reserve_y: get_req(3, "reserve_y")?,
+            user_token_in: get_req(4, "user_token_in")?,
+            user_token_out: get_req(5, "user_token_out")?,
+            token_x_mint: get_req(6, "token_x_mint")?,
+            token_y_mint: get_req(7, "token_y_mint")?,
+            oracle: get_req(8, "oracle")?,
+            host_fee_in: get_opt(9),
+            user: get_req(10, "user")?,
+            token_x_program: get_req(11, "token_x_program")?,
+            token_y_program: get_req(12, "token_y_program")?,
+            event_authority: get_req(13, "event_authority")?,
+            program: get_req(14, "program")?,
+        })
+    }
+}
+
+pub fn get_swap_with_price_impact_accounts(ix: &InstructionView) -> Result<SwapWithPriceImpactAccounts, AccountsError> {
+    SwapWithPriceImpactAccounts::try_from(ix)
+}
+
+/// Accounts for the `swap_with_price_impact2` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SwapWithPriceImpact2Accounts {
+    pub lb_pair: Pubkey,
+    pub bin_array_bitmap_extension: Option<Pubkey>,
+    pub reserve_x: Pubkey,
+    pub reserve_y: Pubkey,
+    pub user_token_in: Pubkey,
+    pub user_token_out: Pubkey,
+    pub token_x_mint: Pubkey,
+    pub token_y_mint: Pubkey,
+    pub oracle: Pubkey,
+    pub host_fee_in: Option<Pubkey>,
+    pub user: Pubkey,
+    pub token_x_program: Pubkey,
+    pub token_y_program: Pubkey,
+    pub memo_program: Pubkey,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for SwapWithPriceImpact2Accounts {
+    type Error = AccountsError;
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |i: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(i).ok_or(AccountsError::Missing { name, index: i })?;
+            to_pubkey(name, i, &a.0)
+        };
+        let get_opt = |i: usize| -> Option<Pubkey> { accounts.get(i).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(SwapWithPriceImpact2Accounts {
+            lb_pair: get_req(0, "lb_pair")?,
+            bin_array_bitmap_extension: get_opt(1),
+            reserve_x: get_req(2, "reserve_x")?,
+            reserve_y: get_req(3, "reserve_y")?,
+            user_token_in: get_req(4, "user_token_in")?,
+            user_token_out: get_req(5, "user_token_out")?,
+            token_x_mint: get_req(6, "token_x_mint")?,
+            token_y_mint: get_req(7, "token_y_mint")?,
+            oracle: get_req(8, "oracle")?,
+            host_fee_in: get_opt(9),
+            user: get_req(10, "user")?,
+            token_x_program: get_req(11, "token_x_program")?,
+            token_y_program: get_req(12, "token_y_program")?,
+            memo_program: get_req(13, "memo_program")?,
+            event_authority: get_req(14, "event_authority")?,
+            program: get_req(15, "program")?,
+        })
+    }
+}
+
+pub fn get_swap_with_price_impact2_accounts(ix: &InstructionView) -> Result<SwapWithPriceImpact2Accounts, AccountsError> {
+    SwapWithPriceImpact2Accounts::try_from(ix)
+}
+
+accounts!(
+    UpdateBaseFeeParametersAccounts,
+    get_update_base_fee_parameters_accounts,
+    {
+        lb_pair,
+        admin,
+        event_authority,
+        program,
+    }
+);
+
+accounts!(
+    UpdateDynamicFeeParametersAccounts,
+    get_update_dynamic_fee_parameters_accounts,
+    {
+        lb_pair,
+        admin,
+        event_authority,
+        program,
+    }
+);
+
+accounts!(
+    UpdateFeesAndReward2Accounts,
+    get_update_fees_and_reward2_accounts,
+    {
+        position,
+        lb_pair,
+        owner,
+    }
+);
+
+accounts!(
+    UpdateFeesAndRewardsAccounts,
+    get_update_fees_and_rewards_accounts,
+    {
+        position,
+        lb_pair,
+        bin_array_lower,
+        bin_array_upper,
+        owner,
+    }
+);
+
+accounts!(
+    UpdatePositionOperatorAccounts,
+    get_update_position_operator_accounts,
+    {
+        position,
+        owner,
+        event_authority,
+        program,
+    }
+);
+
+accounts!(
+    UpdateRewardDurationAccounts,
+    get_update_reward_duration_accounts,
+    {
+        lb_pair,
+        admin,
+        bin_array,
+        event_authority,
+        program,
+    }
+);
+
+accounts!(
+    UpdateRewardFunderAccounts,
+    get_update_reward_funder_accounts,
+    {
+        lb_pair,
+        admin,
+        event_authority,
+        program,
+    }
+);
+
+accounts!(
+    WithdrawIneligibleRewardAccounts,
+    get_withdraw_ineligible_reward_accounts,
+    {
+        lb_pair,
+        reward_vault,
+        reward_mint,
+        funder_token_account,
+        funder,
+        bin_array,
+        token_program,
+        memo_program,
+        event_authority,
+        program,
+    }
+);
+
+accounts!(
+    WithdrawProtocolFeeAccounts,
+    get_withdraw_protocol_fee_accounts,
+    {
+        lb_pair,
+        reserve_x,
+        reserve_y,
+        token_x_mint,
+        token_y_mint,
+        receiver_token_x,
+        receiver_token_y,
+        claim_fee_operator,
+        /// operator
+        operator,
+        token_x_program,
+        token_y_program,
+        memo_program,
+    }
+);

--- a/src/meteora/dllm/events.rs
+++ b/src/meteora/dllm/events.rs
@@ -1,0 +1,112 @@
+//! Meteora DLMM on-chain events.
+
+use crate::ParseError;
+use serde::{Deserialize, Serialize};
+
+// -----------------------------------------------------------------------------
+// Discriminators (first 8 bytes of the emitted log’s data)
+// -----------------------------------------------------------------------------
+const ADD_LIQUIDITY: [u8; 8] = [31, 94, 125, 90, 227, 52, 61, 186];
+const CLAIM_FEE: [u8; 8] = [75, 122, 154, 48, 140, 74, 123, 163];
+const CLAIM_FEE2: [u8; 8] = [232, 171, 242, 97, 58, 77, 35, 45];
+const CLAIM_REWARD: [u8; 8] = [148, 116, 134, 204, 22, 171, 85, 95];
+const CLAIM_REWARD2: [u8; 8] = [27, 143, 244, 33, 80, 43, 110, 146];
+const COMPOSITION_FEE: [u8; 8] = [128, 151, 123, 106, 17, 102, 113, 142];
+const DECREASE_POSITION_LENGTH: [u8; 8] = [52, 118, 235, 85, 172, 169, 15, 128];
+const DYNAMIC_FEE_PARAMETER_UPDATE: [u8; 8] = [88, 88, 178, 135, 194, 146, 91, 243];
+const FEE_PARAMETER_UPDATE: [u8; 8] = [48, 76, 241, 117, 144, 215, 242, 44];
+const FUND_REWARD: [u8; 8] = [246, 228, 58, 130, 145, 170, 79, 204];
+const GO_TO_ABIN: [u8; 8] = [59, 138, 76, 68, 138, 131, 176, 67];
+const INCREASE_OBSERVATION: [u8; 8] = [99, 249, 17, 121, 166, 156, 207, 215];
+const INCREASE_POSITION_LENGTH: [u8; 8] = [157, 239, 42, 204, 30, 56, 223, 46];
+const INITIALIZE_REWARD: [u8; 8] = [211, 153, 88, 62, 149, 60, 177, 70];
+const LB_PAIR_CREATE: [u8; 8] = [185, 74, 252, 125, 27, 215, 188, 111];
+const POSITION_CLOSE: [u8; 8] = [255, 196, 16, 107, 28, 202, 53, 128];
+const POSITION_CREATE: [u8; 8] = [144, 142, 252, 84, 157, 53, 37, 121];
+const REBALANCING: [u8; 8] = [0, 109, 117, 179, 61, 91, 199, 200];
+const REMOVE_LIQUIDITY: [u8; 8] = [116, 244, 97, 232, 103, 31, 152, 58];
+const SWAP: [u8; 8] = [81, 108, 227, 190, 205, 208, 10, 196];
+const UPDATE_POSITION_LOCK_RELEASE_POINT: [u8; 8] = [133, 214, 66, 224, 64, 12, 7, 191];
+const UPDATE_POSITION_OPERATOR: [u8; 8] = [39, 115, 48, 204, 246, 47, 66, 57];
+const UPDATE_REWARD_DURATION: [u8; 8] = [223, 245, 224, 153, 49, 29, 163, 172];
+const UPDATE_REWARD_FUNDER: [u8; 8] = [224, 178, 174, 74, 252, 165, 85, 180];
+const WITHDRAW_INELIGIBLE_REWARD: [u8; 8] = [231, 189, 65, 149, 102, 215, 154, 244];
+
+// -----------------------------------------------------------------------------
+// High-level event enum
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MeteoraDllmEvent {
+    AddLiquidity,
+    ClaimFee,
+    ClaimFee2,
+    ClaimReward,
+    ClaimReward2,
+    CompositionFee,
+    DecreasePositionLength,
+    DynamicFeeParameterUpdate,
+    FeeParameterUpdate,
+    FundReward,
+    GoToABin,
+    IncreaseObservation,
+    IncreasePositionLength,
+    InitializeReward,
+    LbPairCreate,
+    PositionClose,
+    PositionCreate,
+    Rebalancing,
+    RemoveLiquidity,
+    Swap,
+    UpdatePositionLockReleasePoint,
+    UpdatePositionOperator,
+    UpdateRewardDuration,
+    UpdateRewardFunder,
+    WithdrawIneligibleReward,
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for MeteoraDllmEvent {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.len() < 8 {
+            return Err(ParseError::TooShort(data.len()));
+        }
+        let disc: [u8; 8] = data[0..8].try_into().expect("slice len 8");
+        Ok(match disc {
+            ADD_LIQUIDITY => Self::AddLiquidity,
+            CLAIM_FEE => Self::ClaimFee,
+            CLAIM_FEE2 => Self::ClaimFee2,
+            CLAIM_REWARD => Self::ClaimReward,
+            CLAIM_REWARD2 => Self::ClaimReward2,
+            COMPOSITION_FEE => Self::CompositionFee,
+            DECREASE_POSITION_LENGTH => Self::DecreasePositionLength,
+            DYNAMIC_FEE_PARAMETER_UPDATE => Self::DynamicFeeParameterUpdate,
+            FEE_PARAMETER_UPDATE => Self::FeeParameterUpdate,
+            FUND_REWARD => Self::FundReward,
+            GO_TO_ABIN => Self::GoToABin,
+            INCREASE_OBSERVATION => Self::IncreaseObservation,
+            INCREASE_POSITION_LENGTH => Self::IncreasePositionLength,
+            INITIALIZE_REWARD => Self::InitializeReward,
+            LB_PAIR_CREATE => Self::LbPairCreate,
+            POSITION_CLOSE => Self::PositionClose,
+            POSITION_CREATE => Self::PositionCreate,
+            REBALANCING => Self::Rebalancing,
+            REMOVE_LIQUIDITY => Self::RemoveLiquidity,
+            SWAP => Self::Swap,
+            UPDATE_POSITION_LOCK_RELEASE_POINT => Self::UpdatePositionLockReleasePoint,
+            UPDATE_POSITION_OPERATOR => Self::UpdatePositionOperator,
+            UPDATE_REWARD_DURATION => Self::UpdateRewardDuration,
+            UPDATE_REWARD_FUNDER => Self::UpdateRewardFunder,
+            WITHDRAW_INELIGIBLE_REWARD => Self::WithdrawIneligibleReward,
+            other => return Err(ParseError::Unknown(other)),
+        })
+    }
+}
+
+pub fn unpack(data: &[u8]) -> Result<MeteoraDllmEvent, ParseError> {
+    MeteoraDllmEvent::try_from(data)
+}

--- a/src/meteora/dllm/instructions.rs
+++ b/src/meteora/dllm/instructions.rs
@@ -1,0 +1,993 @@
+//! Meteora DLMM on-chain instructions.
+
+use crate::ParseError;
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+use solana_program::pubkey::Pubkey;
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub enum AccountsType {
+    TransferHookX,
+    TransferHookY,
+    TransferHookReward,
+    TransferHookMultiReward(u8),
+}
+
+/// Type of the activation
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub enum ActivationType {
+    Slot,
+    Timestamp,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct AddLiquidityParams {
+    pub min_delta_id: i32,
+
+    pub max_delta_id: i32,
+
+    pub x0: u64,
+
+    pub y0: u64,
+
+    pub delta_x: u64,
+
+    pub delta_y: u64,
+
+    pub bit_flag: u8,
+
+    pub favor_x_in_active_id: bool,
+
+    pub padding: [u8; 16],
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct AddLiquiditySingleSidePreciseParameter {
+    pub bins: Vec<CompressedBinDepositAmount>,
+
+    pub decompress_multiplier: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct AddLiquiditySingleSidePreciseParameter2 {
+    pub bins: Vec<CompressedBinDepositAmount>,
+
+    pub decompress_multiplier: u64,
+
+    pub max_amount: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct BaseFeeParameter {
+    /// Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee
+    pub protocol_share: u16,
+    /// Base factor for base fee rate
+    pub base_factor: u16,
+    /// Base fee power factor
+    pub base_fee_power_factor: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct BinLiquidityDistribution {
+    /// Define the bin ID wish to deposit to.
+    pub bin_id: i32,
+    /// DistributionX (or distributionY) is the percentages of amountX (or amountY) you want to add to each bin.
+    pub distribution_x: u16,
+    /// DistributionX (or distributionY) is the percentages of amountX (or amountY) you want to add to each bin.
+    pub distribution_y: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct BinLiquidityDistributionByWeight {
+    /// Define the bin ID wish to deposit to.
+    pub bin_id: i32,
+    /// weight of liquidity distributed for this bin id
+    pub weight: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct BinLiquidityReduction {
+    pub bin_id: i32,
+
+    pub bps_to_remove: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CompressedBinDepositAmount {
+    pub bin_id: i32,
+
+    pub amount: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CustomizableParams {
+    /// Pool price
+    pub active_id: i32,
+    /// Bin step
+    pub bin_step: u16,
+    /// Base factor
+    pub base_factor: u16,
+    /// Activation type. 0 = Slot, 1 = Time. Check ActivationType enum
+    pub activation_type: u8,
+    /// Whether the pool has an alpha vault
+    pub has_alpha_vault: bool,
+    /// Decide when does the pool start trade. None = Now
+    pub activation_point: Option<u64>,
+    /// Pool creator have permission to enable/disable pool with restricted program validation. Only applicable for customizable permissionless pool.
+    pub creator_pool_on_off_control: bool,
+    /// Base fee power factor
+    pub base_fee_power_factor: u8,
+    /// Padding, for future use
+    pub padding: [u8; 62],
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct DummyIx {
+    pub _pair_status: PairStatus,
+
+    pub _pair_type: PairType,
+
+    pub _activation_type: ActivationType,
+
+    pub _token_program_flag: TokenProgramFlags,
+
+    pub _resize_side: ResizeSide,
+
+    pub _rounding: Rounding,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct DynamicFeeParameter {
+    /// Filter period determine high frequency trading time window.
+    pub filter_period: u16,
+    /// Decay period determine when the volatile fee start decay / decrease.
+    pub decay_period: u16,
+    /// Reduction factor controls the volatile fee rate decrement rate.
+    pub reduction_factor: u16,
+    /// Used to scale the variable fee component depending on the dynamic of the market
+    pub variable_fee_control: u32,
+    /// Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate.
+    pub max_volatility_accumulator: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct InitPermissionPairIx {
+    pub active_id: i32,
+
+    pub bin_step: u16,
+
+    pub base_factor: u16,
+
+    pub base_fee_power_factor: u8,
+
+    pub activation_type: u8,
+
+    pub protocol_share: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct InitPresetParameters2Ix {
+    pub index: u16,
+    /// Bin step. Represent the price increment / decrement.
+    pub bin_step: u16,
+    /// Used for base fee calculation. base_fee_rate = base_factor * bin_step * 10 * 10^base_fee_power_factor
+    pub base_factor: u16,
+    /// Filter period determine high frequency trading time window.
+    pub filter_period: u16,
+    /// Decay period determine when the volatile fee start decay / decrease.
+    pub decay_period: u16,
+    /// Reduction factor controls the volatile fee rate decrement rate.
+    pub reduction_factor: u16,
+    /// Used to scale the variable fee component depending on the dynamic of the market
+    pub variable_fee_control: u32,
+    /// Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate.
+    pub max_volatility_accumulator: u32,
+    /// Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee
+    pub protocol_share: u16,
+    /// Base fee power factor
+    pub base_fee_power_factor: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct InitPresetParametersIx {
+    /// Bin step. Represent the price increment / decrement.
+    pub bin_step: u16,
+    /// Used for base fee calculation. base_fee_rate = base_factor * bin_step * 10 * 10^base_fee_power_factor
+    pub base_factor: u16,
+    /// Filter period determine high frequency trading time window.
+    pub filter_period: u16,
+    /// Decay period determine when the volatile fee start decay / decrease.
+    pub decay_period: u16,
+    /// Reduction factor controls the volatile fee rate decrement rate.
+    pub reduction_factor: u16,
+    /// Used to scale the variable fee component depending on the dynamic of the market
+    pub variable_fee_control: u32,
+    /// Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate.
+    pub max_volatility_accumulator: u32,
+    /// Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee
+    pub protocol_share: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct InitializeLbPair2Params {
+    /// Pool price
+    pub active_id: i32,
+    /// Padding, for future use
+    pub padding: [u8; 96],
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct LiquidityOneSideParameter {
+    /// Amount of X token or Y token to deposit
+    pub amount: u64,
+    /// Active bin that integrator observe off-chain
+    pub active_id: i32,
+    /// max active bin slippage allowed
+    pub max_active_bin_slippage: i32,
+    /// Liquidity distribution to each bins
+    pub bin_liquidity_dist: Vec<BinLiquidityDistributionByWeight>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct LiquidityParameter {
+    /// Amount of X token to deposit
+    pub amount_x: u64,
+    /// Amount of Y token to deposit
+    pub amount_y: u64,
+    /// Liquidity distribution to each bins
+    pub bin_liquidity_dist: Vec<BinLiquidityDistribution>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct LiquidityParameterByStrategy {
+    /// Amount of X token to deposit
+    pub amount_x: u64,
+    /// Amount of Y token to deposit
+    pub amount_y: u64,
+    /// Active bin that integrator observe off-chain
+    pub active_id: i32,
+    /// max active bin slippage allowed
+    pub max_active_bin_slippage: i32,
+    /// strategy parameters
+    pub strategy_parameters: StrategyParameters,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct LiquidityParameterByStrategyOneSide {
+    /// Amount of X token or Y token to deposit
+    pub amount: u64,
+    /// Active bin that integrator observe off-chain
+    pub active_id: i32,
+    /// max active bin slippage allowed
+    pub max_active_bin_slippage: i32,
+    /// strategy parameters
+    pub strategy_parameters: StrategyParameters,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct LiquidityParameterByWeight {
+    /// Amount of X token to deposit
+    pub amount_x: u64,
+    /// Amount of Y token to deposit
+    pub amount_y: u64,
+    /// Active bin that integrator observe off-chain
+    pub active_id: i32,
+    /// max active bin slippage allowed
+    pub max_active_bin_slippage: i32,
+    /// Liquidity distribution to each bins
+    pub bin_liquidity_dist: Vec<BinLiquidityDistributionByWeight>,
+}
+
+/// Pair status. 0 = Enabled, 1 = Disabled. Putting 0 as enabled for backward compatibility.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub enum PairStatus {
+    Enabled,
+    Disabled,
+}
+
+/// Type of the Pair. 0 = Permissionless, 1 = Permission, 2 = CustomizablePermissionless. Putting 0 as permissionless for backward compatibility.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub enum PairType {
+    Permissionless,
+    Permission,
+    CustomizablePermissionless,
+    PermissionlessV2,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct RebalanceLiquidityParams {
+    /// active id
+    pub active_id: i32,
+    /// max active bin slippage allowed
+    pub max_active_bin_slippage: u16,
+    /// a flag to indicate that whether fee should be harvested
+    pub should_claim_fee: bool,
+    /// a flag to indicate that whether rewards should be harvested
+    pub should_claim_reward: bool,
+    /// threshold for withdraw token x
+    pub min_withdraw_x_amount: u64,
+    /// threshold for deposit token x
+    pub max_deposit_x_amount: u64,
+    /// threshold for withdraw token y
+    pub min_withdraw_y_amount: u64,
+    /// threshold for deposit token y
+    pub max_deposit_y_amount: u64,
+    /// padding 32 bytes for future usage
+    pub padding: [u8; 32],
+    /// removes
+    pub removes: Vec<RemoveLiquidityParams>,
+    /// adds
+    pub adds: Vec<AddLiquidityParams>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct RemainingAccountsInfo {
+    pub slices: Vec<RemainingAccountsSlice>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct RemainingAccountsSlice {
+    pub accounts_type: AccountsType,
+
+    pub length: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct RemoveLiquidityParams {
+    pub min_bin_id: Option<i32>,
+
+    pub max_bin_id: Option<i32>,
+
+    pub bps: u16,
+
+    pub padding: [u8; 16],
+}
+
+/// Side of resize, 0 for lower and 1 for upper
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub enum ResizeSide {
+    Lower,
+    Upper,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub enum Rounding {
+    Up,
+    Down,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct StrategyParameters {
+    /// min bin id
+    pub min_bin_id: i32,
+    /// max bin id
+    pub max_bin_id: i32,
+    /// strategy type
+    pub strategy_type: StrategyType,
+    /// parameters
+    pub parameteres: [u8; 64],
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub enum StrategyType {
+    SpotOneSide,
+    CurveOneSide,
+    BidAskOneSide,
+    SpotBalanced,
+    CurveBalanced,
+    BidAskBalanced,
+    SpotImBalanced,
+    CurveImBalanced,
+    BidAskImBalanced,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub enum TokenProgramFlags {
+    TokenProgram,
+    TokenProgram2022,
+}
+
+// -----------------------------------------------------------------------------
+// Discriminators
+// -----------------------------------------------------------------------------
+pub const ADD_LIQUIDITY: [u8; 8] = [181, 157, 89, 67, 143, 182, 52, 72];
+pub const ADD_LIQUIDITY2: [u8; 8] = [228, 162, 78, 28, 70, 219, 116, 115];
+pub const ADD_LIQUIDITY_BY_STRATEGY: [u8; 8] = [7, 3, 150, 127, 148, 40, 61, 200];
+pub const ADD_LIQUIDITY_BY_STRATEGY2: [u8; 8] = [3, 221, 149, 218, 111, 141, 118, 213];
+pub const ADD_LIQUIDITY_BY_STRATEGY_ONE_SIDE: [u8; 8] = [41, 5, 238, 175, 100, 225, 6, 205];
+pub const ADD_LIQUIDITY_BY_WEIGHT: [u8; 8] = [28, 140, 238, 99, 231, 162, 21, 149];
+pub const ADD_LIQUIDITY_ONE_SIDE: [u8; 8] = [94, 155, 103, 151, 70, 95, 220, 165];
+pub const ADD_LIQUIDITY_ONE_SIDE_PRECISE: [u8; 8] = [161, 194, 103, 84, 171, 71, 250, 154];
+pub const ADD_LIQUIDITY_ONE_SIDE_PRECISE2: [u8; 8] = [33, 51, 163, 201, 117, 98, 125, 231];
+pub const CLAIM_FEE: [u8; 8] = [169, 32, 79, 137, 136, 232, 70, 137];
+pub const CLAIM_FEE2: [u8; 8] = [112, 191, 101, 171, 28, 144, 127, 187];
+pub const CLAIM_REWARD: [u8; 8] = [149, 95, 181, 242, 94, 90, 158, 162];
+pub const CLAIM_REWARD2: [u8; 8] = [190, 3, 127, 119, 178, 87, 157, 183];
+pub const CLOSE_CLAIM_PROTOCOL_FEE_OPERATOR: [u8; 8] = [8, 41, 87, 35, 80, 48, 121, 26];
+pub const CLOSE_POSITION: [u8; 8] = [123, 134, 81, 0, 49, 68, 98, 98];
+pub const CLOSE_POSITION2: [u8; 8] = [174, 90, 35, 115, 186, 40, 147, 226];
+pub const CLOSE_POSITION_IF_EMPTY: [u8; 8] = [59, 124, 212, 118, 91, 152, 110, 157];
+pub const CLOSE_PRESET_PARAMETER: [u8; 8] = [4, 148, 145, 100, 134, 26, 181, 61];
+pub const CLOSE_PRESET_PARAMETER2: [u8; 8] = [39, 25, 95, 107, 116, 17, 115, 28];
+pub const CREATE_CLAIM_PROTOCOL_FEE_OPERATOR: [u8; 8] = [51, 19, 150, 252, 105, 157, 48, 91];
+pub const DECREASE_POSITION_LENGTH: [u8; 8] = [194, 219, 136, 32, 25, 96, 105, 37];
+pub const FOR_IDL_TYPE_GENERATION_DO_NOT_CALL: [u8; 8] = [180, 105, 69, 80, 95, 50, 73, 108];
+pub const FUND_REWARD: [u8; 8] = [188, 50, 249, 165, 93, 151, 38, 63];
+pub const GO_TO_A_BIN: [u8; 8] = [146, 72, 174, 224, 40, 253, 84, 174];
+pub const INCREASE_ORACLE_LENGTH: [u8; 8] = [190, 61, 125, 87, 103, 79, 158, 173];
+pub const INCREASE_POSITION_LENGTH: [u8; 8] = [80, 83, 117, 211, 66, 13, 33, 149];
+pub const INITIALIZE_BIN_ARRAY: [u8; 8] = [35, 86, 19, 185, 78, 212, 75, 211];
+pub const INITIALIZE_BIN_ARRAY_BITMAP_EXTENSION: [u8; 8] = [47, 157, 226, 180, 12, 240, 33, 71];
+pub const INITIALIZE_CUSTOMIZABLE_PERMISSIONLESS_LB_PAIR: [u8; 8] = [46, 39, 41, 135, 111, 183, 200, 64];
+pub const INITIALIZE_CUSTOMIZABLE_PERMISSIONLESS_LB_PAIR2: [u8; 8] = [243, 73, 129, 126, 51, 19, 241, 107];
+pub const INITIALIZE_LB_PAIR: [u8; 8] = [45, 154, 237, 210, 221, 15, 166, 92];
+pub const INITIALIZE_LB_PAIR2: [u8; 8] = [73, 59, 36, 120, 237, 83, 108, 198];
+pub const INITIALIZE_PERMISSION_LB_PAIR: [u8; 8] = [108, 102, 213, 85, 251, 3, 53, 21];
+pub const INITIALIZE_POSITION: [u8; 8] = [219, 192, 234, 71, 190, 191, 102, 80];
+pub const INITIALIZE_POSITION_BY_OPERATOR: [u8; 8] = [251, 189, 190, 244, 117, 254, 35, 148];
+pub const INITIALIZE_POSITION_PDA: [u8; 8] = [46, 82, 125, 146, 85, 141, 228, 153];
+pub const INITIALIZE_PRESET_PARAMETER: [u8; 8] = [66, 188, 71, 211, 98, 109, 14, 186];
+pub const INITIALIZE_PRESET_PARAMETER2: [u8; 8] = [184, 7, 240, 171, 103, 47, 183, 121];
+pub const INITIALIZE_REWARD: [u8; 8] = [95, 135, 192, 196, 242, 129, 230, 68];
+pub const INITIALIZE_TOKEN_BADGE: [u8; 8] = [253, 77, 205, 95, 27, 224, 89, 223];
+pub const MIGRATE_BIN_ARRAY: [u8; 8] = [17, 23, 159, 211, 101, 184, 41, 241];
+pub const MIGRATE_POSITION: [u8; 8] = [15, 132, 59, 50, 199, 6, 251, 46];
+pub const REBALANCE_LIQUIDITY: [u8; 8] = [92, 4, 176, 193, 119, 185, 83, 9];
+pub const REMOVE_ALL_LIQUIDITY: [u8; 8] = [10, 51, 61, 35, 112, 105, 24, 85];
+pub const REMOVE_LIQUIDITY: [u8; 8] = [80, 85, 209, 72, 24, 206, 177, 108];
+pub const REMOVE_LIQUIDITY2: [u8; 8] = [230, 215, 82, 127, 241, 101, 227, 146];
+pub const REMOVE_LIQUIDITY_BY_RANGE: [u8; 8] = [26, 82, 102, 152, 240, 74, 105, 26];
+pub const REMOVE_LIQUIDITY_BY_RANGE2: [u8; 8] = [204, 2, 195, 145, 53, 145, 145, 205];
+pub const SET_ACTIVATION_POINT: [u8; 8] = [91, 249, 15, 165, 26, 129, 254, 125];
+pub const SET_PAIR_STATUS: [u8; 8] = [67, 248, 231, 137, 154, 149, 217, 174];
+pub const SET_PAIR_STATUS_PERMISSIONLESS: [u8; 8] = [78, 59, 152, 211, 70, 183, 46, 208];
+pub const SET_PRE_ACTIVATION_DURATION: [u8; 8] = [165, 61, 201, 244, 130, 159, 22, 100];
+pub const SET_PRE_ACTIVATION_SWAP_ADDRESS: [u8; 8] = [57, 139, 47, 123, 216, 80, 223, 10];
+pub const SWAP: [u8; 8] = [248, 198, 158, 145, 225, 117, 135, 200];
+pub const SWAP2: [u8; 8] = [65, 75, 63, 76, 235, 91, 91, 136];
+pub const SWAP_EXACT_OUT: [u8; 8] = [250, 73, 101, 33, 38, 207, 75, 184];
+pub const SWAP_EXACT_OUT2: [u8; 8] = [43, 215, 247, 132, 137, 60, 243, 81];
+pub const SWAP_WITH_PRICE_IMPACT: [u8; 8] = [56, 173, 230, 208, 173, 228, 156, 205];
+pub const SWAP_WITH_PRICE_IMPACT2: [u8; 8] = [74, 98, 192, 214, 177, 51, 75, 51];
+pub const UPDATE_BASE_FEE_PARAMETERS: [u8; 8] = [75, 168, 223, 161, 16, 195, 3, 47];
+pub const UPDATE_DYNAMIC_FEE_PARAMETERS: [u8; 8] = [92, 161, 46, 246, 255, 189, 22, 22];
+pub const UPDATE_FEES_AND_REWARD2: [u8; 8] = [32, 142, 184, 154, 103, 65, 184, 88];
+pub const UPDATE_FEES_AND_REWARDS: [u8; 8] = [154, 230, 250, 13, 236, 209, 75, 223];
+pub const UPDATE_POSITION_OPERATOR: [u8; 8] = [202, 184, 103, 143, 180, 191, 116, 217];
+pub const UPDATE_REWARD_DURATION: [u8; 8] = [138, 174, 196, 169, 213, 235, 254, 107];
+pub const UPDATE_REWARD_FUNDER: [u8; 8] = [211, 28, 48, 32, 215, 160, 35, 23];
+pub const WITHDRAW_INELIGIBLE_REWARD: [u8; 8] = [148, 206, 42, 195, 247, 49, 103, 8];
+pub const WITHDRAW_PROTOCOL_FEE: [u8; 8] = [158, 201, 158, 189, 33, 93, 162, 103];
+
+// -----------------------------------------------------------------------------
+// Instruction enumeration
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MeteoraDllmInstruction {
+    AddLiquidity(AddLiquidityInstruction),
+    AddLiquidity2(AddLiquidity2Instruction),
+    AddLiquidityByStrategy(AddLiquidityByStrategyInstruction),
+    AddLiquidityByStrategy2(AddLiquidityByStrategy2Instruction),
+    AddLiquidityByStrategyOneSide(AddLiquidityByStrategyOneSideInstruction),
+    AddLiquidityByWeight(AddLiquidityByWeightInstruction),
+    AddLiquidityOneSide(AddLiquidityOneSideInstruction),
+    AddLiquidityOneSidePrecise(AddLiquidityOneSidePreciseInstruction),
+    AddLiquidityOneSidePrecise2(AddLiquidityOneSidePrecise2Instruction),
+    ClaimFee,
+    ClaimFee2(ClaimFee2Instruction),
+    ClaimReward(ClaimRewardInstruction),
+    ClaimReward2(ClaimReward2Instruction),
+    CloseClaimProtocolFeeOperator,
+    ClosePosition,
+    ClosePosition2,
+    ClosePositionIfEmpty,
+    ClosePresetParameter,
+    ClosePresetParameter2,
+    CreateClaimProtocolFeeOperator,
+    DecreasePositionLength(DecreasePositionLengthInstruction),
+    ForIdlTypeGenerationDoNotCall(ForIdlTypeGenerationDoNotCallInstruction),
+    FundReward(FundRewardInstruction),
+    GoToABin(GoToABinInstruction),
+    IncreaseOracleLength(IncreaseOracleLengthInstruction),
+    IncreasePositionLength(IncreasePositionLengthInstruction),
+    InitializeBinArray(InitializeBinArrayInstruction),
+    InitializeBinArrayBitmapExtension,
+    InitializeCustomizablePermissionlessLbPair(InitializeCustomizablePermissionlessLbPairInstruction),
+    InitializeCustomizablePermissionlessLbPair2(InitializeCustomizablePermissionlessLbPair2Instruction),
+    InitializeLbPair(InitializeLbPairInstruction),
+    InitializeLbPair2(InitializeLbPair2Instruction),
+    InitializePermissionLbPair(InitializePermissionLbPairInstruction),
+    InitializePosition(InitializePositionInstruction),
+    InitializePositionByOperator(InitializePositionByOperatorInstruction),
+    InitializePositionPda(InitializePositionPdaInstruction),
+    InitializePresetParameter(InitializePresetParameterInstruction),
+    InitializePresetParameter2(InitializePresetParameter2Instruction),
+    InitializeReward(InitializeRewardInstruction),
+    InitializeTokenBadge,
+    MigrateBinArray,
+    MigratePosition,
+    RebalanceLiquidity(RebalanceLiquidityInstruction),
+    RemoveAllLiquidity,
+    RemoveLiquidity(RemoveLiquidityInstruction),
+    RemoveLiquidity2(RemoveLiquidity2Instruction),
+    RemoveLiquidityByRange(RemoveLiquidityByRangeInstruction),
+    RemoveLiquidityByRange2(RemoveLiquidityByRange2Instruction),
+    SetActivationPoint(SetActivationPointInstruction),
+    SetPairStatus(SetPairStatusInstruction),
+    SetPairStatusPermissionless(SetPairStatusPermissionlessInstruction),
+    SetPreActivationDuration(SetPreActivationDurationInstruction),
+    SetPreActivationSwapAddress(SetPreActivationSwapAddressInstruction),
+    Swap(SwapInstruction),
+    Swap2(Swap2Instruction),
+    SwapExactOut(SwapExactOutInstruction),
+    SwapExactOut2(SwapExactOut2Instruction),
+    SwapWithPriceImpact(SwapWithPriceImpactInstruction),
+    SwapWithPriceImpact2(SwapWithPriceImpact2Instruction),
+    UpdateBaseFeeParameters(UpdateBaseFeeParametersInstruction),
+    UpdateDynamicFeeParameters(UpdateDynamicFeeParametersInstruction),
+    UpdateFeesAndReward2(UpdateFeesAndReward2Instruction),
+    UpdateFeesAndRewards,
+    UpdatePositionOperator(UpdatePositionOperatorInstruction),
+    UpdateRewardDuration(UpdateRewardDurationInstruction),
+    UpdateRewardFunder(UpdateRewardFunderInstruction),
+    WithdrawIneligibleReward(WithdrawIneligibleRewardInstruction),
+    WithdrawProtocolFee(WithdrawProtocolFeeInstruction),
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Payload structs
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct AddLiquidityInstruction {
+    pub liquidity_parameter: LiquidityParameter,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct AddLiquidity2Instruction {
+    pub liquidity_parameter: LiquidityParameter,
+
+    pub remaining_accounts_info: RemainingAccountsInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct AddLiquidityByStrategyInstruction {
+    pub liquidity_parameter: LiquidityParameterByStrategy,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct AddLiquidityByStrategy2Instruction {
+    pub liquidity_parameter: LiquidityParameterByStrategy,
+
+    pub remaining_accounts_info: RemainingAccountsInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct AddLiquidityByStrategyOneSideInstruction {
+    pub liquidity_parameter: LiquidityParameterByStrategyOneSide,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct AddLiquidityByWeightInstruction {
+    pub liquidity_parameter: LiquidityParameterByWeight,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct AddLiquidityOneSideInstruction {
+    pub liquidity_parameter: LiquidityOneSideParameter,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct AddLiquidityOneSidePreciseInstruction {
+    pub parameter: AddLiquiditySingleSidePreciseParameter,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct AddLiquidityOneSidePrecise2Instruction {
+    pub liquidity_parameter: AddLiquiditySingleSidePreciseParameter2,
+
+    pub remaining_accounts_info: RemainingAccountsInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct ClaimFee2Instruction {
+    pub min_bin_id: i32,
+
+    pub max_bin_id: i32,
+
+    pub remaining_accounts_info: RemainingAccountsInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct ClaimRewardInstruction {
+    pub reward_index: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct ClaimReward2Instruction {
+    pub reward_index: u64,
+
+    pub min_bin_id: i32,
+
+    pub max_bin_id: i32,
+
+    pub remaining_accounts_info: RemainingAccountsInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct DecreasePositionLengthInstruction {
+    pub length_to_remove: u16,
+
+    pub side: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct ForIdlTypeGenerationDoNotCallInstruction {
+    pub _ix: DummyIx,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct FundRewardInstruction {
+    pub reward_index: u64,
+
+    pub amount: u64,
+
+    pub carry_forward: bool,
+
+    pub remaining_accounts_info: RemainingAccountsInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct GoToABinInstruction {
+    pub bin_id: i32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct IncreaseOracleLengthInstruction {
+    pub length_to_add: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct IncreasePositionLengthInstruction {
+    pub length_to_add: u16,
+
+    pub side: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct InitializeBinArrayInstruction {
+    pub index: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct InitializeCustomizablePermissionlessLbPairInstruction {
+    pub params: CustomizableParams,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct InitializeCustomizablePermissionlessLbPair2Instruction {
+    pub params: CustomizableParams,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct InitializeLbPairInstruction {
+    pub active_id: i32,
+
+    pub bin_step: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct InitializeLbPair2Instruction {
+    pub params: InitializeLbPair2Params,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct InitializePermissionLbPairInstruction {
+    pub ix_data: InitPermissionPairIx,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct InitializePositionInstruction {
+    pub lower_bin_id: i32,
+
+    pub width: i32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct InitializePositionByOperatorInstruction {
+    pub lower_bin_id: i32,
+
+    pub width: i32,
+
+    pub fee_owner: Pubkey,
+
+    pub lock_release_point: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct InitializePositionPdaInstruction {
+    pub lower_bin_id: i32,
+
+    pub width: i32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct InitializePresetParameterInstruction {
+    pub ix: InitPresetParametersIx,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct InitializePresetParameter2Instruction {
+    pub ix: InitPresetParameters2Ix,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct InitializeRewardInstruction {
+    pub reward_index: u64,
+
+    pub reward_duration: u64,
+
+    pub funder: Pubkey,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct RebalanceLiquidityInstruction {
+    pub params: RebalanceLiquidityParams,
+
+    pub remaining_accounts_info: RemainingAccountsInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct RemoveLiquidityInstruction {
+    pub bin_liquidity_removal: Vec<BinLiquidityReduction>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct RemoveLiquidity2Instruction {
+    pub bin_liquidity_removal: Vec<BinLiquidityReduction>,
+
+    pub remaining_accounts_info: RemainingAccountsInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct RemoveLiquidityByRangeInstruction {
+    pub from_bin_id: i32,
+
+    pub to_bin_id: i32,
+
+    pub bps_to_remove: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct RemoveLiquidityByRange2Instruction {
+    pub from_bin_id: i32,
+
+    pub to_bin_id: i32,
+
+    pub bps_to_remove: u16,
+
+    pub remaining_accounts_info: RemainingAccountsInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SetActivationPointInstruction {
+    pub activation_point: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SetPairStatusInstruction {
+    pub status: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SetPairStatusPermissionlessInstruction {
+    pub status: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SetPreActivationDurationInstruction {
+    pub pre_activation_duration: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SetPreActivationSwapAddressInstruction {
+    pub pre_activation_swap_address: Pubkey,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SwapInstruction {
+    pub amount_in: u64,
+
+    pub min_amount_out: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct Swap2Instruction {
+    pub amount_in: u64,
+
+    pub min_amount_out: u64,
+
+    pub remaining_accounts_info: RemainingAccountsInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SwapExactOutInstruction {
+    pub max_in_amount: u64,
+
+    pub out_amount: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SwapExactOut2Instruction {
+    pub max_in_amount: u64,
+
+    pub out_amount: u64,
+
+    pub remaining_accounts_info: RemainingAccountsInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SwapWithPriceImpactInstruction {
+    pub amount_in: u64,
+
+    pub active_id: Option<i32>,
+
+    pub max_price_impact_bps: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SwapWithPriceImpact2Instruction {
+    pub amount_in: u64,
+
+    pub active_id: Option<i32>,
+
+    pub max_price_impact_bps: u16,
+
+    pub remaining_accounts_info: RemainingAccountsInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct UpdateBaseFeeParametersInstruction {
+    pub fee_parameter: BaseFeeParameter,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct UpdateDynamicFeeParametersInstruction {
+    pub fee_parameter: DynamicFeeParameter,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct UpdateFeesAndReward2Instruction {
+    pub min_bin_id: i32,
+
+    pub max_bin_id: i32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct UpdatePositionOperatorInstruction {
+    pub operator: Pubkey,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct UpdateRewardDurationInstruction {
+    pub reward_index: u64,
+
+    pub new_duration: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct UpdateRewardFunderInstruction {
+    pub reward_index: u64,
+
+    pub new_funder: Pubkey,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct WithdrawIneligibleRewardInstruction {
+    pub reward_index: u64,
+
+    pub remaining_accounts_info: RemainingAccountsInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct WithdrawProtocolFeeInstruction {
+    pub max_amount_x: u64,
+
+    pub max_amount_y: u64,
+
+    pub remaining_accounts_info: RemainingAccountsInfo,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for MeteoraDllmInstruction {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.len() < 8 {
+            return Err(ParseError::TooShort(data.len()));
+        }
+        let (disc, payload) = data.split_at(8);
+        let discriminator: [u8; 8] = disc.try_into().expect("slice len 8");
+        Ok(match discriminator {
+            ADD_LIQUIDITY => Self::AddLiquidity(AddLiquidityInstruction::try_from_slice(payload)?),
+            ADD_LIQUIDITY2 => Self::AddLiquidity2(AddLiquidity2Instruction::try_from_slice(payload)?),
+            ADD_LIQUIDITY_BY_STRATEGY => Self::AddLiquidityByStrategy(AddLiquidityByStrategyInstruction::try_from_slice(payload)?),
+            ADD_LIQUIDITY_BY_STRATEGY2 => Self::AddLiquidityByStrategy2(AddLiquidityByStrategy2Instruction::try_from_slice(payload)?),
+            ADD_LIQUIDITY_BY_STRATEGY_ONE_SIDE => Self::AddLiquidityByStrategyOneSide(AddLiquidityByStrategyOneSideInstruction::try_from_slice(payload)?),
+            ADD_LIQUIDITY_BY_WEIGHT => Self::AddLiquidityByWeight(AddLiquidityByWeightInstruction::try_from_slice(payload)?),
+            ADD_LIQUIDITY_ONE_SIDE => Self::AddLiquidityOneSide(AddLiquidityOneSideInstruction::try_from_slice(payload)?),
+            ADD_LIQUIDITY_ONE_SIDE_PRECISE => Self::AddLiquidityOneSidePrecise(AddLiquidityOneSidePreciseInstruction::try_from_slice(payload)?),
+            ADD_LIQUIDITY_ONE_SIDE_PRECISE2 => Self::AddLiquidityOneSidePrecise2(AddLiquidityOneSidePrecise2Instruction::try_from_slice(payload)?),
+            CLAIM_FEE => Self::ClaimFee,
+            CLAIM_FEE2 => Self::ClaimFee2(ClaimFee2Instruction::try_from_slice(payload)?),
+            CLAIM_REWARD => Self::ClaimReward(ClaimRewardInstruction::try_from_slice(payload)?),
+            CLAIM_REWARD2 => Self::ClaimReward2(ClaimReward2Instruction::try_from_slice(payload)?),
+            CLOSE_CLAIM_PROTOCOL_FEE_OPERATOR => Self::CloseClaimProtocolFeeOperator,
+            CLOSE_POSITION => Self::ClosePosition,
+            CLOSE_POSITION2 => Self::ClosePosition2,
+            CLOSE_POSITION_IF_EMPTY => Self::ClosePositionIfEmpty,
+            CLOSE_PRESET_PARAMETER => Self::ClosePresetParameter,
+            CLOSE_PRESET_PARAMETER2 => Self::ClosePresetParameter2,
+            CREATE_CLAIM_PROTOCOL_FEE_OPERATOR => Self::CreateClaimProtocolFeeOperator,
+            DECREASE_POSITION_LENGTH => Self::DecreasePositionLength(DecreasePositionLengthInstruction::try_from_slice(payload)?),
+            FOR_IDL_TYPE_GENERATION_DO_NOT_CALL => Self::ForIdlTypeGenerationDoNotCall(ForIdlTypeGenerationDoNotCallInstruction::try_from_slice(payload)?),
+            FUND_REWARD => Self::FundReward(FundRewardInstruction::try_from_slice(payload)?),
+            GO_TO_A_BIN => Self::GoToABin(GoToABinInstruction::try_from_slice(payload)?),
+            INCREASE_ORACLE_LENGTH => Self::IncreaseOracleLength(IncreaseOracleLengthInstruction::try_from_slice(payload)?),
+            INCREASE_POSITION_LENGTH => Self::IncreasePositionLength(IncreasePositionLengthInstruction::try_from_slice(payload)?),
+            INITIALIZE_BIN_ARRAY => Self::InitializeBinArray(InitializeBinArrayInstruction::try_from_slice(payload)?),
+            INITIALIZE_BIN_ARRAY_BITMAP_EXTENSION => Self::InitializeBinArrayBitmapExtension,
+            INITIALIZE_CUSTOMIZABLE_PERMISSIONLESS_LB_PAIR => {
+                Self::InitializeCustomizablePermissionlessLbPair(InitializeCustomizablePermissionlessLbPairInstruction::try_from_slice(payload)?)
+            }
+            INITIALIZE_CUSTOMIZABLE_PERMISSIONLESS_LB_PAIR2 => {
+                Self::InitializeCustomizablePermissionlessLbPair2(InitializeCustomizablePermissionlessLbPair2Instruction::try_from_slice(payload)?)
+            }
+            INITIALIZE_LB_PAIR => Self::InitializeLbPair(InitializeLbPairInstruction::try_from_slice(payload)?),
+            INITIALIZE_LB_PAIR2 => Self::InitializeLbPair2(InitializeLbPair2Instruction::try_from_slice(payload)?),
+            INITIALIZE_PERMISSION_LB_PAIR => Self::InitializePermissionLbPair(InitializePermissionLbPairInstruction::try_from_slice(payload)?),
+            INITIALIZE_POSITION => Self::InitializePosition(InitializePositionInstruction::try_from_slice(payload)?),
+            INITIALIZE_POSITION_BY_OPERATOR => Self::InitializePositionByOperator(InitializePositionByOperatorInstruction::try_from_slice(payload)?),
+            INITIALIZE_POSITION_PDA => Self::InitializePositionPda(InitializePositionPdaInstruction::try_from_slice(payload)?),
+            INITIALIZE_PRESET_PARAMETER => Self::InitializePresetParameter(InitializePresetParameterInstruction::try_from_slice(payload)?),
+            INITIALIZE_PRESET_PARAMETER2 => Self::InitializePresetParameter2(InitializePresetParameter2Instruction::try_from_slice(payload)?),
+            INITIALIZE_REWARD => Self::InitializeReward(InitializeRewardInstruction::try_from_slice(payload)?),
+            INITIALIZE_TOKEN_BADGE => Self::InitializeTokenBadge,
+            MIGRATE_BIN_ARRAY => Self::MigrateBinArray,
+            MIGRATE_POSITION => Self::MigratePosition,
+            REBALANCE_LIQUIDITY => Self::RebalanceLiquidity(RebalanceLiquidityInstruction::try_from_slice(payload)?),
+            REMOVE_ALL_LIQUIDITY => Self::RemoveAllLiquidity,
+            REMOVE_LIQUIDITY => Self::RemoveLiquidity(RemoveLiquidityInstruction::try_from_slice(payload)?),
+            REMOVE_LIQUIDITY2 => Self::RemoveLiquidity2(RemoveLiquidity2Instruction::try_from_slice(payload)?),
+            REMOVE_LIQUIDITY_BY_RANGE => Self::RemoveLiquidityByRange(RemoveLiquidityByRangeInstruction::try_from_slice(payload)?),
+            REMOVE_LIQUIDITY_BY_RANGE2 => Self::RemoveLiquidityByRange2(RemoveLiquidityByRange2Instruction::try_from_slice(payload)?),
+            SET_ACTIVATION_POINT => Self::SetActivationPoint(SetActivationPointInstruction::try_from_slice(payload)?),
+            SET_PAIR_STATUS => Self::SetPairStatus(SetPairStatusInstruction::try_from_slice(payload)?),
+            SET_PAIR_STATUS_PERMISSIONLESS => Self::SetPairStatusPermissionless(SetPairStatusPermissionlessInstruction::try_from_slice(payload)?),
+            SET_PRE_ACTIVATION_DURATION => Self::SetPreActivationDuration(SetPreActivationDurationInstruction::try_from_slice(payload)?),
+            SET_PRE_ACTIVATION_SWAP_ADDRESS => Self::SetPreActivationSwapAddress(SetPreActivationSwapAddressInstruction::try_from_slice(payload)?),
+            SWAP => Self::Swap(SwapInstruction::try_from_slice(payload)?),
+            SWAP2 => Self::Swap2(Swap2Instruction::try_from_slice(payload)?),
+            SWAP_EXACT_OUT => Self::SwapExactOut(SwapExactOutInstruction::try_from_slice(payload)?),
+            SWAP_EXACT_OUT2 => Self::SwapExactOut2(SwapExactOut2Instruction::try_from_slice(payload)?),
+            SWAP_WITH_PRICE_IMPACT => Self::SwapWithPriceImpact(SwapWithPriceImpactInstruction::try_from_slice(payload)?),
+            SWAP_WITH_PRICE_IMPACT2 => Self::SwapWithPriceImpact2(SwapWithPriceImpact2Instruction::try_from_slice(payload)?),
+            UPDATE_BASE_FEE_PARAMETERS => Self::UpdateBaseFeeParameters(UpdateBaseFeeParametersInstruction::try_from_slice(payload)?),
+            UPDATE_DYNAMIC_FEE_PARAMETERS => Self::UpdateDynamicFeeParameters(UpdateDynamicFeeParametersInstruction::try_from_slice(payload)?),
+            UPDATE_FEES_AND_REWARD2 => Self::UpdateFeesAndReward2(UpdateFeesAndReward2Instruction::try_from_slice(payload)?),
+            UPDATE_FEES_AND_REWARDS => Self::UpdateFeesAndRewards,
+            UPDATE_POSITION_OPERATOR => Self::UpdatePositionOperator(UpdatePositionOperatorInstruction::try_from_slice(payload)?),
+            UPDATE_REWARD_DURATION => Self::UpdateRewardDuration(UpdateRewardDurationInstruction::try_from_slice(payload)?),
+            UPDATE_REWARD_FUNDER => Self::UpdateRewardFunder(UpdateRewardFunderInstruction::try_from_slice(payload)?),
+            WITHDRAW_INELIGIBLE_REWARD => Self::WithdrawIneligibleReward(WithdrawIneligibleRewardInstruction::try_from_slice(payload)?),
+            WITHDRAW_PROTOCOL_FEE => Self::WithdrawProtocolFee(WithdrawProtocolFeeInstruction::try_from_slice(payload)?),
+            other => return Err(ParseError::Unknown(other)),
+        })
+    }
+}
+
+pub fn unpack(data: &[u8]) -> Result<MeteoraDllmInstruction, ParseError> {
+    MeteoraDllmInstruction::try_from(data)
+}


### PR DESCRIPTION
## Summary
- add account parsing for Meteora DLMM program
- add instruction and event decoding based on program IDL

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_68b49bcc9d40832882b8a706f3be03f1