### PR TITLE
refactor: centralize account helpers

### DIFF
--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -1,0 +1,60 @@
+use solana_program::pubkey::Pubkey;
+use thiserror::Error;
+
+// -----------------------------------------------------------------------------
+// Error type shared across account parsers
+// -----------------------------------------------------------------------------
+#[derive(Debug, Error)]
+pub enum AccountsError {
+    #[error("missing required account `{name}` at index {index}")]
+    Missing { name: &'static str, index: usize },
+    #[error("invalid key length for `{name}` at index {index}: got {got}, want 32")]
+    InvalidLen { name: &'static str, index: usize, got: usize },
+}
+
+#[inline]
+pub fn to_pubkey(name: &'static str, index: usize, bytes: &[u8]) -> Result<Pubkey, AccountsError> {
+    let arr: [u8; 32] = bytes
+        .try_into()
+        .map_err(|_| AccountsError::InvalidLen { name, index, got: bytes.len() })?;
+    Ok(Pubkey::new_from_array(arr))
+}
+
+// -----------------------------------------------------------------------------
+// Helper macro for required-only account structs
+// -----------------------------------------------------------------------------
+#[macro_export]
+macro_rules! accounts {
+    ($name:ident, $getter:ident, { $( $(#[$doc:meta])* $field:ident ),+ $(,)? }) => {
+        #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+        pub struct $name {
+            $( $(#[$doc])* pub $field: Pubkey,)+
+        }
+
+        impl<'ix> TryFrom<&InstructionView<'ix>> for $name {
+            type Error = $crate::accounts::AccountsError;
+            fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+                let accounts = ix.accounts();
+                let mut idx = 0;
+                $(
+                    let $field = {
+                        let name = stringify!($field);
+                        let a = accounts
+                            .get(idx)
+                            .ok_or($crate::accounts::AccountsError::Missing { name, index: idx })?;
+                        let pk = $crate::accounts::to_pubkey(name, idx, &a.0)?;
+                        idx += 1;
+                        pk
+                    };
+                )+
+                let _ = idx;
+                Ok(Self { $($field,)+ })
+            }
+        }
+
+        pub fn $getter(ix: &InstructionView) -> Result<$name, $crate::accounts::AccountsError> {
+            $name::try_from(ix)
+        }
+    };
+}
+

--- a/src/bonkswap/accounts.rs
+++ b/src/bonkswap/accounts.rs
@@ -2,64 +2,8 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 use substreams_solana::block_view::InstructionView;
-use thiserror::Error;
 
-// -----------------------------------------------------------------------------
-// Error type
-// -----------------------------------------------------------------------------
-#[derive(Debug, Error)]
-pub enum AccountsError {
-    #[error("missing required account `{name}` at index {index}")]
-    Missing { name: &'static str, index: usize },
-    #[error("invalid key length for `{name}` at index {index}: got {got}, want 32")]
-    InvalidLen { name: &'static str, index: usize, got: usize },
-}
-
-#[inline]
-fn to_pubkey(name: &'static str, index: usize, bytes: &[u8]) -> Result<Pubkey, AccountsError> {
-    let arr: [u8; 32] = bytes
-        .try_into()
-        .map_err(|_| AccountsError::InvalidLen { name, index, got: bytes.len() })?;
-    Ok(Pubkey::new_from_array(arr))
-}
-
-// -----------------------------------------------------------------------------
-// Helper macro for required-only account structs
-// -----------------------------------------------------------------------------
-macro_rules! accounts {
-    ($name:ident, $getter:ident, { $($field:ident),+ $(,)? }) => {
-        #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
-        pub struct $name {
-            $(pub $field: Pubkey,)+
-        }
-
-        impl<'ix> TryFrom<&InstructionView<'ix>> for $name {
-            type Error = AccountsError;
-
-            fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
-                let accounts = ix.accounts();
-                let mut idx = 0;
-                $(
-                    let $field = {
-                        let name = stringify!($field);
-                        let a = accounts
-                            .get(idx)
-                            .ok_or(AccountsError::Missing { name, index: idx })?;
-                        let pk = to_pubkey(name, idx, &a.0)?;
-                        idx += 1;
-                        pk
-                    };
-                )+
-                let _ = idx;
-                Ok(Self { $($field,)+ })
-            }
-        }
-
-        pub fn $getter(ix: &InstructionView) -> Result<$name, AccountsError> {
-            $name::try_from(ix)
-        }
-    };
-}
+use crate::accounts::{self as _, AccountsError};
 
 // -----------------------------------------------------------------------------
 // Swap accounts (with optional referrer)
@@ -112,7 +56,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for SwapAccounts {
 
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
 
         let get_opt = |index: usize| -> Option<Pubkey> {

--- a/src/jupiter/v4/accounts.rs
+++ b/src/jupiter/v4/accounts.rs
@@ -2,61 +2,8 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 use substreams_solana::block_view::InstructionView;
-use thiserror::Error;
 
-// -----------------------------------------------------------------------------
-// Error type
-// -----------------------------------------------------------------------------
-#[derive(Debug, Error)]
-pub enum AccountsError {
-    #[error("missing required account `{name}` at index {index}")]
-    Missing { name: &'static str, index: usize },
-    #[error("invalid key length for `{name}` at index {index}: got {got}, want 32")]
-    InvalidLen { name: &'static str, index: usize, got: usize },
-}
-
-#[inline]
-fn to_pubkey(name: &'static str, index: usize, bytes: &[u8]) -> Result<Pubkey, AccountsError> {
-    let arr: [u8; 32] = bytes.try_into().map_err(|_| AccountsError::InvalidLen { name, index, got: bytes.len() })?;
-    Ok(Pubkey::new_from_array(arr))
-}
-
-// -----------------------------------------------------------------------------
-// Helper macro for required-only account structs
-// -----------------------------------------------------------------------------
-macro_rules! accounts {
-    ($name:ident, $getter:ident, { $( $(#[$doc:meta])* $field:ident ),+ $(,)? }) => {
-        #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
-        pub struct $name {
-            $( $(#[$doc])* pub $field: Pubkey,)+
-        }
-
-        impl<'ix> TryFrom<&InstructionView<'ix>> for $name {
-            type Error = AccountsError;
-            fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
-                let accounts = ix.accounts();
-                let mut idx = 0;
-                $(
-                    let $field = {
-                        let name = stringify!($field);
-                        let a = accounts
-                            .get(idx)
-                            .ok_or(AccountsError::Missing { name, index: idx })?;
-                        let pk = to_pubkey(name, idx, &a.0)?;
-                        idx += 1;
-                        pk
-                    };
-                )+
-                let _ = idx;
-                Ok(Self { $($field,)+ })
-            }
-        }
-
-        pub fn $getter(ix: &InstructionView) -> Result<$name, AccountsError> {
-            $name::try_from(ix)
-        }
-    };
-}
+use crate::accounts;
 
 // -----------------------------------------------------------------------------
 // Route

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 #![allow(deprecated)]
+#[macro_use]
+pub mod accounts;
 pub mod bonkswap;
 pub mod jupiter;
 pub mod orca;

--- a/src/meteora/amm/accounts.rs
+++ b/src/meteora/amm/accounts.rs
@@ -2,24 +2,8 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 use substreams_solana::block_view::InstructionView;
-use thiserror::Error;
 
-// -----------------------------------------------------------------------------
-// Error type
-// -----------------------------------------------------------------------------
-#[derive(Debug, Error)]
-pub enum AccountsError {
-    #[error("missing required account `{name}` at index {index}")]
-    Missing { name: &"static str, index: usize },
-    #[error("invalid key length for `{name}` at index {index}: got {got}, want 32")]
-    InvalidLen { name: &"static str, index: usize, got: usize },
-}
-
-#[inline]
-fn to_pubkey(name: &"static str, index: usize, bytes: &[u8]) -> Result<Pubkey, AccountsError> {
-    let arr: [u8; 32] = bytes.try_into().map_err(|_| AccountsError::InvalidLen { name, index, got: bytes.len() })?;
-    Ok(Pubkey::new_from_array(arr))
-}
+use crate::accounts::{self as _, AccountsError};
 
 // -----------------------------------------------------------------------------
 // Accounts structs
@@ -81,7 +65,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for InitializePermissionedPoolAccounts 
         let accounts = ix.accounts();
         let get = |index: usize, name: &"static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(Self {
             pool: get(0, "pool")?,
@@ -175,7 +159,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for InitializePermissionlessPoolAccount
         let accounts = ix.accounts();
         let get = |index: usize, name: &"static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(Self {
             pool: get(0, "pool")?,
@@ -271,7 +255,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for InitializePermissionlessPoolWithFee
         let accounts = ix.accounts();
         let get = |index: usize, name: &"static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(Self {
             pool: get(0, "pool")?,
@@ -323,7 +307,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for EnableOrDisablePoolAccounts {
         let accounts = ix.accounts();
         let get = |index: usize, name: &"static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(Self {
             pool: get(0, "pool")?,
@@ -377,7 +361,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for SwapAccounts {
         let accounts = ix.accounts();
         let get = |index: usize, name: &"static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(Self {
             pool: get(0, "pool")?,
@@ -444,7 +428,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for RemoveLiquiditySingleSideAccounts {
         let accounts = ix.accounts();
         let get = |index: usize, name: &"static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(Self {
             pool: get(0, "pool")?,
@@ -513,7 +497,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for AddImbalanceLiquidityAccounts {
         let accounts = ix.accounts();
         let get = |index: usize, name: &"static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(Self {
             pool: get(0, "pool")?,
@@ -583,7 +567,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for RemoveBalanceLiquidityAccounts {
         let accounts = ix.accounts();
         let get = |index: usize, name: &"static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(Self {
             pool: get(0, "pool")?,
@@ -653,7 +637,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for AddBalanceLiquidityAccounts {
         let accounts = ix.accounts();
         let get = |index: usize, name: &"static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(Self {
             pool: get(0, "pool")?,
@@ -695,7 +679,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for SetPoolFeesAccounts {
         let accounts = ix.accounts();
         let get = |index: usize, name: &"static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(Self {
             pool: get(0, "pool")?,
@@ -724,7 +708,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for OverrideCurveParamAccounts {
         let accounts = ix.accounts();
         let get = |index: usize, name: &"static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(Self {
             pool: get(0, "pool")?,
@@ -764,7 +748,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for GetPoolInfoAccounts {
         let accounts = ix.accounts();
         let get = |index: usize, name: &"static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(Self {
             pool: get(0, "pool")?,
@@ -826,7 +810,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for BootstrapLiquidityAccounts {
         let accounts = ix.accounts();
         let get = |index: usize, name: &"static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(Self {
             pool: get(0, "pool")?,
@@ -876,7 +860,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for CreateMintMetadataAccounts {
         let accounts = ix.accounts();
         let get = |index: usize, name: &"static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(Self {
             pool: get(0, "pool")?,
@@ -916,7 +900,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for CreateLockEscrowAccounts {
         let accounts = ix.accounts();
         let get = |index: usize, name: &"static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(Self {
             pool: get(0, "pool")?,
@@ -970,7 +954,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for LockAccounts {
         let accounts = ix.accounts();
         let get = |index: usize, name: &"static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(Self {
             pool: get(0, "pool")?,
@@ -1041,7 +1025,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for ClaimFeeAccounts {
         let accounts = ix.accounts();
         let get = |index: usize, name: &"static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(Self {
             pool: get(0, "pool")?,
@@ -1084,7 +1068,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for CreateConfigAccounts {
         let accounts = ix.accounts();
         let get = |index: usize, name: &"static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(Self {
             config: get(0, "config")?,
@@ -1112,7 +1096,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for CloseConfigAccounts {
         let accounts = ix.accounts();
         let get = |index: usize, name: &"static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(Self {
             config: get(0, "config")?,
@@ -1185,7 +1169,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for InitializePermissionlessConstantPro
         let accounts = ix.accounts();
         let get = |index: usize, name: &"static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(Self {
             pool: get(0, "pool")?,
@@ -1281,7 +1265,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for InitializePermissionlessConstantPro
         let accounts = ix.accounts();
         let get = |index: usize, name: &"static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(Self {
             pool: get(0, "pool")?,
@@ -1376,7 +1360,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for InitializeCustomizablePermissionles
         let accounts = ix.accounts();
         let get = |index: usize, name: &"static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(Self {
             pool: get(0, "pool")?,
@@ -1427,7 +1411,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for UpdateActivationPointAccounts {
         let accounts = ix.accounts();
         let get = |index: usize, name: &"static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(Self {
             pool: get(0, "pool")?,
@@ -1459,7 +1443,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for WithdrawProtocolFeesAccounts {
         let accounts = ix.accounts();
         let get = |index: usize, name: &"static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(Self {
             pool: get(0, "pool")?,
@@ -1490,7 +1474,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for SetWhitelistedVaultAccounts {
         let accounts = ix.accounts();
         let get = |index: usize, name: &"static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(Self {
             pool: get(0, "pool")?,
@@ -1523,7 +1507,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for PartnerClaimFeeAccounts {
         let accounts = ix.accounts();
         let get = |index: usize, name: &"static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(Self {
             pool: get(0, "pool")?,

--- a/src/meteora/daam/accounts.rs
+++ b/src/meteora/daam/accounts.rs
@@ -2,26 +2,8 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 use substreams_solana::block_view::InstructionView;
-use thiserror::Error;
 
-// -----------------------------------------------------------------------------
-// Error type
-// -----------------------------------------------------------------------------
-#[derive(Debug, Error)]
-pub enum AccountsError {
-    #[error("missing required account `{name}` at index {index}")]
-    Missing { name: &'static str, index: usize },
-    #[error("invalid key length for `{name}` at index {index}: got {got}, want 32")]
-    InvalidLen { name: &'static str, index: usize, got: usize },
-}
-
-#[inline]
-fn to_pubkey(name: &'static str, index: usize, bytes: &[u8]) -> Result<Pubkey, AccountsError> {
-    let arr: [u8; 32] = bytes
-        .try_into()
-        .map_err(|_| AccountsError::InvalidLen { name, index, got: bytes.len() })?;
-    Ok(Pubkey::new_from_array(arr))
-}
+use crate::accounts::{self as _, AccountsError};
 
 // -----------------------------------------------------------------------------
 // AddLiquidity accounts
@@ -76,7 +58,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for AddLiquidityAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         let get_opt = |index: usize| -> Option<Pubkey> {
             accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array)
@@ -153,7 +135,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for ClaimPartnerFeeAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         let get_opt = |index: usize| -> Option<Pubkey> {
             accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array)
@@ -235,7 +217,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for ClaimPositionFeeAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         let get_opt = |index: usize| -> Option<Pubkey> {
             accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array)
@@ -317,7 +299,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for ClaimProtocolFeeAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         let get_opt = |index: usize| -> Option<Pubkey> {
             accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array)
@@ -385,7 +367,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for ClaimRewardAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         let get_opt = |index: usize| -> Option<Pubkey> {
             accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array)
@@ -435,7 +417,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for CloseClaimFeeOperatorAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         let get_opt = |index: usize| -> Option<Pubkey> {
             accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array)
@@ -479,7 +461,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for CloseConfigAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         let get_opt = |index: usize| -> Option<Pubkey> {
             accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array)
@@ -537,7 +519,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for ClosePositionAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         let get_opt = |index: usize| -> Option<Pubkey> {
             accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array)
@@ -586,7 +568,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for CloseTokenBadgeAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         let get_opt = |index: usize| -> Option<Pubkey> {
             accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array)
@@ -632,7 +614,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for CreateClaimFeeOperatorAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         let get_opt = |index: usize| -> Option<Pubkey> {
             accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array)
@@ -677,7 +659,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for CreateConfigAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         let get_opt = |index: usize| -> Option<Pubkey> {
             accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array)
@@ -721,7 +703,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for CreateDynamicConfigAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         let get_opt = |index: usize| -> Option<Pubkey> {
             accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array)
@@ -781,7 +763,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for CreatePositionAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         let get_opt = |index: usize| -> Option<Pubkey> {
             accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array)
@@ -833,7 +815,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for CreateTokenBadgeAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         let get_opt = |index: usize| -> Option<Pubkey> {
             accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array)
@@ -884,7 +866,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for FundRewardAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         let get_opt = |index: usize| -> Option<Pubkey> {
             accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array)
@@ -972,7 +954,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for InitializeCustomizablePoolAccounts 
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         let get_opt = |index: usize| -> Option<Pubkey> {
             accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array)
@@ -1074,7 +1056,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for InitializePoolAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         let get_opt = |index: usize| -> Option<Pubkey> {
             accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array)
@@ -1179,7 +1161,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for InitializePoolWithDynamicConfigAcco
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         let get_opt = |index: usize| -> Option<Pubkey> {
             accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array)
@@ -1249,7 +1231,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for InitializeRewardAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         let get_opt = |index: usize| -> Option<Pubkey> {
             accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array)
@@ -1308,7 +1290,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for LockPositionAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         let get_opt = |index: usize| -> Option<Pubkey> {
             accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array)
@@ -1360,7 +1342,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for PermanentLockPositionAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         let get_opt = |index: usize| -> Option<Pubkey> {
             accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array)
@@ -1404,7 +1386,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for RefreshVestingAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         let get_opt = |index: usize| -> Option<Pubkey> {
             accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array)
@@ -1477,7 +1459,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for RemoveAllLiquidityAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         let get_opt = |index: usize| -> Option<Pubkey> {
             accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array)
@@ -1561,7 +1543,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for RemoveLiquidityAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         let get_opt = |index: usize| -> Option<Pubkey> {
             accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array)
@@ -1613,7 +1595,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for SetPoolStatusAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         let get_opt = |index: usize| -> Option<Pubkey> {
             accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array)
@@ -1670,7 +1652,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for SplitPositionAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         let get_opt = |index: usize| -> Option<Pubkey> {
             accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array)
@@ -1747,7 +1729,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for SwapAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         let get_opt = |index: usize| -> Option<Pubkey> {
             accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array)
@@ -1798,7 +1780,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for UpdateRewardDurationAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         let get_opt = |index: usize| -> Option<Pubkey> {
             accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array)
@@ -1839,7 +1821,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for UpdateRewardFunderAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         let get_opt = |index: usize| -> Option<Pubkey> {
             accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array)
@@ -1890,7 +1872,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for WithdrawIneligibleRewardAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         let get_opt = |index: usize| -> Option<Pubkey> {
             accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array)

--- a/src/orca/whirlpool/accounts.rs
+++ b/src/orca/whirlpool/accounts.rs
@@ -2,42 +2,8 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 use substreams_solana::block_view::InstructionView;
-use thiserror::Error;
 
-#[derive(Debug, Error)]
-pub enum AccountsError {
-    #[error("missing required account `{name}` at index {index}")]
-    Missing { name: &'static str, index: usize },
-    #[error("invalid key length for `{name}` at index {index}: got {got}, want 32")]
-    InvalidLen { name: &'static str, index: usize, got: usize },
-}
-
-fn to_pubkey(name: &'static str, index: usize, bytes: &[u8]) -> Result<Pubkey, AccountsError> {
-    let arr: [u8; 32] = bytes.try_into().map_err(|_| AccountsError::InvalidLen { name, index, got: bytes.len() })?;
-    Ok(Pubkey::new_from_array(arr))
-}
-
-macro_rules! accounts {
-    ($name:ident, $getter:ident, { $($field:ident),+ $(,)? }) => {
-        #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
-        pub struct $name {
-            $(pub $field: Pubkey,)+
-        }
-        impl<'ix> TryFrom<&InstructionView<'ix>> for $name {
-            type Error = AccountsError;
-            fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
-                let accounts = ix.accounts();
-                let mut idx = 0;
-                $(let $field = { let name = stringify!($field); let a = accounts.get(idx).ok_or(AccountsError::Missing { name, index: idx })?; let pk = to_pubkey(name, idx, &a.0)?; idx += 1; pk };)+
-                let _ = idx;
-                Ok(Self { $($field,)+ })
-            }
-        }
-        pub fn $getter(ix: &InstructionView) -> Result<$name, AccountsError> {
-            $name::try_from(ix)
-        }
-    };
-}
+use crate::accounts;
 
 accounts!(
     InitializeConfigAccounts,

--- a/src/raydium/clmm/v3/accounts.rs
+++ b/src/raydium/clmm/v3/accounts.rs
@@ -2,24 +2,8 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 use substreams_solana::block_view::InstructionView;
-use thiserror::Error;
 
-// -----------------------------------------------------------------------------
-// Error type
-// -----------------------------------------------------------------------------
-#[derive(Debug, Error)]
-pub enum AccountsError {
-    #[error("missing required account `{name}` at index {index}")]
-    Missing { name: &'static str, index: usize },
-    #[error("invalid key length for `{name}` at index {index}: got {got}, want 32")]
-    InvalidLen { name: &'static str, index: usize, got: usize },
-}
-
-#[inline]
-fn to_pubkey(name: &'static str, index: usize, bytes: &[u8]) -> Result<Pubkey, AccountsError> {
-    let arr: [u8; 32] = bytes.try_into().map_err(|_| AccountsError::InvalidLen { name, index, got: bytes.len() })?;
-    Ok(Pubkey::new_from_array(arr))
-}
+use crate::accounts::{self as _, AccountsError};
 
 /// Accounts for the `close_position` instruction.
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
@@ -44,7 +28,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for ClosePositionAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(ClosePositionAccounts {
             nft_owner: get_req(0, "nft_owner")?,
@@ -95,7 +79,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for CollectFundFeeAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(CollectFundFeeAccounts {
             owner: get_req(0, "owner")?,
@@ -151,7 +135,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for CollectProtocolFeeAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(CollectProtocolFeeAccounts {
             owner: get_req(0, "owner")?,
@@ -200,7 +184,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for CollectRemainingRewardsAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(CollectRemainingRewardsAccounts {
             reward_funder: get_req(0, "reward_funder")?,
@@ -236,7 +220,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for CreateAmmConfigAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(CreateAmmConfigAccounts {
             owner: get_req(0, "owner")?,
@@ -267,7 +251,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for CreateOperationAccountAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(CreateOperationAccountAccounts {
             owner: get_req(0, "owner")?,
@@ -319,7 +303,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for CreatePoolAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(CreatePoolAccounts {
             pool_creator: get_req(0, "pool_creator")?,
@@ -362,7 +346,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for CreateSupportMintAssociatedAccounts
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(CreateSupportMintAssociatedAccounts {
             owner: get_req(0, "owner")?,
@@ -411,7 +395,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for DecreaseLiquidityAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(DecreaseLiquidityAccounts {
             nft_owner: get_req(0, "nft_owner")?,
@@ -476,7 +460,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for DecreaseLiquidityV2Accounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(DecreaseLiquidityV2Accounts {
             nft_owner: get_req(0, "nft_owner")?,
@@ -537,7 +521,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for IncreaseLiquidityAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(IncreaseLiquidityAccounts {
             nft_owner: get_req(0, "nft_owner")?,
@@ -600,7 +584,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for IncreaseLiquidityV2Accounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(IncreaseLiquidityV2Accounts {
             nft_owner: get_req(0, "nft_owner")?,
@@ -654,7 +638,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for InitializeRewardAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(InitializeRewardAccounts {
             reward_funder: get_req(0, "reward_funder")?,
@@ -723,7 +707,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for OpenPositionAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(OpenPositionAccounts {
             payer: get_req(0, "payer")?,
@@ -806,7 +790,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for OpenPositionV2Accounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(OpenPositionV2Accounts {
             payer: get_req(0, "payer")?,
@@ -887,7 +871,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for OpenPositionWithToken22NftAccounts 
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(OpenPositionWithToken22NftAccounts {
             payer: get_req(0, "payer")?,
@@ -940,7 +924,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for SetRewardParamsAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(SetRewardParamsAccounts {
             authority: get_req(0, "authority")?,
@@ -988,7 +972,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for SwapAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(SwapAccounts {
             payer: get_req(0, "payer")?,
@@ -1033,7 +1017,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for SwapRouterBaseInAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(SwapRouterBaseInAccounts {
             payer: get_req(0, "payer")?,
@@ -1088,7 +1072,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for SwapV2Accounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(SwapV2Accounts {
             payer: get_req(0, "payer")?,
@@ -1127,7 +1111,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for TransferRewardOwnerAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(TransferRewardOwnerAccounts {
             authority: get_req(0, "authority")?,
@@ -1156,7 +1140,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for UpdateAmmConfigAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(UpdateAmmConfigAccounts {
             owner: get_req(0, "owner")?,
@@ -1186,7 +1170,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for UpdateOperationAccountAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(UpdateOperationAccountAccounts {
             owner: get_req(0, "owner")?,
@@ -1214,7 +1198,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for UpdatePoolStatusAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(UpdatePoolStatusAccounts {
             authority: get_req(0, "authority")?,
@@ -1241,7 +1225,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for UpdateRewardInfosAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(UpdateRewardInfosAccounts {
             pool_state: get_req(0, "pool_state")?,

--- a/src/raydium/cpmm/accounts.rs
+++ b/src/raydium/cpmm/accounts.rs
@@ -2,24 +2,8 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 use substreams_solana::block_view::InstructionView;
-use thiserror::Error;
 
-// -----------------------------------------------------------------------------
-// Error type
-// -----------------------------------------------------------------------------
-#[derive(Debug, Error)]
-pub enum AccountsError {
-    #[error("missing required account `{name}` at index {index}")]
-    Missing { name: &'static str, index: usize },
-    #[error("invalid key length for `{name}` at index {index}: got {got}, want 32")]
-    InvalidLen { name: &'static str, index: usize, got: usize },
-}
-
-#[inline]
-fn to_pubkey(name: &'static str, index: usize, bytes: &[u8]) -> Result<Pubkey, AccountsError> {
-    let arr: [u8; 32] = bytes.try_into().map_err(|_| AccountsError::InvalidLen { name, index, got: bytes.len() })?;
-    Ok(Pubkey::new_from_array(arr))
-}
+use crate::accounts::{self as _, AccountsError};
 
 /// Accounts for the `close_permission_pda` instruction.
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
@@ -38,7 +22,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for ClosePermissionPdaAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(ClosePermissionPdaAccounts {
             owner: get_req(0, "owner")?,
@@ -92,7 +76,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for CollectCreatorFeeAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(CollectCreatorFeeAccounts {
             creator: get_req(0, "creator")?,
@@ -152,7 +136,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for CollectFundFeeAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(CollectFundFeeAccounts {
             owner: get_req(0, "owner")?,
@@ -210,7 +194,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for CollectProtocolFeeAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(CollectProtocolFeeAccounts {
             owner: get_req(0, "owner")?,
@@ -250,7 +234,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for CreateAmmConfigAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(CreateAmmConfigAccounts {
             owner: get_req(0, "owner")?,
@@ -281,7 +265,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for CreatePermissionPdaAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(CreatePermissionPdaAccounts {
             owner: get_req(0, "owner")?,
@@ -332,7 +316,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for DepositAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(DepositAccounts {
             owner: get_req(0, "owner")?,
@@ -414,7 +398,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for InitializeAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(InitializeAccounts {
             creator: get_req(0, "creator")?,
@@ -503,7 +487,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for InitializeWithPermissionAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(InitializeWithPermissionAccounts {
             payer: get_req(0, "payer")?,
@@ -572,7 +556,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for SwapBaseInputAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(SwapBaseInputAccounts {
             payer: get_req(0, "payer")?,
@@ -633,7 +617,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for SwapBaseOutputAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(SwapBaseOutputAccounts {
             payer: get_req(0, "payer")?,
@@ -673,7 +657,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for UpdateAmmConfigAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(UpdateAmmConfigAccounts {
             owner: get_req(0, "owner")?,
@@ -700,7 +684,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for UpdatePoolStatusAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(UpdatePoolStatusAccounts {
             authority: get_req(0, "authority")?,
@@ -752,7 +736,7 @@ impl<'ix> TryFrom<&InstructionView<'ix>> for WithdrawAccounts {
         let accounts = ix.accounts();
         let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
             let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
-            to_pubkey(name, index, &a.0)
+            crate::accounts::to_pubkey(name, index, &a.0)
         };
         Ok(WithdrawAccounts {
             owner: get_req(0, "owner")?,

--- a/src/raydium/launchpad/accounts.rs
+++ b/src/raydium/launchpad/accounts.rs
@@ -2,62 +2,8 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 use substreams_solana::block_view::InstructionView;
-use thiserror::Error;
 
-// -----------------------------------------------------------------------------
-// Error type
-// -----------------------------------------------------------------------------
-#[derive(Debug, Error)]
-pub enum AccountsError {
-    #[error("missing required account `{name}` at index {index}")]
-    Missing { name: &'static str, index: usize },
-    #[error("invalid key length for `{name}` at index {index}: got {got}, want 32")]
-    InvalidLen { name: &'static str, index: usize, got: usize },
-}
-
-#[inline]
-fn to_pubkey(name: &'static str, index: usize, bytes: &[u8]) -> Result<Pubkey, AccountsError> {
-    let arr: [u8; 32] = bytes.try_into().map_err(|_| AccountsError::InvalidLen { name, index, got: bytes.len() })?;
-    Ok(Pubkey::new_from_array(arr))
-}
-
-// -----------------------------------------------------------------------------
-// Helper macro with doc comments
-// -----------------------------------------------------------------------------
-macro_rules! accounts {
-    ($name:ident, $getter:ident, { $( $(#[$meta:meta])* $field:ident ),+ $(,)? }) => {
-        #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
-        pub struct $name {
-            $( $(#[$meta])* pub $field: Pubkey,)+
-        }
-
-        impl<'ix> TryFrom<&InstructionView<'ix>> for $name {
-            type Error = AccountsError;
-
-            fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
-                let accounts = ix.accounts();
-                let mut idx = 0;
-                $(
-                    let $field = {
-                        let name = stringify!($field);
-                        let a = accounts
-                            .get(idx)
-                            .ok_or(AccountsError::Missing { name, index: idx })?;
-                        let pk = to_pubkey(name, idx, &a.0)?;
-                        idx += 1;
-                        pk
-                    };
-                )+
-                let _ = idx;
-                Ok(Self { $( $field, )+ })
-            }
-        }
-
-        pub fn $getter(ix: &InstructionView) -> Result<$name, AccountsError> {
-            $name::try_from(ix)
-        }
-    };
-}
+use crate::accounts;
 
 // -----------------------------------------------------------------------------
 // Buy exact in accounts


### PR DESCRIPTION
## Summary
- extract `AccountsError`, `to_pubkey` and `accounts!` macro into shared `accounts` module
- refactor account files to use shared helpers

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_68b49e39e6dc8328969a0f8843e15f90