### PR TITLE
feat: parse raydium stable swap event

### DIFF
--- a/src/raydium/stable/events.rs
+++ b/src/raydium/stable/events.rs
@@ -1,26 +1,65 @@
 //! Raydium Stable AMM events.
 
 use crate::ParseError;
+use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 
-// The Raydium stable AMM program does not currently emit structured events.
-// This module defines a placeholder enum for interface completeness.
+// -----------------------------------------------------------------------------
+// Discriminators
+// -----------------------------------------------------------------------------
+/// `SwapEvent` discriminator reused from Raydium CPMM.
+pub const SWAP_EVENT: [u8; 8] = [64, 198, 205, 232, 38, 8, 113, 226];
 
+// -----------------------------------------------------------------------------
+// Event enumeration
+// -----------------------------------------------------------------------------
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RaydiumStableEvent {
-    /// No known events
+    /// Emitted when a swap occurs.
+    SwapEvent(SwapEvent),
+    /// Discriminator did not match any known event.
     Unknown,
 }
 
+// -----------------------------------------------------------------------------
+// Payload structs
+// -----------------------------------------------------------------------------
+/// Emitted when performing a swap on the Raydium Stable AMM.
+///
+/// The payload layout is:
+/// `[u8 dex][u64 amount_in][u64 amount_out]`.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SwapEvent {
+    /// DEX identifier as defined by Jupiter's aggregator.
+    pub dex: u8,
+    /// Amount of tokens supplied to the pool.
+    pub amount_in: u64,
+    /// Amount of tokens received from the pool.
+    pub amount_out: u64,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
 impl<'a> TryFrom<&'a [u8]> for RaydiumStableEvent {
     type Error = ParseError;
 
-    fn try_from(_data: &'a [u8]) -> Result<Self, Self::Error> {
-        Ok(Self::Unknown)
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.len() < 8 {
+            return Err(ParseError::TooShort(data.len()));
+        }
+
+        let (disc, payload) = data.split_at(8);
+        let discriminator: [u8; 8] = disc.try_into().expect("slice len 8");
+
+        Ok(match discriminator {
+            SWAP_EVENT => Self::SwapEvent(SwapEvent::try_from_slice(payload)?),
+            _ => Self::Unknown,
+        })
     }
 }
 
+/// Convenience wrapper that forwards to `TryFrom`.
 pub fn unpack(data: &[u8]) -> Result<RaydiumStableEvent, ParseError> {
     RaydiumStableEvent::try_from(data)
 }
-

--- a/tests/raydium_stable.rs
+++ b/tests/raydium_stable.rs
@@ -1,0 +1,22 @@
+#![cfg(test)]
+#![allow(deprecated)]
+mod tests {
+    use base64::Engine;
+    use substreams_solana_idls::raydium::stable;
+
+    #[test]
+    fn unpack_stable_swap_event() {
+        // https://provided program logs event example
+        let base64 = "QMbN6CYIceIF0asNAwAAAABJXQ0DAAAAAA==";
+        let bytes = base64::engine::general_purpose::STANDARD.decode(base64).expect("decode base64");
+
+        match stable::events::unpack(&bytes).expect("decode event") {
+            stable::events::RaydiumStableEvent::SwapEvent(event) => {
+                assert_eq!(event.dex, 5, "dex");
+                assert_eq!(event.amount_in, 51_227_601, "amount_in");
+                assert_eq!(event.amount_out, 51_207_497, "amount_out");
+            }
+            _ => panic!("Expected SwapEvent"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- parse Raydium Stable SwapEvent including dex, amount in/out
- add test decoding on-chain event example

## Testing
- `cargo test --test raydium_stable`


------
https://chatgpt.com/codex/tasks/task_b_68c19cfb69508328aec6ebcf5975f958