### PR TITLE
Implement PumpFun account parsing

### DIFF
--- a/src/pumpfun/amm/accounts.rs
+++ b/src/pumpfun/amm/accounts.rs
@@ -1,0 +1,182 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+use solana_program::pubkey::Pubkey;
+use substreams_solana::block_view::InstructionView;
+
+// -----------------------------------------------------------------------------
+// Account structs
+// -----------------------------------------------------------------------------
+accounts!(
+    BuyAccounts,
+    get_buy_accounts,
+    {
+        pool,
+        user,
+        global_config,
+        base_mint,
+        quote_mint,
+        user_base_token_account,
+        user_quote_token_account,
+        pool_base_token_account,
+        pool_quote_token_account,
+        protocol_fee_recipient,
+        protocol_fee_recipient_token_account,
+        base_token_program,
+        quote_token_program,
+        system_program,
+        associated_token_program,
+        event_authority,
+        program
+    }
+);
+
+accounts!(
+    CreateConfigAccounts,
+    get_create_config_accounts,
+    {
+        admin,
+        global_config,
+        system_program,
+        event_authority,
+        program
+    }
+);
+
+accounts!(
+    CreatePoolAccounts,
+    get_create_pool_accounts,
+    {
+        pool,
+        global_config,
+        creator,
+        base_mint,
+        quote_mint,
+        lp_mint,
+        user_base_token_account,
+        user_quote_token_account,
+        user_pool_token_account,
+        pool_base_token_account,
+        pool_quote_token_account,
+        system_program,
+        token_2022_program,
+        base_token_program,
+        quote_token_program,
+        associated_token_program,
+        event_authority,
+        program
+    }
+);
+
+accounts!(
+    DepositAccounts,
+    get_deposit_accounts,
+    {
+        pool,
+        global_config,
+        user,
+        base_mint,
+        quote_mint,
+        lp_mint,
+        user_base_token_account,
+        user_quote_token_account,
+        user_pool_token_account,
+        pool_base_token_account,
+        pool_quote_token_account,
+        token_program,
+        token_2022_program,
+        event_authority,
+        program
+    }
+);
+
+accounts!(
+    DisableAccounts,
+    get_disable_accounts,
+    {
+        admin,
+        global_config,
+        event_authority,
+        program
+    }
+);
+
+accounts!(
+    ExtendAccountAccounts,
+    get_extend_account_accounts,
+    {
+        account,
+        user,
+        system_program,
+        event_authority,
+        program
+    }
+);
+
+accounts!(
+    SellAccounts,
+    get_sell_accounts,
+    {
+        pool,
+        user,
+        global_config,
+        base_mint,
+        quote_mint,
+        user_base_token_account,
+        user_quote_token_account,
+        pool_base_token_account,
+        pool_quote_token_account,
+        protocol_fee_recipient,
+        protocol_fee_recipient_token_account,
+        base_token_program,
+        quote_token_program,
+        system_program,
+        associated_token_program,
+        event_authority,
+        program
+    }
+);
+
+accounts!(
+    UpdateAdminAccounts,
+    get_update_admin_accounts,
+    {
+        admin,
+        global_config,
+        new_admin,
+        event_authority,
+        program
+    }
+);
+
+accounts!(
+    UpdateFeeConfigAccounts,
+    get_update_fee_config_accounts,
+    {
+        admin,
+        global_config,
+        event_authority,
+        program
+    }
+);
+
+accounts!(
+    WithdrawAccounts,
+    get_withdraw_accounts,
+    {
+        pool,
+        global_config,
+        user,
+        base_mint,
+        quote_mint,
+        lp_mint,
+        user_base_token_account,
+        user_quote_token_account,
+        user_pool_token_account,
+        pool_base_token_account,
+        pool_quote_token_account,
+        token_program,
+        token_2022_program,
+        event_authority,
+        program
+    }
+);

--- a/src/pumpfun/amm/mod.rs
+++ b/src/pumpfun/amm/mod.rs
@@ -1,4 +1,5 @@
 use substreams_solana::b58;
+pub mod accounts;
 pub mod events;
 pub mod instructions;
 pub mod logs;

--- a/src/pumpfun/bonding_curve/accounts.rs
+++ b/src/pumpfun/bonding_curve/accounts.rs
@@ -1,0 +1,102 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+use solana_program::pubkey::Pubkey;
+use substreams_solana::block_view::InstructionView;
+
+// -----------------------------------------------------------------------------
+// Account structs
+// -----------------------------------------------------------------------------
+accounts!(
+    InitializeAccounts,
+    get_initialize_accounts,
+    {
+        global_state,
+        admin,
+        system_program,
+        event_authority,
+        program
+    }
+);
+
+accounts!(
+    SetParamsAccounts,
+    get_set_params_accounts,
+    {
+        curve_config,
+        admin,
+        global_state,
+        event_authority,
+        program
+    }
+);
+
+accounts!(
+    CreateAccounts,
+    get_create_accounts,
+    {
+        mint,
+        mint_authority,
+        curve_config,
+        curve,
+        global_state,
+        metadata_program,
+        metadata,
+        user,
+        system_program,
+        token_program,
+        associated_token_program,
+        rent,
+        event_authority,
+        program
+    }
+);
+
+accounts!(
+    BuyAccounts,
+    get_buy_accounts,
+    {
+        global_state,
+        fee_recipient,
+        mint,
+        curve_config,
+        token_vault,
+        user_state,
+        user,
+        system_program,
+        token_program,
+        creator_vault,
+        event_authority,
+        program
+    }
+);
+
+accounts!(
+    SellAccounts,
+    get_sell_accounts,
+    {
+        global_state,
+        fee_recipient,
+        mint,
+        curve_config,
+        token_vault,
+        user_state,
+        user,
+        system_program,
+        creator_vault,
+        token_program,
+        event_authority,
+        program
+    }
+);
+
+accounts!(
+    WithdrawAccounts,
+    get_withdraw_accounts,
+    {
+        global_state,
+        fee_recipient,
+        system_program,
+        event_authority,
+        program
+    }
+);

--- a/src/pumpfun/bonding_curve/mod.rs
+++ b/src/pumpfun/bonding_curve/mod.rs
@@ -1,4 +1,5 @@
 use substreams_solana::b58;
+pub mod accounts;
 pub mod events;
 pub mod instructions;
 


### PR DESCRIPTION
## Summary
- add account parsers for PumpFun AMM instructions
- add account parsers for PumpFun bonding-curve instructions

## Testing
- `cargo test` *(fails: name `IDX_PROGRAM` is defined multiple times in `src/meteora/daam/accounts.rs`)*

------
https://chatgpt.com/codex/tasks/task_b_68b4b22212988328b07622cae7d14404