### PR TITLE
Handle Raydium CPMM swap event versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,12 @@ checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -2032,6 +2038,7 @@ dependencies = [
 name = "substreams-solana-idls"
 version = "0.5.1"
 dependencies = [
+ "base64 0.21.7",
  "borsh 1.5.7",
  "serde",
  "serde-big-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.143"
 thiserror = "2.0.16"
 serde-big-array = "0.5"
+
+[dev-dependencies]
+base64 = "0.21"

--- a/tests/cpmm.rs
+++ b/tests/cpmm.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 #![allow(deprecated)]
 mod tests {
-    use solana_program::pubkey::Pubkey;
+    use base64::Engine;
     use substreams::hex;
     use substreams_solana_idls::raydium::cpmm;
 
@@ -22,32 +22,30 @@ mod tests {
 
     #[test]
     fn unpack_cpmm_swap_event_v2() {
-        use cpmm::events::{SwapEventV2, SWAP_EVENT};
-
-        let event = SwapEventV2 {
-            pool_id: Pubkey::default(),
-            input_vault_before: 1,
-            output_vault_before: 2,
-            input_amount: 3,
-            output_amount: 4,
-            input_transfer_fee: 5,
-            output_transfer_fee: 6,
-            base_input: true,
-            input_mint: Pubkey::default(),
-            output_mint: Pubkey::default(),
-            trade_fee: 7,
-            creator_fee: 8,
-            creator_fee_on_input: false,
-        };
-
-        let mut bytes = SWAP_EVENT.to_vec();
-        bytes.extend(borsh::to_vec(&event).expect("encode"));
+        // https://solscan.io/tx/gz8KEqNmnNpthq31nQogLWkLNMm3eT3FzQKcNwoJ6wAhLxUVk6qCbGvRPhFw5et8dxrS6psBnMFcbuAdtbGFQta
+        let base64 = "QMbN6CYIceLDaOKRwjNXP6I2Olk7UZ+dmtkrhhO8crfwIq0BUi5EJ1h+UMWwFgAABwYi+rIBAAApSLsuAAAAAJiTfQMAAAAAAAAAAAAAAAAAAAAAAAAAAAFapfStVf3ObMBLO2gYyo3hrXzhGzL3/H46j2BlPPT19QabiFf+q4GE+2h/Y0YYwDXaxDncGus7VZig8AAAAAABgegdAAAAAAAAAAAAAAAAAAE=";
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(base64)
+            .expect("decode base64");
 
         match cpmm::events::unpack_event(&bytes).expect("decode event") {
-            cpmm::events::RaydiumCpmmEvent::SwapEventV2(decoded) => {
-                assert_eq!(decoded.trade_fee, 7, "trade_fee");
-                assert_eq!(decoded.creator_fee, 8, "creator_fee");
-                assert!(!decoded.creator_fee_on_input, "creator_fee_on_input");
+            cpmm::events::RaydiumCpmmEvent::SwapEventV2(event) => {
+                assert_eq!(event.base_input, true, "base_input");
+                assert_eq!(event.input_amount, 784_025_641, "input_amount");
+                assert_eq!(event.output_amount, 58_561_432, "output_amount");
+                assert_eq!(event.trade_fee, 1_960_065, "trade_fee");
+                assert_eq!(event.creator_fee, 0, "creator_fee");
+                assert!(event.creator_fee_on_input, "creator_fee_on_input");
+                assert_eq!(
+                    event.input_mint.to_string(),
+                    "76rTxzztXjJe7AUaBi7jQ5J61MFgpQgB4Cc934sWbonk",
+                    "input_mint",
+                );
+                assert_eq!(
+                    event.output_mint.to_string(),
+                    "So11111111111111111111111111111111111111112",
+                    "output_mint",
+                );
             }
             _ => panic!("Expected SwapEventV2"),
         }

--- a/tests/cpmm.rs
+++ b/tests/cpmm.rs
@@ -1,21 +1,56 @@
 #![cfg(test)]
 #![allow(deprecated)]
 mod tests {
+    use solana_program::pubkey::Pubkey;
     use substreams::hex;
     use substreams_solana_idls::raydium::cpmm;
 
     #[test]
-    fn unpack_cpmm_swap_event() {
+    fn unpack_cpmm_swap_event_v1() {
         // https://solscan.io/tx/4kKAK8GFTrdmqsMqny7Bvh4Ume5vWqsw9BHeVUwEiPefbdxAYSnzWF38QV4iV1Y7Q3WnddGkfKbCyxtn4NoqoKuD
-        // let base64 = "QMbN6CYIceJwUd/DEGbRPw2+ldrbHD1h/PUjKCkbb/k/AK44Td3RrLH9rdkNAAAA/rbodtcmAQDAD7ZMAAAAAFw7UYM6BgAAAAAAAAAAAAAAAAAAAAAAAAE=";
+        // let base64 = "QMbN6CYIceJwUd/DEGbRPw2+ldrbHD1h/PUjKCkbb/k/AK44Td3RrLH9rdkNAAAA/rbodtcmAQDAD7ZMAAAAAFw7UYM6BgAAAAAAAAAAAAAAAAAAAAAAAE=";
         let bytes = hex!("40c6cde8260871e27051dfc31066d13f0dbe95dadb1c3d61fcf52328291b6ff93f00ae384dddd1acb1fdadd90d000000feb6e876d7260100c00fb64c000000005c3b51833a0600000000000000000000000000000000000001");
 
         match cpmm::events::unpack_event(&bytes).expect("decode event") {
-            cpmm::events::RaydiumCpmmEvent::SwapEvent(event) => {
+            cpmm::events::RaydiumCpmmEvent::SwapEventV1(event) => {
                 assert_eq!(event.base_input, true, "base_input");
-                assert_eq!(event.input_amount, 1287000000, "input_amount");
+                assert_eq!(event.input_amount, 1_287_000_000, "input_amount");
             }
             _ => panic!("Expected a Event"),
         }
     }
+
+    #[test]
+    fn unpack_cpmm_swap_event_v2() {
+        use cpmm::events::{SwapEventV2, SWAP_EVENT};
+
+        let event = SwapEventV2 {
+            pool_id: Pubkey::default(),
+            input_vault_before: 1,
+            output_vault_before: 2,
+            input_amount: 3,
+            output_amount: 4,
+            input_transfer_fee: 5,
+            output_transfer_fee: 6,
+            base_input: true,
+            input_mint: Pubkey::default(),
+            output_mint: Pubkey::default(),
+            trade_fee: 7,
+            creator_fee: 8,
+            creator_fee_on_input: false,
+        };
+
+        let mut bytes = SWAP_EVENT.to_vec();
+        bytes.extend(borsh::to_vec(&event).expect("encode"));
+
+        match cpmm::events::unpack_event(&bytes).expect("decode event") {
+            cpmm::events::RaydiumCpmmEvent::SwapEventV2(decoded) => {
+                assert_eq!(decoded.trade_fee, 7, "trade_fee");
+                assert_eq!(decoded.creator_fee, 8, "creator_fee");
+                assert!(!decoded.creator_fee_on_input, "creator_fee_on_input");
+            }
+            _ => panic!("Expected SwapEventV2"),
+        }
+    }
 }
+


### PR DESCRIPTION
## Summary
- decode Raydium CPMM swap events by payload length to support both v1 and v2
- add tests for swap event v1 and v2 decoding

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_68c0c7e9a48c8328843d225f74e113d3