### PR TITLE
Add Jupiter DCA IDL helpers

### DIFF
--- a/src/jupiter/dca/accounts.rs
+++ b/src/jupiter/dca/accounts.rs
@@ -1,0 +1,370 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+use solana_program::pubkey::Pubkey;
+use substreams_solana::block_view::InstructionView;
+
+use crate::accounts::{to_pubkey, AccountsError};
+
+// -----------------------------------------------------------------------------
+// Simple instructions
+// -----------------------------------------------------------------------------
+accounts!(
+    OpenDcaAccounts,
+    get_open_dca_accounts,
+    {
+        dca,
+        user,
+        input_mint,
+        output_mint,
+        user_ata,
+        in_ata,
+        out_ata,
+        system_program,
+        token_program,
+        associated_token_program,
+        event_authority,
+        program
+    }
+);
+
+accounts!(
+    OpenDcaV2Accounts,
+    get_open_dca_v2_accounts,
+    {
+        dca,
+        user,
+        payer,
+        input_mint,
+        output_mint,
+        user_ata,
+        in_ata,
+        out_ata,
+        system_program,
+        token_program,
+        associated_token_program,
+        event_authority,
+        program
+    }
+);
+
+accounts!(
+    CloseDcaAccounts,
+    get_close_dca_accounts,
+    {
+        user,
+        dca,
+        input_mint,
+        output_mint,
+        in_ata,
+        out_ata,
+        user_in_ata,
+        user_out_ata,
+        system_program,
+        token_program,
+        associated_token_program,
+        event_authority,
+        program
+    }
+);
+
+accounts!(
+    DepositAccounts,
+    get_deposit_accounts,
+    {
+        user,
+        dca,
+        in_ata,
+        user_in_ata,
+        token_program,
+        event_authority,
+        program
+    }
+);
+
+accounts!(
+    WithdrawFeesAccounts,
+    get_withdraw_fees_accounts,
+    {
+        admin,
+        mint,
+        fee_authority,
+        program_fee_ata,
+        admin_fee_ata,
+        system_program,
+        token_program,
+        associated_token_program
+    }
+);
+
+accounts!(
+    InitiateFlashFillAccounts,
+    get_initiate_flash_fill_accounts,
+    {
+        keeper,
+        dca,
+        input_mint,
+        keeper_in_ata,
+        in_ata,
+        out_ata,
+        instructions_sysvar,
+        system_program,
+        token_program,
+        associated_token_program
+    }
+);
+
+accounts!(
+    FulfillFlashFillAccounts,
+    get_fulfill_flash_fill_accounts,
+    {
+        keeper,
+        dca,
+        input_mint,
+        output_mint,
+        keeper_in_ata,
+        in_ata,
+        out_ata,
+        fee_authority,
+        fee_ata,
+        instructions_sysvar,
+        system_program,
+        token_program,
+        associated_token_program,
+        event_authority,
+        program
+    }
+);
+
+accounts!(
+    InitiateDlmmFillAccounts,
+    get_initiate_dlmm_fill_accounts,
+    {
+        keeper,
+        dca,
+        input_mint,
+        keeper_in_ata,
+        in_ata,
+        out_ata,
+        instructions_sysvar,
+        system_program,
+        token_program,
+        associated_token_program
+    }
+);
+
+accounts!(
+    FulfillDlmmFillAccounts,
+    get_fulfill_dlmm_fill_accounts,
+    {
+        keeper,
+        dca,
+        input_mint,
+        output_mint,
+        keeper_in_ata,
+        in_ata,
+        out_ata,
+        fee_authority,
+        fee_ata,
+        instructions_sysvar,
+        system_program,
+        token_program,
+        associated_token_program,
+        event_authority,
+        program
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Instructions with optional accounts
+// -----------------------------------------------------------------------------
+const IDX_WD_USER: usize = 0;
+const IDX_WD_DCA: usize = 1;
+const IDX_WD_INPUT_MINT: usize = 2;
+const IDX_WD_OUTPUT_MINT: usize = 3;
+const IDX_WD_DCA_ATA: usize = 4;
+const IDX_WD_USER_IN_ATA: usize = 5;
+const IDX_WD_USER_OUT_ATA: usize = 6;
+const IDX_WD_SYSTEM_PROGRAM: usize = 7;
+const IDX_WD_TOKEN_PROGRAM: usize = 8;
+const IDX_WD_ASSOCIATED_TOKEN_PROGRAM: usize = 9;
+const IDX_WD_EVENT_AUTHORITY: usize = 10;
+const IDX_WD_PROGRAM: usize = 11;
+
+/// Accounts for the `withdraw` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct WithdrawAccounts {
+    pub user: Pubkey,
+    pub dca: Pubkey,
+    pub input_mint: Pubkey,
+    pub output_mint: Pubkey,
+    pub dca_ata: Pubkey,
+    pub user_in_ata: Option<Pubkey>,
+    pub user_out_ata: Option<Pubkey>,
+    pub system_program: Pubkey,
+    pub token_program: Pubkey,
+    pub associated_token_program: Pubkey,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for WithdrawAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, a.0)
+        };
+        let get_opt = |index: usize| -> Option<Pubkey> { accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(WithdrawAccounts {
+            user: get_req(IDX_WD_USER, "user")?,
+            dca: get_req(IDX_WD_DCA, "dca")?,
+            input_mint: get_req(IDX_WD_INPUT_MINT, "input_mint")?,
+            output_mint: get_req(IDX_WD_OUTPUT_MINT, "output_mint")?,
+            dca_ata: get_req(IDX_WD_DCA_ATA, "dca_ata")?,
+            user_in_ata: get_opt(IDX_WD_USER_IN_ATA),
+            user_out_ata: get_opt(IDX_WD_USER_OUT_ATA),
+            system_program: get_req(IDX_WD_SYSTEM_PROGRAM, "system_program")?,
+            token_program: get_req(IDX_WD_TOKEN_PROGRAM, "token_program")?,
+            associated_token_program: get_req(IDX_WD_ASSOCIATED_TOKEN_PROGRAM, "associated_token_program")?,
+            event_authority: get_req(IDX_WD_EVENT_AUTHORITY, "event_authority")?,
+            program: get_req(IDX_WD_PROGRAM, "program")?,
+        })
+    }
+}
+
+pub fn get_withdraw_accounts(ix: &InstructionView) -> Result<WithdrawAccounts, AccountsError> {
+    WithdrawAccounts::try_from(ix)
+}
+
+const IDX_TR_KEEPER: usize = 0;
+const IDX_TR_DCA: usize = 1;
+const IDX_TR_USER: usize = 2;
+const IDX_TR_OUTPUT_MINT: usize = 3;
+const IDX_TR_DCA_OUT_ATA: usize = 4;
+const IDX_TR_USER_OUT_ATA: usize = 5;
+const IDX_TR_INTERMEDIATE_ACCOUNT: usize = 6;
+const IDX_TR_SYSTEM_PROGRAM: usize = 7;
+const IDX_TR_TOKEN_PROGRAM: usize = 8;
+const IDX_TR_ASSOCIATED_TOKEN_PROGRAM: usize = 9;
+const IDX_TR_EVENT_AUTHORITY: usize = 10;
+const IDX_TR_PROGRAM: usize = 11;
+
+/// Accounts for the `transfer` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct TransferAccounts {
+    pub keeper: Pubkey,
+    pub dca: Pubkey,
+    pub user: Pubkey,
+    pub output_mint: Pubkey,
+    pub dca_out_ata: Pubkey,
+    pub user_out_ata: Option<Pubkey>,
+    pub intermediate_account: Option<Pubkey>,
+    pub system_program: Pubkey,
+    pub token_program: Pubkey,
+    pub associated_token_program: Pubkey,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for TransferAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, a.0)
+        };
+        let get_opt = |index: usize| -> Option<Pubkey> { accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(TransferAccounts {
+            keeper: get_req(IDX_TR_KEEPER, "keeper")?,
+            dca: get_req(IDX_TR_DCA, "dca")?,
+            user: get_req(IDX_TR_USER, "user")?,
+            output_mint: get_req(IDX_TR_OUTPUT_MINT, "output_mint")?,
+            dca_out_ata: get_req(IDX_TR_DCA_OUT_ATA, "dca_out_ata")?,
+            user_out_ata: get_opt(IDX_TR_USER_OUT_ATA),
+            intermediate_account: get_opt(IDX_TR_INTERMEDIATE_ACCOUNT),
+            system_program: get_req(IDX_TR_SYSTEM_PROGRAM, "system_program")?,
+            token_program: get_req(IDX_TR_TOKEN_PROGRAM, "token_program")?,
+            associated_token_program: get_req(IDX_TR_ASSOCIATED_TOKEN_PROGRAM, "associated_token_program")?,
+            event_authority: get_req(IDX_TR_EVENT_AUTHORITY, "event_authority")?,
+            program: get_req(IDX_TR_PROGRAM, "program")?,
+        })
+    }
+}
+
+pub fn get_transfer_accounts(ix: &InstructionView) -> Result<TransferAccounts, AccountsError> {
+    TransferAccounts::try_from(ix)
+}
+
+const IDX_EC_KEEPER: usize = 0;
+const IDX_EC_DCA: usize = 1;
+const IDX_EC_INPUT_MINT: usize = 2;
+const IDX_EC_OUTPUT_MINT: usize = 3;
+const IDX_EC_IN_ATA: usize = 4;
+const IDX_EC_OUT_ATA: usize = 5;
+const IDX_EC_USER: usize = 6;
+const IDX_EC_USER_OUT_ATA: usize = 7;
+const IDX_EC_INIT_USER_OUT_ATA: usize = 8;
+const IDX_EC_INTERMEDIATE_ACCOUNT: usize = 9;
+const IDX_EC_SYSTEM_PROGRAM: usize = 10;
+const IDX_EC_TOKEN_PROGRAM: usize = 11;
+const IDX_EC_ASSOCIATED_TOKEN_PROGRAM: usize = 12;
+const IDX_EC_EVENT_AUTHORITY: usize = 13;
+const IDX_EC_PROGRAM: usize = 14;
+
+/// Accounts for the `end_and_close` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct EndAndCloseAccounts {
+    pub keeper: Pubkey,
+    pub dca: Pubkey,
+    pub input_mint: Pubkey,
+    pub output_mint: Pubkey,
+    pub in_ata: Pubkey,
+    pub out_ata: Pubkey,
+    pub user: Pubkey,
+    pub user_out_ata: Option<Pubkey>,
+    pub init_user_out_ata: Option<Pubkey>,
+    pub intermediate_account: Option<Pubkey>,
+    pub system_program: Pubkey,
+    pub token_program: Pubkey,
+    pub associated_token_program: Pubkey,
+    pub event_authority: Pubkey,
+    pub program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for EndAndCloseAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, a.0)
+        };
+        let get_opt = |index: usize| -> Option<Pubkey> { accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(EndAndCloseAccounts {
+            keeper: get_req(IDX_EC_KEEPER, "keeper")?,
+            dca: get_req(IDX_EC_DCA, "dca")?,
+            input_mint: get_req(IDX_EC_INPUT_MINT, "input_mint")?,
+            output_mint: get_req(IDX_EC_OUTPUT_MINT, "output_mint")?,
+            in_ata: get_req(IDX_EC_IN_ATA, "in_ata")?,
+            out_ata: get_req(IDX_EC_OUT_ATA, "out_ata")?,
+            user: get_req(IDX_EC_USER, "user")?,
+            user_out_ata: get_opt(IDX_EC_USER_OUT_ATA),
+            init_user_out_ata: get_opt(IDX_EC_INIT_USER_OUT_ATA),
+            intermediate_account: get_opt(IDX_EC_INTERMEDIATE_ACCOUNT),
+            system_program: get_req(IDX_EC_SYSTEM_PROGRAM, "system_program")?,
+            token_program: get_req(IDX_EC_TOKEN_PROGRAM, "token_program")?,
+            associated_token_program: get_req(IDX_EC_ASSOCIATED_TOKEN_PROGRAM, "associated_token_program")?,
+            event_authority: get_req(IDX_EC_EVENT_AUTHORITY, "event_authority")?,
+            program: get_req(IDX_EC_PROGRAM, "program")?,
+        })
+    }
+}
+
+pub fn get_end_and_close_accounts(ix: &InstructionView) -> Result<EndAndCloseAccounts, AccountsError> {
+    EndAndCloseAccounts::try_from(ix)
+}

--- a/src/jupiter/dca/events.rs
+++ b/src/jupiter/dca/events.rs
@@ -1,0 +1,124 @@
+//! Jupiter DCA on-chain events.
+
+use crate::ParseError;
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+use solana_program::pubkey::Pubkey;
+
+// -----------------------------------------------------------------------------
+// Discriminators (first 8 bytes)
+// -----------------------------------------------------------------------------
+const COLLECTED_FEE: [u8; 8] = [42, 136, 216, 116, 181, 209, 109, 181];
+const FILLED: [u8; 8] = [134, 4, 17, 63, 221, 45, 177, 173];
+const OPENED: [u8; 8] = [166, 172, 97, 9, 77, 76, 189, 109];
+const CLOSED: [u8; 8] = [50, 31, 87, 155, 135, 220, 195, 239];
+const WITHDRAW: [u8; 8] = [192, 241, 201, 217, 70, 150, 90, 247];
+const DEPOSIT: [u8; 8] = [62, 205, 242, 175, 244, 169, 136, 52];
+
+// -----------------------------------------------------------------------------
+// High-level event enum
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum JupiterDcaEvent {
+    CollectedFee(CollectedFeeEvent),
+    Filled(FilledEvent),
+    Opened(OpenedEvent),
+    Closed(ClosedEvent),
+    Withdraw(WithdrawEvent),
+    Deposit(DepositEvent),
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Payload structs
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CollectedFeeEvent {
+    pub user_key: Pubkey,
+    pub dca_key: Pubkey,
+    pub mint: Pubkey,
+    pub amount: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct FilledEvent {
+    pub user_key: Pubkey,
+    pub dca_key: Pubkey,
+    pub input_mint: Pubkey,
+    pub output_mint: Pubkey,
+    pub in_amount: u64,
+    pub out_amount: u64,
+    pub fee_mint: Pubkey,
+    pub fee: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct OpenedEvent {
+    pub user_key: Pubkey,
+    pub dca_key: Pubkey,
+    pub in_deposited: u64,
+    pub input_mint: Pubkey,
+    pub output_mint: Pubkey,
+    pub cycle_frequency: i64,
+    pub in_amount_per_cycle: u64,
+    pub created_at: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct ClosedEvent {
+    pub user_key: Pubkey,
+    pub dca_key: Pubkey,
+    pub in_deposited: u64,
+    pub input_mint: Pubkey,
+    pub output_mint: Pubkey,
+    pub cycle_frequency: i64,
+    pub in_amount_per_cycle: u64,
+    pub created_at: i64,
+    pub total_in_withdrawn: u64,
+    pub total_out_withdrawn: u64,
+    pub unfilled_amount: u64,
+    pub user_closed: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct WithdrawEvent {
+    pub dca_key: Pubkey,
+    pub in_amount: u64,
+    pub out_amount: u64,
+    pub user_withdraw: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct DepositEvent {
+    pub dca_key: Pubkey,
+    pub amount: u64,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for JupiterDcaEvent {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.len() < 8 {
+            return Err(ParseError::TooShort(data.len()));
+        }
+        let (disc, payload) = data.split_at(8);
+        let discriminator: [u8; 8] = disc.try_into().expect("slice len 8");
+        Ok(match discriminator {
+            COLLECTED_FEE => Self::CollectedFee(CollectedFeeEvent::try_from_slice(payload)?),
+            FILLED => Self::Filled(FilledEvent::try_from_slice(payload)?),
+            OPENED => Self::Opened(OpenedEvent::try_from_slice(payload)?),
+            CLOSED => Self::Closed(ClosedEvent::try_from_slice(payload)?),
+            WITHDRAW => Self::Withdraw(WithdrawEvent::try_from_slice(payload)?),
+            DEPOSIT => Self::Deposit(DepositEvent::try_from_slice(payload)?),
+            _ => Self::Unknown,
+        })
+    }
+}
+
+/// Convenience wrapper that forwards to `TryFrom`.
+pub fn unpack(data: &[u8]) -> Result<JupiterDcaEvent, ParseError> {
+    JupiterDcaEvent::try_from(data)
+}

--- a/src/jupiter/dca/instructions.rs
+++ b/src/jupiter/dca/instructions.rs
@@ -1,0 +1,142 @@
+//! Jupiter DCA on-chain instructions.
+
+use crate::ParseError;
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+
+// -----------------------------------------------------------------------------
+// Custom types
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct WithdrawParams {
+    pub withdraw_amount: u64,
+    pub withdrawal: Withdrawal,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub enum Withdrawal {
+    In,
+    Out,
+}
+
+// -----------------------------------------------------------------------------
+// Payload structs
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct OpenDcaInstruction {
+    pub application_idx: u64,
+    pub in_amount: u64,
+    pub in_amount_per_cycle: u64,
+    pub cycle_frequency: i64,
+    pub min_out_amount: Option<u64>,
+    pub max_out_amount: Option<u64>,
+    pub start_at: Option<i64>,
+    pub close_wsol_in_ata: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct OpenDcaV2Instruction {
+    pub application_idx: u64,
+    pub in_amount: u64,
+    pub in_amount_per_cycle: u64,
+    pub cycle_frequency: i64,
+    pub min_out_amount: Option<u64>,
+    pub max_out_amount: Option<u64>,
+    pub start_at: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct WithdrawInstruction {
+    pub withdraw_params: WithdrawParams,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct DepositInstruction {
+    pub deposit_in: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct WithdrawFeesInstruction {
+    pub amount: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct FulfillFlashFillInstruction {
+    pub repay_amount: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct FulfillDlmmFillInstruction {
+    pub repay_amount: u64,
+}
+
+// -----------------------------------------------------------------------------
+// Discriminators
+// -----------------------------------------------------------------------------
+pub const OPEN_DCA: [u8; 8] = [36, 65, 185, 54, 1, 210, 100, 163];
+pub const OPEN_DCA_V2: [u8; 8] = [142, 119, 43, 109, 162, 52, 11, 177];
+pub const CLOSE_DCA: [u8; 8] = [22, 7, 33, 98, 168, 183, 34, 243];
+pub const WITHDRAW: [u8; 8] = [183, 18, 70, 156, 148, 109, 161, 34];
+pub const DEPOSIT: [u8; 8] = [242, 35, 198, 137, 82, 225, 242, 182];
+pub const WITHDRAW_FEES: [u8; 8] = [198, 212, 171, 109, 144, 215, 174, 89];
+pub const INITIATE_FLASH_FILL: [u8; 8] = [143, 205, 3, 191, 162, 215, 245, 49];
+pub const FULFILL_FLASH_FILL: [u8; 8] = [115, 64, 226, 78, 33, 211, 105, 162];
+pub const INITIATE_DLMM_FILL: [u8; 8] = [155, 193, 80, 121, 91, 147, 254, 187];
+pub const FULFILL_DLMM_FILL: [u8; 8] = [1, 230, 118, 251, 45, 177, 101, 187];
+pub const TRANSFER: [u8; 8] = [163, 52, 200, 231, 140, 3, 69, 186];
+pub const END_AND_CLOSE: [u8; 8] = [83, 125, 166, 69, 247, 252, 103, 133];
+
+// -----------------------------------------------------------------------------
+// High-level instruction enum
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum JupiterDcaInstruction {
+    OpenDca(OpenDcaInstruction),
+    OpenDcaV2(OpenDcaV2Instruction),
+    CloseDca,
+    Withdraw(WithdrawInstruction),
+    Deposit(DepositInstruction),
+    WithdrawFees(WithdrawFeesInstruction),
+    InitiateFlashFill,
+    FulfillFlashFill(FulfillFlashFillInstruction),
+    InitiateDlmmFill,
+    FulfillDlmmFill(FulfillDlmmFillInstruction),
+    Transfer,
+    EndAndClose,
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for JupiterDcaInstruction {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.len() < 8 {
+            return Err(ParseError::TooShort(data.len()));
+        }
+        let (disc, payload) = data.split_at(8);
+        let discriminator: [u8; 8] = disc.try_into().expect("slice len 8");
+        Ok(match discriminator {
+            OPEN_DCA => Self::OpenDca(OpenDcaInstruction::try_from_slice(payload)?),
+            OPEN_DCA_V2 => Self::OpenDcaV2(OpenDcaV2Instruction::try_from_slice(payload)?),
+            CLOSE_DCA => Self::CloseDca,
+            WITHDRAW => Self::Withdraw(WithdrawInstruction::try_from_slice(payload)?),
+            DEPOSIT => Self::Deposit(DepositInstruction::try_from_slice(payload)?),
+            WITHDRAW_FEES => Self::WithdrawFees(WithdrawFeesInstruction::try_from_slice(payload)?),
+            INITIATE_FLASH_FILL => Self::InitiateFlashFill,
+            FULFILL_FLASH_FILL => Self::FulfillFlashFill(FulfillFlashFillInstruction::try_from_slice(payload)?),
+            INITIATE_DLMM_FILL => Self::InitiateDlmmFill,
+            FULFILL_DLMM_FILL => Self::FulfillDlmmFill(FulfillDlmmFillInstruction::try_from_slice(payload)?),
+            TRANSFER => Self::Transfer,
+            END_AND_CLOSE => Self::EndAndClose,
+            other => return Err(ParseError::Unknown(other)),
+        })
+    }
+}
+
+/// Convenience wrapper that forwards to `TryFrom`.
+pub fn unpack(data: &[u8]) -> Result<JupiterDcaInstruction, ParseError> {
+    JupiterDcaInstruction::try_from(data)
+}

--- a/src/jupiter/dca/mod.rs
+++ b/src/jupiter/dca/mod.rs
@@ -1,0 +1,10 @@
+use substreams_solana::b58;
+
+pub mod accounts;
+pub mod events;
+pub mod instructions;
+
+/// Jupiter DCA
+///
+/// https://solscan.io/account/DCA265Vj8a9CEuX1eb1LWRnDT7uK6q1xMipnNyatn23M
+pub const PROGRAM_ID: [u8; 32] = b58!("DCA265Vj8a9CEuX1eb1LWRnDT7uK6q1xMipnNyatn23M");

--- a/src/jupiter/mod.rs
+++ b/src/jupiter/mod.rs
@@ -1,2 +1,3 @@
+pub mod dca;
 pub mod v4;
 pub mod v6;


### PR DESCRIPTION
## Summary
- add IDL-based accounts, instructions, and events for Jupiter DCA program
- expose Jupiter DCA program ID and module

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_68c19dbfe2248328be5288f7cb410c98