### PR TITLE
Add Stabble weighted swap IDL

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod meteora;
 pub mod orca;
 pub mod pumpfun;
 pub mod raydium;
+pub mod stabble;
 
 use thiserror::Error;
 

--- a/src/stabble/accounts.rs
+++ b/src/stabble/accounts.rs
@@ -1,0 +1,98 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+use solana_program::pubkey::Pubkey;
+use substreams_solana::block_view::InstructionView;
+
+use crate::accounts;
+
+// -----------------------------------------------------------------------------
+// Deposit accounts
+// -----------------------------------------------------------------------------
+accounts!(
+    DepositAccounts,
+    get_deposit_accounts,
+    {
+        /// The user providing liquidity
+        user,
+        /// The user's pool token account
+        user_pool_token,
+        /// Pool token mint
+        mint,
+        /// Pool state account
+        pool,
+        /// Pool authority PDA
+        pool_authority,
+        /// Vault state account
+        vault,
+        /// Vault authority PDA
+        vault_authority,
+        /// SPL Token program
+        token_program,
+        /// SPL Token 2022 program
+        token_program_2022
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Withdraw accounts
+// -----------------------------------------------------------------------------
+accounts!(
+    WithdrawAccounts,
+    get_withdraw_accounts,
+    {
+        /// The user removing liquidity
+        user,
+        /// The user's pool token account
+        user_pool_token,
+        /// Pool token mint
+        mint,
+        /// Pool state account
+        pool,
+        /// Withdraw authority PDA
+        withdraw_authority,
+        /// Vault state account
+        vault,
+        /// Vault authority PDA
+        vault_authority,
+        /// Vault program id
+        vault_program,
+        /// SPL Token program
+        token_program,
+        /// SPL Token 2022 program
+        token_program_2022
+    }
+);
+
+// -----------------------------------------------------------------------------
+// Swap accounts
+// -----------------------------------------------------------------------------
+accounts!(
+    SwapAccounts,
+    get_swap_accounts,
+    {
+        /// The user performing the swap
+        user,
+        /// User token account for the input token
+        user_token_in,
+        /// User token account for the output token
+        user_token_out,
+        /// Pool vault for the input token
+        vault_token_in,
+        /// Pool vault for the output token
+        vault_token_out,
+        /// Beneficiary token account for fees
+        beneficiary_token_out,
+        /// Pool state account
+        pool,
+        /// Withdraw authority PDA
+        withdraw_authority,
+        /// Vault state account
+        vault,
+        /// Vault authority PDA
+        vault_authority,
+        /// Vault program id
+        vault_program,
+        /// SPL Token program
+        token_program
+    }
+);

--- a/src/stabble/events.rs
+++ b/src/stabble/events.rs
@@ -1,0 +1,76 @@
+//! Stabble swap events.
+
+use crate::ParseError;
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+use solana_program::pubkey::Pubkey;
+
+// -----------------------------------------------------------------------------
+// Discriminators
+// -----------------------------------------------------------------------------
+pub const POOL_BALANCE_UPDATED_EVENT: [u8; 8] = [172, 82, 114, 207, 27, 103, 211, 4];
+pub const POOL_UPDATED_EVENT: [u8; 8] = [128, 39, 94, 221, 230, 222, 127, 141];
+
+// -----------------------------------------------------------------------------
+// Event enumeration
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum StabbleEvent {
+    PoolBalanceUpdatedEvent(PoolBalanceUpdatedEvent),
+    PoolUpdatedEvent(PoolUpdatedEvent),
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Payload structs
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct PoolBalanceUpdatedEvent {
+    pub pubkey: Pubkey,
+    pub data: PoolBalanceUpdatedData,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct PoolBalanceUpdatedData {
+    pub balances: Vec<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct PoolUpdatedEvent {
+    pub pubkey: Pubkey,
+    pub data: PoolUpdatedData,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct PoolUpdatedData {
+    pub is_active: bool,
+    pub swap_fee: u64,
+    pub max_supply: u64,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for StabbleEvent {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.len() < 8 {
+            return Err(ParseError::TooShort(data.len()));
+        }
+
+        let (disc, payload) = data.split_at(8);
+        let discriminator: [u8; 8] = disc.try_into().expect("slice len 8");
+
+        Ok(match discriminator {
+            POOL_BALANCE_UPDATED_EVENT => Self::PoolBalanceUpdatedEvent(PoolBalanceUpdatedEvent::try_from_slice(payload)?),
+            POOL_UPDATED_EVENT => Self::PoolUpdatedEvent(PoolUpdatedEvent::try_from_slice(payload)?),
+            other => return Err(ParseError::Unknown(other)),
+        })
+    }
+}
+
+/// Convenience wrapper that forwards to `TryFrom`.
+pub fn unpack(data: &[u8]) -> Result<StabbleEvent, ParseError> {
+    StabbleEvent::try_from(data)
+}

--- a/src/stabble/instructions.rs
+++ b/src/stabble/instructions.rs
@@ -1,0 +1,75 @@
+//! Stabble swap instructions.
+
+use crate::ParseError;
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+
+// -----------------------------------------------------------------------------
+// Discriminators
+// -----------------------------------------------------------------------------
+pub const DEPOSIT: [u8; 8] = [242, 35, 198, 137, 82, 225, 242, 182];
+pub const WITHDRAW: [u8; 8] = [183, 18, 70, 156, 148, 109, 161, 34];
+pub const SWAP: [u8; 8] = [248, 198, 158, 145, 225, 117, 135, 200];
+
+// -----------------------------------------------------------------------------
+// Instruction enumeration
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum StabbleInstruction {
+    Deposit(DepositInstruction),
+    Withdraw(WithdrawInstruction),
+    Swap(SwapInstruction),
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Payload structs
+// -----------------------------------------------------------------------------
+/// Add liquidity to the pool.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct DepositInstruction {
+    pub amounts: Vec<u64>,
+    pub minimum_amount_out: u64,
+}
+
+/// Remove liquidity from the pool.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct WithdrawInstruction {
+    pub amount: u64,
+    pub minimum_amounts_out: Vec<u64>,
+}
+
+/// Swap tokens through the pool.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SwapInstruction {
+    pub amount_in: Option<u64>,
+    pub minimum_amount_out: u64,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for StabbleInstruction {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.len() < 8 {
+            return Err(ParseError::TooShort(data.len()));
+        }
+
+        let (disc, payload) = data.split_at(8);
+        let discriminator: [u8; 8] = disc.try_into().expect("slice len 8");
+
+        Ok(match discriminator {
+            DEPOSIT => Self::Deposit(DepositInstruction::try_from_slice(payload)?),
+            WITHDRAW => Self::Withdraw(WithdrawInstruction::try_from_slice(payload)?),
+            SWAP => Self::Swap(SwapInstruction::try_from_slice(payload)?),
+            other => return Err(ParseError::Unknown(other)),
+        })
+    }
+}
+
+/// Convenience wrapper that forwards to `TryFrom`.
+pub fn unpack(data: &[u8]) -> Result<StabbleInstruction, ParseError> {
+    StabbleInstruction::try_from(data)
+}

--- a/src/stabble/mod.rs
+++ b/src/stabble/mod.rs
@@ -1,0 +1,10 @@
+use substreams_solana::b58;
+
+pub mod accounts;
+pub mod events;
+pub mod instructions;
+
+/// Stabble weighted swap program
+///
+/// https://solscan.io/account/swapFpHZwjELNnjvThjajtiVmkz3yPQEHjLtka2fwHW
+pub const PROGRAM_ID: [u8; 32] = b58!("swapFpHZwjELNnjvThjajtiVmkz3yPQEHjLtka2fwHW");


### PR DESCRIPTION
## Summary
- add Stabble weighted swap instruction, account, and event parsers
- expose Stabble IDL module

## Testing
- `cargo test` *(fails: compilation hangs in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68c19d7be8f083289d8c2ee99d0e0e6f