### PR TITLE
Add Phonenix instruction and event parsing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod bonkswap;
 pub mod jupiter;
 pub mod meteora;
 pub mod orca;
+pub mod phonenix;
 pub mod pumpfun;
 pub mod raydium;
 

--- a/src/phonenix/accounts.rs
+++ b/src/phonenix/accounts.rs
@@ -1,0 +1,34 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+use solana_program::pubkey::Pubkey;
+use substreams_solana::block_view::InstructionView;
+
+use crate::accounts;
+
+// -----------------------------------------------------------------------------
+// Swap accounts
+// -----------------------------------------------------------------------------
+accounts!(
+    SwapAccounts,
+    get_swap_accounts,
+    {
+        /// Phoenix program
+        phoenix_program,
+        /// Phoenix log authority
+        log_authority,
+        /// Market state account
+        market,
+        /// Trader performing the swap
+        trader,
+        /// Trader base token account
+        base_account,
+        /// Trader quote token account
+        quote_account,
+        /// Base vault PDA
+        base_vault,
+        /// Quote vault PDA
+        quote_vault,
+        /// SPL token program
+        token_program
+    }
+);

--- a/src/phonenix/events.rs
+++ b/src/phonenix/events.rs
@@ -1,0 +1,57 @@
+//! Phonenix market events.
+
+use crate::ParseError;
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+use solana_program::pubkey::Pubkey;
+
+// -----------------------------------------------------------------------------
+// Discriminators
+// -----------------------------------------------------------------------------
+pub const FILL_EVENT: u8 = 2;
+
+// -----------------------------------------------------------------------------
+// Event enumeration
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PhonenixEvent {
+    Fill(FillEvent),
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Payload structs
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct FillEvent {
+    pub index: u16,
+    pub maker_id: Pubkey,
+    pub order_sequence_number: u64,
+    pub price_in_ticks: u64,
+    pub base_lots_filled: u64,
+    pub base_lots_remaining: u64,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for PhonenixEvent {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.is_empty() {
+            return Err(ParseError::TooShort(data.len()));
+        }
+        let (disc, payload) = data.split_at(1);
+        let discriminator = disc[0];
+        Ok(match discriminator {
+            FILL_EVENT => Self::Fill(FillEvent::try_from_slice(payload)?),
+            other => return Err(ParseError::Unknown([other, 0, 0, 0, 0, 0, 0, 0])),
+        })
+    }
+}
+
+/// Convenience wrapper that forwards to `TryFrom`.
+pub fn unpack(data: &[u8]) -> Result<PhonenixEvent, ParseError> {
+    PhonenixEvent::try_from(data)
+}

--- a/src/phonenix/instructions.rs
+++ b/src/phonenix/instructions.rs
@@ -1,0 +1,65 @@
+//! Phonenix trading instructions.
+
+use crate::ParseError;
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+
+// -----------------------------------------------------------------------------
+// Discriminators
+// -----------------------------------------------------------------------------
+pub const SWAP: u8 = 0;
+pub const SWAP_WITH_FREE_FUNDS: u8 = 1;
+
+// -----------------------------------------------------------------------------
+// Instruction enumeration
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PhonenixInstruction {
+    Swap(SwapInstruction),
+    SwapWithFreeFunds(SwapWithFreeFundsInstruction),
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Payload structs
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SwapInstruction {
+    /// Raw order packet payload
+    pub order_packet: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SwapWithFreeFundsInstruction {
+    /// Raw order packet payload
+    pub order_packet: Vec<u8>,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for PhonenixInstruction {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.is_empty() {
+            return Err(ParseError::TooShort(data.len()));
+        }
+        let (disc, payload) = data.split_at(1);
+        let discriminator = disc[0];
+        Ok(match discriminator {
+            SWAP => Self::Swap(SwapInstruction {
+                order_packet: payload.to_vec(),
+            }),
+            SWAP_WITH_FREE_FUNDS => Self::SwapWithFreeFunds(SwapWithFreeFundsInstruction {
+                order_packet: payload.to_vec(),
+            }),
+            other => return Err(ParseError::Unknown([other, 0, 0, 0, 0, 0, 0, 0])),
+        })
+    }
+}
+
+/// Convenience wrapper that forwards to `TryFrom`.
+pub fn unpack(data: &[u8]) -> Result<PhonenixInstruction, ParseError> {
+    PhonenixInstruction::try_from(data)
+}

--- a/src/phonenix/mod.rs
+++ b/src/phonenix/mod.rs
@@ -1,0 +1,10 @@
+use substreams_solana::b58;
+
+pub mod accounts;
+pub mod events;
+pub mod instructions;
+
+/// Phonenix program
+///
+/// https://solscan.io/account/PhoeNiXZ8ByJGLkxNfZRnkUfjvmuYqLR89jjFHGqdXY
+pub const PROGRAM_ID: [u8; 32] = b58!("PhoeNiXZ8ByJGLkxNfZRnkUfjvmuYqLR89jjFHGqdXY");


### PR DESCRIPTION
## Summary
- add Phonenix program module with program ID PhoeNiXZ8ByJGLkxNfZRnkUfjvmuYqLR89jjFHGqdXY
- parse swap accounts, swap instructions and fill events

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_68c19e3ef044832880e74a357294ee1e