### PR TITLE
Fix Raydium CPMM swap event parsing

### DIFF
--- a/src/raydium/cpmm/events.rs
+++ b/src/raydium/cpmm/events.rs
@@ -56,13 +56,8 @@ pub struct SwapEvent {
     pub output_amount: u64,
     pub input_transfer_fee: u64,
     pub output_transfer_fee: u64,
+    /// `true` if the swap was performed with the base token as input.
     pub base_input: bool,
-    pub input_mint: Pubkey,
-    pub output_mint: Pubkey,
-    pub trade_fee: u64,
-    /// Amount of fee tokens going to creator
-    pub creator_fee: u64,
-    pub creator_fee_on_input: bool,
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- align `SwapEvent` struct with on-chain Raydium CPMM log layout to avoid decode errors

## Testing
- `cargo test tests::unpack_cpmm_swap_event -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_b_68c07d087f3c8328a2e9edf51604765f