### PR TITLE
Add Jupiter limit order IDL

### DIFF
--- a/src/jupiter/limit_order/accounts.rs
+++ b/src/jupiter/limit_order/accounts.rs
@@ -1,0 +1,309 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+use solana_program::pubkey::Pubkey;
+use substreams_solana::block_view::InstructionView;
+
+use crate::accounts::{to_pubkey, AccountsError};
+
+// -----------------------------------------------------------------------------
+// Simple instructions
+// -----------------------------------------------------------------------------
+accounts!(
+    PreFlashFillOrderAccounts,
+    get_pre_flash_fill_order_accounts,
+    { order, reserve, taker, taker_output_account, input_mint, input_mint_token_program, instruction, system_program }
+);
+
+accounts!(
+    WithdrawFeeAccounts,
+    get_withdraw_fee_accounts,
+    { admin, fee_authority, program_fee_account, admin_token_acocunt, token_program, mint }
+);
+
+accounts!(
+    InitFeeAccounts,
+    get_init_fee_accounts,
+    { keeper, fee_authority, system_program }
+);
+
+accounts!(
+    UpdateFeeAccounts,
+    get_update_fee_accounts,
+    { keeper, fee_authority }
+);
+
+// -----------------------------------------------------------------------------
+// Instructions with optional accounts
+// -----------------------------------------------------------------------------
+const IDX_BASE: usize = 0;
+const IDX_MAKER: usize = 1;
+const IDX_ORDER: usize = 2;
+const IDX_RESERVE: usize = 3;
+const IDX_MAKER_INPUT_ACCOUNT: usize = 4;
+const IDX_INPUT_MINT: usize = 5;
+const IDX_MAKER_OUTPUT_ACCOUNT: usize = 6;
+const IDX_REFERRAL: usize = 7;
+const IDX_OUTPUT_MINT: usize = 8;
+const IDX_SYSTEM_PROGRAM: usize = 9;
+const IDX_TOKEN_PROGRAM: usize = 10;
+const IDX_RENT: usize = 11;
+
+/// Accounts for the `initialize_order` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct InitializeOrderAccounts {
+    pub base: Pubkey,
+    pub maker: Pubkey,
+    pub order: Pubkey,
+    pub reserve: Pubkey,
+    pub maker_input_account: Pubkey,
+    pub input_mint: Pubkey,
+    pub maker_output_account: Pubkey,
+    pub referral: Option<Pubkey>,
+    pub output_mint: Pubkey,
+    pub system_program: Pubkey,
+    pub token_program: Pubkey,
+    pub rent: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for InitializeOrderAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, a.0)
+        };
+        let get_opt = |index: usize| -> Option<Pubkey> { accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(InitializeOrderAccounts {
+            base: get_req(IDX_BASE, "base")?,
+            maker: get_req(IDX_MAKER, "maker")?,
+            order: get_req(IDX_ORDER, "order")?,
+            reserve: get_req(IDX_RESERVE, "reserve")?,
+            maker_input_account: get_req(IDX_MAKER_INPUT_ACCOUNT, "maker_input_account")?,
+            input_mint: get_req(IDX_INPUT_MINT, "input_mint")?,
+            maker_output_account: get_req(IDX_MAKER_OUTPUT_ACCOUNT, "maker_output_account")?,
+            referral: get_opt(IDX_REFERRAL),
+            output_mint: get_req(IDX_OUTPUT_MINT, "output_mint")?,
+            system_program: get_req(IDX_SYSTEM_PROGRAM, "system_program")?,
+            token_program: get_req(IDX_TOKEN_PROGRAM, "token_program")?,
+            rent: get_req(IDX_RENT, "rent")?,
+        })
+    }
+}
+
+pub fn get_initialize_order_accounts(ix: &InstructionView) -> Result<InitializeOrderAccounts, AccountsError> {
+    InitializeOrderAccounts::try_from(ix)
+}
+
+const IDX_FO_ORDER: usize = 0;
+const IDX_FO_RESERVE: usize = 1;
+const IDX_FO_MAKER: usize = 2;
+const IDX_FO_TAKER: usize = 3;
+const IDX_FO_TAKER_OUTPUT_ACCOUNT: usize = 4;
+const IDX_FO_MAKER_OUTPUT_ACCOUNT: usize = 5;
+const IDX_FO_TAKER_INPUT_ACCOUNT: usize = 6;
+const IDX_FO_FEE_AUTHORITY: usize = 7;
+const IDX_FO_PROGRAM_FEE_ACCOUNT: usize = 8;
+const IDX_FO_REFERRAL: usize = 9;
+const IDX_FO_TOKEN_PROGRAM: usize = 10;
+const IDX_FO_SYSTEM_PROGRAM: usize = 11;
+
+/// Accounts for the `fill_order` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct FillOrderAccounts {
+    pub order: Pubkey,
+    pub reserve: Pubkey,
+    pub maker: Pubkey,
+    pub taker: Pubkey,
+    pub taker_output_account: Pubkey,
+    pub maker_output_account: Pubkey,
+    pub taker_input_account: Pubkey,
+    pub fee_authority: Pubkey,
+    pub program_fee_account: Pubkey,
+    pub referral: Option<Pubkey>,
+    pub token_program: Pubkey,
+    pub system_program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for FillOrderAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, a.0)
+        };
+        let get_opt = |index: usize| -> Option<Pubkey> { accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(FillOrderAccounts {
+            order: get_req(IDX_FO_ORDER, "order")?,
+            reserve: get_req(IDX_FO_RESERVE, "reserve")?,
+            maker: get_req(IDX_FO_MAKER, "maker")?,
+            taker: get_req(IDX_FO_TAKER, "taker")?,
+            taker_output_account: get_req(IDX_FO_TAKER_OUTPUT_ACCOUNT, "taker_output_account")?,
+            maker_output_account: get_req(IDX_FO_MAKER_OUTPUT_ACCOUNT, "maker_output_account")?,
+            taker_input_account: get_req(IDX_FO_TAKER_INPUT_ACCOUNT, "taker_input_account")?,
+            fee_authority: get_req(IDX_FO_FEE_AUTHORITY, "fee_authority")?,
+            program_fee_account: get_req(IDX_FO_PROGRAM_FEE_ACCOUNT, "program_fee_account")?,
+            referral: get_opt(IDX_FO_REFERRAL),
+            token_program: get_req(IDX_FO_TOKEN_PROGRAM, "token_program")?,
+            system_program: get_req(IDX_FO_SYSTEM_PROGRAM, "system_program")?,
+        })
+    }
+}
+
+pub fn get_fill_order_accounts(ix: &InstructionView) -> Result<FillOrderAccounts, AccountsError> {
+    FillOrderAccounts::try_from(ix)
+}
+
+const IDX_FFL_ORDER: usize = 0;
+const IDX_FFL_RESERVE: usize = 1;
+const IDX_FFL_MAKER: usize = 2;
+const IDX_FFL_TAKER: usize = 3;
+const IDX_FFL_MAKER_OUTPUT_ACCOUNT: usize = 4;
+const IDX_FFL_TAKER_INPUT_ACCOUNT: usize = 5;
+const IDX_FFL_FEE_AUTHORITY: usize = 6;
+const IDX_FFL_PROGRAM_FEE_ACCOUNT: usize = 7;
+const IDX_FFL_REFERRAL: usize = 8;
+const IDX_FFL_INPUT_MINT: usize = 9;
+const IDX_FFL_INPUT_MINT_TOKEN_PROGRAM: usize = 10;
+const IDX_FFL_OUTPUT_MINT: usize = 11;
+const IDX_FFL_OUTPUT_MINT_TOKEN_PROGRAM: usize = 12;
+const IDX_FFL_SYSTEM_PROGRAM: usize = 13;
+
+/// Accounts for the `flash_fill_order` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct FlashFillOrderAccounts {
+    pub order: Pubkey,
+    pub reserve: Pubkey,
+    pub maker: Pubkey,
+    pub taker: Pubkey,
+    pub maker_output_account: Pubkey,
+    pub taker_input_account: Pubkey,
+    pub fee_authority: Pubkey,
+    pub program_fee_account: Pubkey,
+    pub referral: Option<Pubkey>,
+    pub input_mint: Pubkey,
+    pub input_mint_token_program: Pubkey,
+    pub output_mint: Pubkey,
+    pub output_mint_token_program: Pubkey,
+    pub system_program: Pubkey,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for FlashFillOrderAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, a.0)
+        };
+        let get_opt = |index: usize| -> Option<Pubkey> { accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(FlashFillOrderAccounts {
+            order: get_req(IDX_FFL_ORDER, "order")?,
+            reserve: get_req(IDX_FFL_RESERVE, "reserve")?,
+            maker: get_req(IDX_FFL_MAKER, "maker")?,
+            taker: get_req(IDX_FFL_TAKER, "taker")?,
+            maker_output_account: get_req(IDX_FFL_MAKER_OUTPUT_ACCOUNT, "maker_output_account")?,
+            taker_input_account: get_req(IDX_FFL_TAKER_INPUT_ACCOUNT, "taker_input_account")?,
+            fee_authority: get_req(IDX_FFL_FEE_AUTHORITY, "fee_authority")?,
+            program_fee_account: get_req(IDX_FFL_PROGRAM_FEE_ACCOUNT, "program_fee_account")?,
+            referral: get_opt(IDX_FFL_REFERRAL),
+            input_mint: get_req(IDX_FFL_INPUT_MINT, "input_mint")?,
+            input_mint_token_program: get_req(IDX_FFL_INPUT_MINT_TOKEN_PROGRAM, "input_mint_token_program")?,
+            output_mint: get_req(IDX_FFL_OUTPUT_MINT, "output_mint")?,
+            output_mint_token_program: get_req(IDX_FFL_OUTPUT_MINT_TOKEN_PROGRAM, "output_mint_token_program")?,
+            system_program: get_req(IDX_FFL_SYSTEM_PROGRAM, "system_program")?,
+        })
+    }
+}
+
+pub fn get_flash_fill_order_accounts(ix: &InstructionView) -> Result<FlashFillOrderAccounts, AccountsError> {
+    FlashFillOrderAccounts::try_from(ix)
+}
+
+const IDX_CO_ORDER: usize = 0;
+const IDX_CO_RESERVE: usize = 1;
+const IDX_CO_MAKER: usize = 2;
+const IDX_CO_MAKER_INPUT_ACCOUNT: usize = 3;
+const IDX_CO_SYSTEM_PROGRAM: usize = 4;
+const IDX_CO_TOKEN_PROGRAM: usize = 5;
+const IDX_CO_INPUT_MINT: usize = 6;
+
+/// Accounts for the `cancel_order` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CancelOrderAccounts {
+    pub order: Pubkey,
+    pub reserve: Pubkey,
+    pub maker: Pubkey,
+    pub maker_input_account: Pubkey,
+    pub system_program: Pubkey,
+    pub token_program: Pubkey,
+    pub input_mint: Option<Pubkey>,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for CancelOrderAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, a.0)
+        };
+        let get_opt = |index: usize| -> Option<Pubkey> { accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(CancelOrderAccounts {
+            order: get_req(IDX_CO_ORDER, "order")?,
+            reserve: get_req(IDX_CO_RESERVE, "reserve")?,
+            maker: get_req(IDX_CO_MAKER, "maker")?,
+            maker_input_account: get_req(IDX_CO_MAKER_INPUT_ACCOUNT, "maker_input_account")?,
+            system_program: get_req(IDX_CO_SYSTEM_PROGRAM, "system_program")?,
+            token_program: get_req(IDX_CO_TOKEN_PROGRAM, "token_program")?,
+            input_mint: get_opt(IDX_CO_INPUT_MINT),
+        })
+    }
+}
+
+pub fn get_cancel_order_accounts(ix: &InstructionView) -> Result<CancelOrderAccounts, AccountsError> {
+    CancelOrderAccounts::try_from(ix)
+}
+
+/// Accounts for the `cancel_expired_order` instruction.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CancelExpiredOrderAccounts {
+    pub order: Pubkey,
+    pub reserve: Pubkey,
+    pub maker: Pubkey,
+    pub maker_input_account: Pubkey,
+    pub system_program: Pubkey,
+    pub token_program: Pubkey,
+    pub input_mint: Option<Pubkey>,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for CancelExpiredOrderAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            to_pubkey(name, index, a.0)
+        };
+        let get_opt = |index: usize| -> Option<Pubkey> { accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+        Ok(CancelExpiredOrderAccounts {
+            order: get_req(IDX_CO_ORDER, "order")?,
+            reserve: get_req(IDX_CO_RESERVE, "reserve")?,
+            maker: get_req(IDX_CO_MAKER, "maker")?,
+            maker_input_account: get_req(IDX_CO_MAKER_INPUT_ACCOUNT, "maker_input_account")?,
+            system_program: get_req(IDX_CO_SYSTEM_PROGRAM, "system_program")?,
+            token_program: get_req(IDX_CO_TOKEN_PROGRAM, "token_program")?,
+            input_mint: get_opt(IDX_CO_INPUT_MINT),
+        })
+    }
+}
+
+pub fn get_cancel_expired_order_accounts(ix: &InstructionView) -> Result<CancelExpiredOrderAccounts, AccountsError> {
+    CancelExpiredOrderAccounts::try_from(ix)
+}

--- a/src/jupiter/limit_order/events.rs
+++ b/src/jupiter/limit_order/events.rs
@@ -1,0 +1,69 @@
+//! Jupiter Limit Order on-chain **events** and their Borsh-deserialisation helpers.
+
+use crate::ParseError;
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+use solana_program::pubkey::Pubkey;
+
+// -----------------------------------------------------------------------------
+// Discriminators (first 8 bytes of the emitted log’s data)
+// -----------------------------------------------------------------------------
+const CANCEL_ORDER_EVENT: [u8; 8] = [174, 66, 141, 17, 4, 224, 162, 77]; // ae428d1104e0a24d
+const CREATE_ORDER_EVENT: [u8; 8] = [49, 142, 72, 166, 230, 29, 84, 84]; // 318e48a6e61d5454
+
+// -----------------------------------------------------------------------------
+// High-level event enum (concise; rich docs live in each struct)
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum JupiterLimitOrderEvent {
+    /// Cancel order. See [`CancelOrderEvent`].
+    CancelOrder(CancelOrderEvent),
+    /// Create order. See [`CreateOrderEvent`].
+    CreateOrder(CreateOrderEvent),
+    /// Discriminator did not match any known event.
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Payload structs (inline field comments instead of tables)
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CancelOrderEvent {
+    pub order_key: Pubkey,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct CreateOrderEvent {
+    pub order_key: Pubkey,
+    pub maker: Pubkey,
+    pub input_mint: Pubkey,
+    pub output_mint: Pubkey,
+    pub in_amount: u64,
+    pub out_amount: u64,
+    pub expired_at: Option<i64>,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for JupiterLimitOrderEvent {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.len() < 16 {
+            return Err(ParseError::TooShort(data.len()));
+        }
+        let disc: [u8; 8] = data[0..8].try_into().expect("slice len 8");
+        let payload = &data[16..];
+        Ok(match disc {
+            CANCEL_ORDER_EVENT => Self::CancelOrder(CancelOrderEvent::try_from_slice(payload)?),
+            CREATE_ORDER_EVENT => Self::CreateOrder(CreateOrderEvent::try_from_slice(payload)?),
+            other => return Err(ParseError::Unknown(other)),
+        })
+    }
+}
+
+/// Convenience wrapper that forwards to `TryFrom`.
+pub fn unpack(data: &[u8]) -> Result<JupiterLimitOrderEvent, ParseError> {
+    JupiterLimitOrderEvent::try_from(data)
+}

--- a/src/jupiter/limit_order/instructions.rs
+++ b/src/jupiter/limit_order/instructions.rs
@@ -1,0 +1,114 @@
+//! Jupiter Limit Order on-chain instructions.
+
+use crate::ParseError;
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+
+// -----------------------------------------------------------------------------
+// Payload structs
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct InitializeOrderInstruction {
+    pub making_amount: u64,
+    pub taking_amount: u64,
+    pub expired_at: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct FillOrderInstruction {
+    pub making_amount: u64,
+    pub max_taking_amount: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct PreFlashFillOrderInstruction {
+    pub making_amount: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct FlashFillOrderInstruction {
+    pub max_taking_amount: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct WithdrawFeeInstruction {
+    pub amount: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct InitFeeInstruction {
+    pub maker_fee: u64,
+    pub maker_stable_fee: u64,
+    pub taker_fee: u64,
+    pub taker_stable_fee: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct UpdateFeeInstruction {
+    pub maker_fee: u64,
+    pub maker_stable_fee: u64,
+    pub taker_fee: u64,
+    pub taker_stable_fee: u64,
+}
+
+// -----------------------------------------------------------------------------
+// Discriminators
+// -----------------------------------------------------------------------------
+pub const INITIALIZE_ORDER: [u8; 8] = [133, 110, 74, 175, 112, 159, 245, 159];
+pub const FILL_ORDER: [u8; 8] = [232, 122, 115, 25, 199, 143, 136, 162];
+pub const PRE_FLASH_FILL_ORDER: [u8; 8] = [240, 47, 153, 68, 13, 190, 225, 42];
+pub const FLASH_FILL_ORDER: [u8; 8] = [252, 104, 18, 134, 164, 78, 18, 140];
+pub const CANCEL_ORDER: [u8; 8] = [95, 129, 237, 240, 8, 49, 223, 132];
+pub const CANCEL_EXPIRED_ORDER: [u8; 8] = [216, 120, 64, 235, 155, 19, 229, 99];
+pub const WITHDRAW_FEE: [u8; 8] = [14, 122, 231, 218, 31, 238, 223, 150];
+pub const INIT_FEE: [u8; 8] = [13, 9, 211, 107, 62, 172, 224, 67];
+pub const UPDATE_FEE: [u8; 8] = [232, 253, 195, 247, 148, 212, 73, 222];
+
+// -----------------------------------------------------------------------------
+// Instruction enumeration
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum JupiterLimitOrderInstruction {
+    InitializeOrder(InitializeOrderInstruction),
+    FillOrder(FillOrderInstruction),
+    PreFlashFillOrder(PreFlashFillOrderInstruction),
+    FlashFillOrder(FlashFillOrderInstruction),
+    CancelOrder,
+    CancelExpiredOrder,
+    WithdrawFee(WithdrawFeeInstruction),
+    InitFee(InitFeeInstruction),
+    UpdateFee(UpdateFeeInstruction),
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for JupiterLimitOrderInstruction {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.len() < 8 {
+            return Err(ParseError::TooShort(data.len()));
+        }
+        let (disc, payload) = data.split_at(8);
+        let discriminator: [u8; 8] = disc.try_into().expect("slice len 8");
+        Ok(match discriminator {
+            INITIALIZE_ORDER => Self::InitializeOrder(InitializeOrderInstruction::try_from_slice(payload)?),
+            FILL_ORDER => Self::FillOrder(FillOrderInstruction::try_from_slice(payload)?),
+            PRE_FLASH_FILL_ORDER => Self::PreFlashFillOrder(PreFlashFillOrderInstruction::try_from_slice(payload)?),
+            FLASH_FILL_ORDER => Self::FlashFillOrder(FlashFillOrderInstruction::try_from_slice(payload)?),
+            CANCEL_ORDER => Self::CancelOrder,
+            CANCEL_EXPIRED_ORDER => Self::CancelExpiredOrder,
+            WITHDRAW_FEE => Self::WithdrawFee(WithdrawFeeInstruction::try_from_slice(payload)?),
+            INIT_FEE => Self::InitFee(InitFeeInstruction::try_from_slice(payload)?),
+            UPDATE_FEE => Self::UpdateFee(UpdateFeeInstruction::try_from_slice(payload)?),
+            other => return Err(ParseError::Unknown(other)),
+        })
+    }
+}
+
+/// Convenience wrapper that forwards to `TryFrom`.
+pub fn unpack(data: &[u8]) -> Result<JupiterLimitOrderInstruction, ParseError> {
+    JupiterLimitOrderInstruction::try_from(data)
+}

--- a/src/jupiter/limit_order/mod.rs
+++ b/src/jupiter/limit_order/mod.rs
@@ -1,0 +1,9 @@
+use substreams_solana::b58;
+pub mod accounts;
+pub mod events;
+pub mod instructions;
+
+/// Jupiter Limit Order
+///
+/// https://solscan.io/account/jupoNjAxXgZ4rjzxzPMP4oxduvQsQtZzyknqvzYNrNu
+pub const PROGRAM_ID: [u8; 32] = b58!("jupoNjAxXgZ4rjzxzPMP4oxduvQsQtZzyknqvzYNrNu");

--- a/src/jupiter/mod.rs
+++ b/src/jupiter/mod.rs
@@ -1,2 +1,3 @@
+pub mod limit_order;
 pub mod v4;
 pub mod v6;


### PR DESCRIPTION
## Summary
- add Jupiter limit order module with instruction, account and event parsers
- expose program id `jupoNjAxXgZ4rjzxzPMP4oxduvQsQtZzyknqvzYNrNu`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_68c19db1450c83288a44c5667e74b103