### PR TITLE
Use base64 engine in tests

### DIFF
--- a/tests/raydium_amm_v4.rs
+++ b/tests/raydium_amm_v4.rs
@@ -1,13 +1,16 @@
 #[cfg(test)]
 mod tests {
+    use base64::Engine;
     use substreams::hex;
     use substreams_solana_idls::raydium;
 
     #[test]
     fn unpack_amm_v4_swap_event() {
         // https://solscan.io/tx/57d3uDBdPyrHX44aPzWVznDn39qx3ixFdRVieEfvhKtYErtgbYUpetApiZaYDSHCsfQWmqJryjknyFYT2U21oqrU
-        // let base64 = "AwBOclMAAAAAmOUFnQ4AAAACAAAAAAAAAABOclMAAAAAfTDHRyEBAAAR7JIChTUAAIVC62EPAAAA";
-        let bytes = hex!("03004e72530000000098e5059d0e0000000200000000000000004e7253000000007d30c7472101000011ec9202853500008542eb610f000000");
+        let base64 = "AwBOclMAAAAAmOUFnQ4AAAACAAAAAAAAAABOclMAAAAAfTDHRyEBAAAR7JIChTUAAIVC62EPAAAA";
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(base64)
+            .expect("decode base64");
 
         match raydium::amm::v4::logs::unpack(&bytes).expect("decode event") {
             raydium::amm::v4::logs::RaydiumV4Log::SwapBaseIn(event) => {
@@ -27,8 +30,10 @@ mod tests {
     #[test]
     fn unpack_amm_v4_swap_event_2() {
         // https://solscan.io/tx/3GTW94fNv4JF4LeWNXCd6mQhxcZjNic9D1UoY9Qenf2S2t7gcgj7z58KwmHMHAYPqKVe812rrnpf2SKw8MdbNW7m
-        // let base64 = "AwL/AQAAAAAAAAAAAAAAAAACAAAAAAAAAAL/AQAAAAAA4VSaQlgAAADuOE6EHwAAAAS2AAAAAAAA";
-        let bytes = hex!("0302ff0100000000000000000000000000020000000000000002ff010000000000e1549a4258000000ee384e841f00000004b6000000000000");
+        let base64 = "AwL/AQAAAAAAAAAAAAAAAAACAAAAAAAAAAL/AQAAAAAA4VSaQlgAAADuOE6EHwAAAAS2AAAAAAAA";
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(base64)
+            .expect("decode base64");
 
         match raydium::amm::v4::logs::unpack(&bytes).expect("decode event") {
             raydium::amm::v4::logs::RaydiumV4Log::SwapBaseIn(event) => {

--- a/tests/raydium_cpmm.rs
+++ b/tests/raydium_cpmm.rs
@@ -2,14 +2,18 @@
 #![allow(deprecated)]
 mod tests {
     use base64::Engine;
-    use substreams::hex;
     use substreams_solana_idls::raydium::cpmm;
 
     #[test]
     fn unpack_cpmm_swap_event_v1() {
         // https://solscan.io/tx/4kKAK8GFTrdmqsMqny7Bvh4Ume5vWqsw9BHeVUwEiPefbdxAYSnzWF38QV4iV1Y7Q3WnddGkfKbCyxtn4NoqoKuD
-        // let base64 = "QMbN6CYIceJwUd/DEGbRPw2+ldrbHD1h/PUjKCkbb/k/AK44Td3RrLH9rdkNAAAA/rbodtcmAQDAD7ZMAAAAAFw7UYM6BgAAAAAAAAAAAAAAAAAAAAAAAE=";
-        let bytes = hex!("40c6cde8260871e27051dfc31066d13f0dbe95dadb1c3d61fcf52328291b6ff93f00ae384dddd1acb1fdadd90d000000feb6e876d7260100c00fb64c000000005c3b51833a0600000000000000000000000000000000000001");
+        let base64 = concat!(
+            "QMbN6CYIceJwUd/DEGbRPw2+ldrbHD1h/PUjKCkbb/k/AK44Td3RrLH9rdkNAAAA/rbodtcmAQDAD7ZMAAAAAFw7UYM6Bg",
+            "AAAAAAAAAAAAAAAAAAAAAAAAE="
+        );
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(base64)
+            .expect("decode base64");
 
         match cpmm::events::unpack_event(&bytes).expect("decode event") {
             cpmm::events::RaydiumCpmmEvent::SwapEventV1(event) => {
@@ -23,7 +27,10 @@ mod tests {
     #[test]
     fn unpack_cpmm_swap_event_v2() {
         // https://solscan.io/tx/gz8KEqNmnNpthq31nQogLWkLNMm3eT3FzQKcNwoJ6wAhLxUVk6qCbGvRPhFw5et8dxrS6psBnMFcbuAdtbGFQta
-        let base64 = "QMbN6CYIceLDaOKRwjNXP6I2Olk7UZ+dmtkrhhO8crfwIq0BUi5EJ1h+UMWwFgAABwYi+rIBAAApSLsuAAAAAJiTfQMAAAAAAAAAAAAAAAAAAAAAAAAAAAFapfStVf3ObMBLO2gYyo3hrXzhGzL3/H46j2BlPPT19QabiFf+q4GE+2h/Y0YYwDXaxDncGus7VZig8AAAAAABgegdAAAAAAAAAAAAAAAAAAE=";
+        let base64 = concat!(
+            "QMbN6CYIceLDaOKRwjNXP6I2Olk7UZ+dmtkrhhO8crfwIq0BUi5EJ1h+UMWwFgAABwYi+rIBAAApSLsuAAAAAJiTfQMAAAAAAAAAAAAAAA",
+            "AAAAAAAAAAAAFapfStVf3ObMBLO2gYyo3hrXzhGzL3/H46j2BlPPT19QabiFf+q4GE+2h/Y0YYwDXaxDncGus7VZig8AAAAAABgegdAAAAAAAAAAAAAAAAAAE="
+        );
         let bytes = base64::engine::general_purpose::STANDARD
             .decode(base64)
             .expect("decode base64");


### PR DESCRIPTION
## Summary
- decode Raydium cpmm swap event v1 test data using the base64 engine
- switch Raydium AMM v4 swap tests from hex! to base64 engine decoding

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_68c0ceca88ac83289088fa619c526e3a