### PR TITLE
feat: add Raydium stable AMM idl

### DIFF
--- a/src/raydium/mod.rs
+++ b/src/raydium/mod.rs
@@ -2,3 +2,4 @@ pub mod amm;
 pub mod clmm;
 pub mod cpmm;
 pub mod launchpad;
+pub mod stable;

--- a/src/raydium/stable/accounts.rs
+++ b/src/raydium/stable/accounts.rs
@@ -1,0 +1,261 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+use solana_program::pubkey::Pubkey;
+use substreams_solana::block_view::InstructionView;
+
+use crate::accounts;
+
+// -----------------------------------------------------------------------------
+// Pre-initialize accounts
+// -----------------------------------------------------------------------------
+accounts!(
+    PreInitializeAccounts,
+    get_pre_initialize_accounts,
+    {
+        /// SPL Token program
+        spl_token_program,
+        /// System program
+        system_program,
+        /// Rent sysvar
+        rent,
+        /// AMM target orders account
+        amm_target_orders,
+        /// AMM authority PDA
+        amm_authority,
+        /// Pool LP mint
+        amm_lp_mint,
+        /// Coin mint
+        coin_mint,
+        /// PC mint
+        pc_mint,
+        /// AMM coin vault
+        amm_coin_vault,
+        /// AMM pc vault
+        amm_pc_vault,
+        /// Serum market
+        serum_market,
+        /// User wallet (payer)
+        user_wallet
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Initialize accounts
+// -----------------------------------------------------------------------------
+accounts!(
+    InitializeAccounts,
+    get_initialize_accounts,
+    {
+        /// SPL Token program
+        spl_token_program,
+        /// System program
+        system_program,
+        /// Rent sysvar
+        rent,
+        /// AMM account
+        amm,
+        /// AMM authority PDA
+        amm_authority,
+        /// AMM open orders
+        amm_open_orders,
+        /// Pool LP mint
+        amm_lp_mint,
+        /// Coin mint
+        coin_mint,
+        /// PC mint
+        pc_mint,
+        /// AMM coin vault
+        amm_coin_vault,
+        /// AMM pc vault
+        amm_pc_vault,
+        /// AMM target orders
+        amm_target_orders,
+        /// Model data account
+        model_data_account,
+        /// Serum DEX program id
+        serum_program,
+        /// Serum market
+        serum_market,
+        /// User destination LP token account
+        user_dest_lp_token,
+        /// User wallet (payer)
+        user_wallet
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Deposit accounts
+// -----------------------------------------------------------------------------
+accounts!(
+    DepositAccounts,
+    get_deposit_accounts,
+    {
+        /// SPL Token program
+        spl_token_program,
+        /// AMM account
+        amm,
+        /// AMM authority PDA
+        amm_authority,
+        /// AMM open orders account
+        amm_open_orders,
+        /// AMM target orders account
+        amm_target_orders,
+        /// Pool LP mint
+        amm_lp_mint,
+        /// AMM coin vault
+        amm_coin_vault,
+        /// AMM pc vault
+        amm_pc_vault,
+        /// Model data account
+        model_data_account,
+        /// Serum market
+        serum_market,
+        /// User coin source token account
+        user_source_coin_token,
+        /// User pc source token account
+        user_source_pc_token,
+        /// User destination LP token account
+        user_dest_lp_token,
+        /// User wallet owner
+        user_owner
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Withdraw accounts
+// -----------------------------------------------------------------------------
+accounts!(
+    WithdrawAccounts,
+    get_withdraw_accounts,
+    {
+        /// SPL Token program
+        spl_token_program,
+        /// AMM account
+        amm,
+        /// AMM authority PDA
+        amm_authority,
+        /// AMM open orders account
+        amm_open_orders,
+        /// AMM target orders account
+        amm_target_orders,
+        /// Pool LP mint
+        amm_lp_mint,
+        /// AMM coin vault
+        amm_coin_vault,
+        /// AMM pc vault
+        amm_pc_vault,
+        /// Model data account
+        model_data_account,
+        /// Serum DEX program id
+        serum_program,
+        /// Serum market
+        serum_market,
+        /// Serum coin vault
+        serum_coin_vault,
+        /// Serum pc vault
+        serum_pc_vault,
+        /// Serum vault signer
+        serum_vault_signer,
+        /// User source LP token
+        user_source_lp_token,
+        /// User destination coin token
+        user_dest_coin_token,
+        /// User destination pc token
+        user_dest_pc_token,
+        /// User wallet owner
+        user_owner
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Swap base in accounts
+// -----------------------------------------------------------------------------
+accounts!(
+    SwapBaseInAccounts,
+    get_swap_base_in_accounts,
+    {
+        /// SPL Token program
+        spl_token_program,
+        /// AMM account
+        amm,
+        /// AMM authority PDA
+        amm_authority,
+        /// AMM open orders account
+        amm_open_orders,
+        /// AMM coin vault
+        amm_coin_vault,
+        /// AMM pc vault
+        amm_pc_vault,
+        /// Model data account
+        model_data_account,
+        /// Serum DEX program id
+        serum_program,
+        /// Serum market
+        serum_market,
+        /// Serum bids account
+        serum_bids,
+        /// Serum asks account
+        serum_asks,
+        /// Serum event queue
+        serum_event_queue,
+        /// Serum coin vault
+        serum_coin_vault,
+        /// Serum pc vault
+        serum_pc_vault,
+        /// Serum vault signer
+        serum_vault_signer,
+        /// User source token account
+        user_source_token,
+        /// User destination token account
+        user_destination_token,
+        /// User source owner
+        user_source_owner
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Swap base out accounts
+// -----------------------------------------------------------------------------
+accounts!(
+    SwapBaseOutAccounts,
+    get_swap_base_out_accounts,
+    {
+        /// SPL Token program
+        spl_token_program,
+        /// AMM account
+        amm,
+        /// AMM authority PDA
+        amm_authority,
+        /// AMM open orders account
+        amm_open_orders,
+        /// AMM coin vault
+        amm_coin_vault,
+        /// AMM pc vault
+        amm_pc_vault,
+        /// Model data account
+        model_data_account,
+        /// Serum DEX program id
+        serum_program,
+        /// Serum market
+        serum_market,
+        /// Serum bids account
+        serum_bids,
+        /// Serum asks account
+        serum_asks,
+        /// Serum event queue
+        serum_event_queue,
+        /// Serum coin vault
+        serum_coin_vault,
+        /// Serum pc vault
+        serum_pc_vault,
+        /// Serum vault signer
+        serum_vault_signer,
+        /// User source token account
+        user_source_token,
+        /// User destination token account
+        user_destination_token,
+        /// User source owner
+        user_source_owner
+    }
+);
+

--- a/src/raydium/stable/events.rs
+++ b/src/raydium/stable/events.rs
@@ -1,0 +1,26 @@
+//! Raydium Stable AMM events.
+
+use crate::ParseError;
+use serde::{Deserialize, Serialize};
+
+// The Raydium stable AMM program does not currently emit structured events.
+// This module defines a placeholder enum for interface completeness.
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RaydiumStableEvent {
+    /// No known events
+    Unknown,
+}
+
+impl<'a> TryFrom<&'a [u8]> for RaydiumStableEvent {
+    type Error = ParseError;
+
+    fn try_from(_data: &'a [u8]) -> Result<Self, Self::Error> {
+        Ok(Self::Unknown)
+    }
+}
+
+pub fn unpack(data: &[u8]) -> Result<RaydiumStableEvent, ParseError> {
+    RaydiumStableEvent::try_from(data)
+}
+

--- a/src/raydium/stable/idl.json
+++ b/src/raydium/stable/idl.json
@@ -1,0 +1,52 @@
+{
+  "version": "0.1.0",
+  "name": "raydium_stable",
+  "instructions": [
+    {
+      "name": "preInitialize",
+      "discriminant": 10,
+      "accounts": [],
+      "args": [ {"name": "nonce", "type": "u8"} ]
+    },
+    {
+      "name": "initialize",
+      "discriminant": 0,
+      "accounts": [],
+      "args": [ {"name": "nonce", "type": "u8"}, {"name": "open_time", "type": "u64"} ]
+    },
+    {
+      "name": "deposit",
+      "discriminant": 3,
+      "accounts": [],
+      "args": [
+        {"name": "max_coin_amount", "type": "u64"},
+        {"name": "max_pc_amount", "type": "u64"},
+        {"name": "base_side", "type": "u64"}
+      ]
+    },
+    {
+      "name": "withdraw",
+      "discriminant": 4,
+      "accounts": [],
+      "args": [ {"name": "amount", "type": "u64"} ]
+    },
+    {
+      "name": "swapBaseIn",
+      "discriminant": 9,
+      "accounts": [],
+      "args": [
+        {"name": "amount_in", "type": "u64"},
+        {"name": "minimum_amount_out", "type": "u64"}
+      ]
+    },
+    {
+      "name": "swapBaseOut",
+      "discriminant": 11,
+      "accounts": [],
+      "args": [
+        {"name": "max_amount_in", "type": "u64"},
+        {"name": "amount_out", "type": "u64"}
+      ]
+    }
+  ]
+}

--- a/src/raydium/stable/instructions.rs
+++ b/src/raydium/stable/instructions.rs
@@ -1,0 +1,124 @@
+//! Raydium Stable AMM instructions.
+
+use crate::ParseError;
+use serde::{Deserialize, Serialize};
+use borsh::{BorshDeserialize, BorshSerialize};
+
+// -----------------------------------------------------------------------------
+// Discriminators (first byte of instruction data)
+// -----------------------------------------------------------------------------
+pub const INITIALIZE: u8 = 0;
+pub const DEPOSIT: u8 = 3;
+pub const WITHDRAW: u8 = 4;
+pub const SWAP_BASE_IN: u8 = 9;
+pub const PRE_INITIALIZE: u8 = 10;
+pub const SWAP_BASE_OUT: u8 = 11;
+
+// -----------------------------------------------------------------------------
+// Instruction enumeration
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RaydiumStableInstruction {
+    Initialize(InitializeInstruction),
+    Deposit(DepositInstruction),
+    Withdraw(WithdrawInstruction),
+    SwapBaseIn(SwapBaseInInstruction),
+    PreInitialize(PreInitializeInstruction),
+    SwapBaseOut(SwapBaseOutInstruction),
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Payload structs
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct InitializeInstruction {
+    pub nonce: u8,
+    pub open_time: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct PreInitializeInstruction {
+    pub nonce: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct DepositInstruction {
+    pub max_coin_amount: u64,
+    pub max_pc_amount: u64,
+    pub base_side: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct WithdrawInstruction {
+    pub amount: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SwapBaseInInstruction {
+    pub amount_in: u64,
+    pub minimum_amount_out: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SwapBaseOutInstruction {
+    pub max_amount_in: u64,
+    pub amount_out: u64,
+}
+
+// -----------------------------------------------------------------------------
+// Deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for RaydiumStableInstruction {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.is_empty() {
+            return Err(ParseError::TooShort(data.len()));
+        }
+        let (&tag, payload) = data.split_first().unwrap();
+        Ok(match tag {
+            INITIALIZE => {
+                if payload.len() < 9 { return Err(ParseError::TooShort(data.len())); }
+                let nonce = payload[0];
+                let open_time = u64::from_le_bytes(payload[1..9].try_into().unwrap());
+                Self::Initialize(InitializeInstruction { nonce, open_time })
+            }
+            DEPOSIT => {
+                if payload.len() < 24 { return Err(ParseError::TooShort(data.len())); }
+                let max_coin_amount = u64::from_le_bytes(payload[0..8].try_into().unwrap());
+                let max_pc_amount = u64::from_le_bytes(payload[8..16].try_into().unwrap());
+                let base_side = u64::from_le_bytes(payload[16..24].try_into().unwrap());
+                Self::Deposit(DepositInstruction { max_coin_amount, max_pc_amount, base_side })
+            }
+            WITHDRAW => {
+                if payload.len() < 8 { return Err(ParseError::TooShort(data.len())); }
+                let amount = u64::from_le_bytes(payload[0..8].try_into().unwrap());
+                Self::Withdraw(WithdrawInstruction { amount })
+            }
+            SWAP_BASE_IN => {
+                if payload.len() < 16 { return Err(ParseError::TooShort(data.len())); }
+                let amount_in = u64::from_le_bytes(payload[0..8].try_into().unwrap());
+                let minimum_amount_out = u64::from_le_bytes(payload[8..16].try_into().unwrap());
+                Self::SwapBaseIn(SwapBaseInInstruction { amount_in, minimum_amount_out })
+            }
+            PRE_INITIALIZE => {
+                if payload.len() < 1 { return Err(ParseError::TooShort(data.len())); }
+                let nonce = payload[0];
+                Self::PreInitialize(PreInitializeInstruction { nonce })
+            }
+            SWAP_BASE_OUT => {
+                if payload.len() < 16 { return Err(ParseError::TooShort(data.len())); }
+                let max_amount_in = u64::from_le_bytes(payload[0..8].try_into().unwrap());
+                let amount_out = u64::from_le_bytes(payload[8..16].try_into().unwrap());
+                Self::SwapBaseOut(SwapBaseOutInstruction { max_amount_in, amount_out })
+            }
+            other => return Err(ParseError::RaydiumUnknown(other)),
+        })
+    }
+}
+
+pub fn unpack(data: &[u8]) -> Result<RaydiumStableInstruction, ParseError> {
+    RaydiumStableInstruction::try_from(data)
+}
+

--- a/src/raydium/stable/mod.rs
+++ b/src/raydium/stable/mod.rs
@@ -1,0 +1,11 @@
+use substreams_solana::b58;
+
+pub mod accounts;
+pub mod events;
+pub mod instructions;
+
+/// Raydium Stable AMM program
+///
+/// https://solscan.io/account/5quBtoiQqxF9Jv6KYKctB59NT3gtJD2Y65kdnB1Uev3h
+pub const PROGRAM_ID: [u8; 32] = b58!("5quBtoiQqxF9Jv6KYKctB59NT3gtJD2Y65kdnB1Uev3h");
+


### PR DESCRIPTION
## Summary
- add Raydium stable AMM instruction parser and account layouts
- expose Raydium stable program module

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_68c18da924dc83288dc319d42aa7d472