### PR TITLE
chore: trim serialization dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,16 +121,11 @@ dependencies = [
 name = "bonkswap"
 version = "0.1.0"
 dependencies = [
- "base64 0.22.1",
  "borsh 1.5.7",
  "idls-common",
- "serde",
- "serde-big-array",
- "serde_json",
  "solana-program",
  "substreams",
  "substreams-solana",
- "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -529,12 +524,7 @@ name = "idls-common"
 version = "0.1.0"
 dependencies = [
  "borsh 1.5.7",
- "serde",
- "serde-big-array",
- "serde_json",
  "solana-program",
- "substreams",
- "substreams-solana",
  "thiserror 2.0.16",
 ]
 
@@ -558,12 +548,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
-
-[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,16 +561,11 @@ dependencies = [
 name = "jupiter"
 version = "0.1.0"
 dependencies = [
- "base64 0.22.1",
  "borsh 1.5.7",
  "idls-common",
- "serde",
- "serde-big-array",
- "serde_json",
  "solana-program",
  "substreams",
  "substreams-solana",
- "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -697,16 +676,11 @@ dependencies = [
 name = "meteora"
 version = "0.1.0"
 dependencies = [
- "base64 0.22.1",
  "borsh 1.5.7",
  "idls-common",
- "serde",
- "serde-big-array",
- "serde_json",
  "solana-program",
  "substreams",
  "substreams-solana",
- "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -791,16 +765,11 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 name = "orca"
 version = "0.1.0"
 dependencies = [
- "base64 0.22.1",
  "borsh 1.5.7",
  "idls-common",
- "serde",
- "serde-big-array",
- "serde_json",
  "solana-program",
  "substreams",
  "substreams-solana",
- "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -893,32 +862,22 @@ dependencies = [
 name = "phoenix"
 version = "0.1.0"
 dependencies = [
- "base64 0.22.1",
  "borsh 1.5.7",
  "idls-common",
- "serde",
- "serde-big-array",
- "serde_json",
  "solana-program",
  "substreams",
  "substreams-solana",
- "thiserror 2.0.16",
 ]
 
 [[package]]
 name = "phonenix"
 version = "0.1.0"
 dependencies = [
- "base64 0.22.1",
  "borsh 1.5.7",
  "idls-common",
- "serde",
- "serde-big-array",
- "serde_json",
  "solana-program",
  "substreams",
  "substreams-solana",
- "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -1023,16 +982,11 @@ dependencies = [
 name = "pumpfun"
 version = "0.1.0"
 dependencies = [
- "base64 0.22.1",
  "borsh 1.5.7",
  "idls-common",
- "serde",
- "serde-big-array",
- "serde_json",
  "solana-program",
  "substreams",
  "substreams-solana",
- "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -1128,13 +1082,9 @@ dependencies = [
  "base64 0.22.1",
  "borsh 1.5.7",
  "idls-common",
- "serde",
- "serde-big-array",
- "serde_json",
  "solana-program",
  "substreams",
  "substreams-solana",
- "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -1204,12 +1154,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1231,15 +1175,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-big-array"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_bytes"
 version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1257,18 +1192,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.143"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
-dependencies = [
- "itoa",
- "memchr",
- "ryu",
- "serde",
 ]
 
 [[package]]
@@ -2114,16 +2037,11 @@ dependencies = [
 name = "stabble"
 version = "0.1.0"
 dependencies = [
- "base64 0.22.1",
  "borsh 1.5.7",
  "idls-common",
- "serde",
- "serde-big-array",
- "serde_json",
  "solana-program",
  "substreams",
  "substreams-solana",
- "thiserror 2.0.16",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,5 @@ substreams = "0.6.2"
 substreams-solana = "0.14.1"
 solana-program = "2.3.0"
 borsh = { version = "1.5.7", features = ["derive"] }
-serde = { version = "1.0.215", features = ["derive"] }
-serde_json = "1.0.143"
 thiserror = "2.0.16"
-serde-big-array = "0.5"
 base64 = "0.22.1"

--- a/README.md
+++ b/README.md
@@ -88,6 +88,6 @@ Swap `pumpfun` for any supported protocol and you get the same ergonomic API.
 
 * Add a new folder under `src/<protocol>` with `instructions.rs`, `events.rs`, and `mod.rs`.
 * Follow existing modules for structure & doc style.
-* Keep dependencies minimal (`borsh`, `serde`, `solana_program` only).
+* Keep dependencies minimal (`borsh`, `solana_program` only).
 
 PRs and issues welcome!

--- a/packages/bonkswap/Cargo.toml
+++ b/packages/bonkswap/Cargo.toml
@@ -9,10 +9,4 @@ substreams = { workspace = true }
 substreams-solana = { workspace = true }
 solana-program = { workspace = true }
 borsh = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
-thiserror = { workspace = true }
-serde-big-array = { workspace = true }
 
-[dev-dependencies]
-base64 = { workspace = true }

--- a/packages/bonkswap/src/accounts.rs
+++ b/packages/bonkswap/src/accounts.rs
@@ -1,5 +1,4 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 use substreams_solana::block_view::InstructionView;
 
@@ -27,7 +26,7 @@ const IDX_TOKEN_PROGRAM: usize = 14;
 const IDX_ASSOCIATED_TOKEN_PROGRAM: usize = 15;
 const IDX_RENT: usize = 16;
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapAccounts {
     pub state: Pubkey,
     pub pool: Pubkey,

--- a/packages/bonkswap/src/instructions.rs
+++ b/packages/bonkswap/src/instructions.rs
@@ -2,17 +2,16 @@
 
 use idls_common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 
 // -----------------------------------------------------------------------------
 // Custom types
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct FixedPoint {
     pub v: u128,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct Token {
     pub v: u64,
 }
@@ -43,7 +42,7 @@ pub const UPDATE_REWARD_TOKENS: [u8; 8] = [156, 68, 147, 116, 29, 57, 159, 114];
 // -----------------------------------------------------------------------------
 // Instruction enumeration
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BonkSwapInstruction {
     CreatePool(CreatePoolInstruction),
     CreateProvider(CreateProviderInstruction),
@@ -70,7 +69,7 @@ pub enum BonkSwapInstruction {
 // -----------------------------------------------------------------------------
 // Payload structs
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreatePoolInstruction {
     pub lp_fee: FixedPoint,
     pub buyback_fee: FixedPoint,
@@ -81,44 +80,44 @@ pub struct CreatePoolInstruction {
     pub bump: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreateProviderInstruction {
     pub token_x_amount: Token,
     pub token_y_amount: Token,
     pub bump: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreateStateInstruction {
     pub nonce: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AddTokensInstruction {
     pub delta_x: Token,
     pub delta_y: Token,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapInstruction {
     pub delta_in: Token,
     pub price_limit: FixedPoint,
     pub x_to_y: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct WithdrawSharesInstruction {
     pub shares: Token,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreateFarmInstruction {
     pub supply: Token,
     pub duration: u64,
     pub bump: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreateDualFarmInstruction {
     pub supply_marco: Token,
     pub supply_project_first: Token,
@@ -126,7 +125,7 @@ pub struct CreateDualFarmInstruction {
     pub bump: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreateTripleFarmInstruction {
     pub supply_marco: Token,
     pub supply_project_first: Token,
@@ -135,7 +134,7 @@ pub struct CreateTripleFarmInstruction {
     pub bump: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AddSupplyInstruction {
     pub supply_marco: Token,
     pub supply_project_first: Token,
@@ -143,7 +142,7 @@ pub struct AddSupplyInstruction {
     pub duration: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct UpdateFeesInstruction {
     pub new_buyback_fee: FixedPoint,
     pub new_project_fee: FixedPoint,

--- a/packages/common/Cargo.toml
+++ b/packages/common/Cargo.toml
@@ -6,9 +6,4 @@ edition = "2021"
 [dependencies]
 thiserror = { workspace = true }
 borsh = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
 solana-program = { workspace = true }
-substreams = { workspace = true }
-substreams-solana = { workspace = true }
-serde-big-array = { workspace = true }

--- a/packages/common/src/accounts.rs
+++ b/packages/common/src/accounts.rs
@@ -24,7 +24,7 @@ pub fn to_pubkey(name: &'static str, index: usize, bytes: &[u8]) -> Result<Pubke
 #[macro_export]
 macro_rules! accounts {
     ($name:ident, $getter:ident, { $( $(#[$doc:meta])* $field:ident ),+ $(,)? }) => {
-        #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+        #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
         pub struct $name {
             $( $(#[$doc])* pub $field: Pubkey,)+
         }

--- a/packages/jupiter/Cargo.toml
+++ b/packages/jupiter/Cargo.toml
@@ -9,10 +9,4 @@ substreams = { workspace = true }
 substreams-solana = { workspace = true }
 solana-program = { workspace = true }
 borsh = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
-thiserror = { workspace = true }
-serde-big-array = { workspace = true }
 
-[dev-dependencies]
-base64 = { workspace = true }

--- a/packages/jupiter/src/dca/accounts.rs
+++ b/packages/jupiter/src/dca/accounts.rs
@@ -1,5 +1,4 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 use substreams_solana::block_view::InstructionView;
 
@@ -191,7 +190,7 @@ const IDX_WD_EVENT_AUTHORITY: usize = 10;
 const IDX_WD_PROGRAM: usize = 11;
 
 /// Accounts for the `withdraw` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct WithdrawAccounts {
     pub user: Pubkey,
     pub dca: Pubkey,
@@ -252,7 +251,7 @@ const IDX_TR_EVENT_AUTHORITY: usize = 10;
 const IDX_TR_PROGRAM: usize = 11;
 
 /// Accounts for the `transfer` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct TransferAccounts {
     pub keeper: Pubkey,
     pub dca: Pubkey,
@@ -316,7 +315,7 @@ const IDX_EC_EVENT_AUTHORITY: usize = 13;
 const IDX_EC_PROGRAM: usize = 14;
 
 /// Accounts for the `end_and_close` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct EndAndCloseAccounts {
     pub keeper: Pubkey,
     pub dca: Pubkey,

--- a/packages/jupiter/src/dca/events.rs
+++ b/packages/jupiter/src/dca/events.rs
@@ -2,7 +2,6 @@
 
 use idls_common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
 // -----------------------------------------------------------------------------
@@ -18,7 +17,7 @@ const DEPOSIT: [u8; 8] = [62, 205, 242, 175, 244, 169, 136, 52];
 // -----------------------------------------------------------------------------
 // High-level event enum
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum JupiterDcaEvent {
     CollectedFee(CollectedFeeEvent),
     Filled(FilledEvent),
@@ -32,7 +31,7 @@ pub enum JupiterDcaEvent {
 // -----------------------------------------------------------------------------
 // Payload structs
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CollectedFeeEvent {
     pub user_key: Pubkey,
     pub dca_key: Pubkey,
@@ -40,7 +39,7 @@ pub struct CollectedFeeEvent {
     pub amount: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct FilledEvent {
     pub user_key: Pubkey,
     pub dca_key: Pubkey,
@@ -52,7 +51,7 @@ pub struct FilledEvent {
     pub fee: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct OpenedEvent {
     pub user_key: Pubkey,
     pub dca_key: Pubkey,
@@ -64,7 +63,7 @@ pub struct OpenedEvent {
     pub created_at: i64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ClosedEvent {
     pub user_key: Pubkey,
     pub dca_key: Pubkey,
@@ -80,7 +79,7 @@ pub struct ClosedEvent {
     pub user_closed: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct WithdrawEvent {
     pub dca_key: Pubkey,
     pub in_amount: u64,
@@ -88,7 +87,7 @@ pub struct WithdrawEvent {
     pub user_withdraw: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct DepositEvent {
     pub dca_key: Pubkey,
     pub amount: u64,

--- a/packages/jupiter/src/dca/instructions.rs
+++ b/packages/jupiter/src/dca/instructions.rs
@@ -2,18 +2,17 @@
 
 use idls_common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 
 // -----------------------------------------------------------------------------
 // Custom types
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct WithdrawParams {
     pub withdraw_amount: u64,
     pub withdrawal: Withdrawal,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum Withdrawal {
     In,
     Out,
@@ -22,7 +21,7 @@ pub enum Withdrawal {
 // -----------------------------------------------------------------------------
 // Payload structs
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct OpenDcaInstruction {
     pub application_idx: u64,
     pub in_amount: u64,
@@ -34,7 +33,7 @@ pub struct OpenDcaInstruction {
     pub close_wsol_in_ata: Option<bool>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct OpenDcaV2Instruction {
     pub application_idx: u64,
     pub in_amount: u64,
@@ -45,27 +44,27 @@ pub struct OpenDcaV2Instruction {
     pub start_at: Option<i64>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct WithdrawInstruction {
     pub withdraw_params: WithdrawParams,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct DepositInstruction {
     pub deposit_in: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct WithdrawFeesInstruction {
     pub amount: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct FulfillFlashFillInstruction {
     pub repay_amount: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct FulfillDlmmFillInstruction {
     pub repay_amount: u64,
 }
@@ -89,7 +88,7 @@ pub const END_AND_CLOSE: [u8; 8] = [83, 125, 166, 69, 247, 252, 103, 133];
 // -----------------------------------------------------------------------------
 // High-level instruction enum
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum JupiterDcaInstruction {
     OpenDca(OpenDcaInstruction),
     OpenDcaV2(OpenDcaV2Instruction),

--- a/packages/jupiter/src/limit_order/accounts.rs
+++ b/packages/jupiter/src/limit_order/accounts.rs
@@ -1,5 +1,4 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 use substreams_solana::block_view::InstructionView;
 
@@ -49,7 +48,7 @@ const IDX_TOKEN_PROGRAM: usize = 10;
 const IDX_RENT: usize = 11;
 
 /// Accounts for the `initialize_order` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeOrderAccounts {
     pub base: Pubkey,
     pub maker: Pubkey,
@@ -110,7 +109,7 @@ const IDX_FO_TOKEN_PROGRAM: usize = 10;
 const IDX_FO_SYSTEM_PROGRAM: usize = 11;
 
 /// Accounts for the `fill_order` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct FillOrderAccounts {
     pub order: Pubkey,
     pub reserve: Pubkey,
@@ -173,7 +172,7 @@ const IDX_FFL_OUTPUT_MINT_TOKEN_PROGRAM: usize = 12;
 const IDX_FFL_SYSTEM_PROGRAM: usize = 13;
 
 /// Accounts for the `flash_fill_order` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct FlashFillOrderAccounts {
     pub order: Pubkey,
     pub reserve: Pubkey,
@@ -233,7 +232,7 @@ const IDX_CO_TOKEN_PROGRAM: usize = 5;
 const IDX_CO_INPUT_MINT: usize = 6;
 
 /// Accounts for the `cancel_order` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CancelOrderAccounts {
     pub order: Pubkey,
     pub reserve: Pubkey,
@@ -271,7 +270,7 @@ pub fn get_cancel_order_accounts(ix: &InstructionView) -> Result<CancelOrderAcco
 }
 
 /// Accounts for the `cancel_expired_order` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CancelExpiredOrderAccounts {
     pub order: Pubkey,
     pub reserve: Pubkey,

--- a/packages/jupiter/src/limit_order/events.rs
+++ b/packages/jupiter/src/limit_order/events.rs
@@ -2,7 +2,6 @@
 
 use idls_common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
 // -----------------------------------------------------------------------------
@@ -14,7 +13,7 @@ const CREATE_ORDER_EVENT: [u8; 8] = [49, 142, 72, 166, 230, 29, 84, 84]; // 318e
 // -----------------------------------------------------------------------------
 // High-level event enum (concise; rich docs live in each struct)
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum JupiterLimitOrderEvent {
     /// Cancel order. See [`CancelOrderEvent`].
     CancelOrder(CancelOrderEvent),
@@ -27,12 +26,12 @@ pub enum JupiterLimitOrderEvent {
 // -----------------------------------------------------------------------------
 // Payload structs (inline field comments instead of tables)
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CancelOrderEvent {
     pub order_key: Pubkey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreateOrderEvent {
     pub order_key: Pubkey,
     pub maker: Pubkey,

--- a/packages/jupiter/src/limit_order/instructions.rs
+++ b/packages/jupiter/src/limit_order/instructions.rs
@@ -2,40 +2,39 @@
 
 use idls_common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 
 // -----------------------------------------------------------------------------
 // Payload structs
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeOrderInstruction {
     pub making_amount: u64,
     pub taking_amount: u64,
     pub expired_at: Option<i64>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct FillOrderInstruction {
     pub making_amount: u64,
     pub max_taking_amount: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct PreFlashFillOrderInstruction {
     pub making_amount: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct FlashFillOrderInstruction {
     pub max_taking_amount: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct WithdrawFeeInstruction {
     pub amount: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitFeeInstruction {
     pub maker_fee: u64,
     pub maker_stable_fee: u64,
@@ -43,7 +42,7 @@ pub struct InitFeeInstruction {
     pub taker_stable_fee: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct UpdateFeeInstruction {
     pub maker_fee: u64,
     pub maker_stable_fee: u64,
@@ -67,7 +66,7 @@ pub const UPDATE_FEE: [u8; 8] = [232, 253, 195, 247, 148, 212, 73, 222];
 // -----------------------------------------------------------------------------
 // Instruction enumeration
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum JupiterLimitOrderInstruction {
     InitializeOrder(InitializeOrderInstruction),
     FillOrder(FillOrderInstruction),

--- a/packages/jupiter/src/v4/accounts.rs
+++ b/packages/jupiter/src/v4/accounts.rs
@@ -1,5 +1,4 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 use substreams_solana::block_view::InstructionView;
 

--- a/packages/jupiter/src/v4/events.rs
+++ b/packages/jupiter/src/v4/events.rs
@@ -2,7 +2,6 @@
 
 use idls_common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
 // -----------------------------------------------------------------------------
@@ -14,7 +13,7 @@ const FEE: [u8; 8] = [6, 220, 131, 59, 240, 71, 51, 96];
 // -----------------------------------------------------------------------------
 // High-level event enum (concise; rich docs live in each struct)
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum JupiterV4Event {
     /// Swap. See [`SwapEvent`].
     Swap(SwapEvent),
@@ -27,7 +26,7 @@ pub enum JupiterV4Event {
 // -----------------------------------------------------------------------------
 // Payload structs (inline field comments instead of tables)
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapEvent {
     pub amm: Pubkey,
     pub input_mint: Pubkey,
@@ -36,7 +35,7 @@ pub struct SwapEvent {
     pub output_amount: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct FeeEvent {
     pub account: Pubkey,
     pub mint: Pubkey,

--- a/packages/jupiter/src/v4/instructions.rs
+++ b/packages/jupiter/src/v4/instructions.rs
@@ -2,53 +2,52 @@
 
 use idls_common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AmountWithSlippage {
     pub amount: u64,
     pub slippage_bps: u16,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SplitLegDeeper {
     pub percent: u8,
     pub swap_leg: SwapLegSwap,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SplitLeg {
     pub percent: u8,
     pub swap_leg: SwapLegDeeper,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum Side {
     Bid,
     Ask,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum SwapLegSwap {
     PlaceholderOne,
     PlaceholderTwo,
     Swap { swap: Swap },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum SwapLegDeeper {
     Chain { swap_legs: Vec<SwapLegSwap> },
     Split { split_legs: Vec<SplitLegDeeper> },
     Swap { swap: Swap },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum SwapLeg {
     Chain { swap_legs: Vec<SwapLegDeeper> },
     Split { split_legs: Vec<SplitLeg> },
     Swap { swap: Swap },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum Swap {
     Saber,
     SaberAddDecimalsDeposit,
@@ -89,7 +88,7 @@ pub const ROUTE: [u8; 8] = [229, 23, 203, 151, 122, 227, 173, 42];
 // -----------------------------------------------------------------------------
 // Instruction enumeration
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum JupiterV4Instruction {
     Route(RouteInstruction),
     Whirlpoolswapexactoutput(WhirlpoolswapexactoutputInstruction),
@@ -131,7 +130,7 @@ pub enum JupiterV4Instruction {
 // -----------------------------------------------------------------------------
 // Payload structs
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct RouteInstruction {
     pub swap_leg: SwapLeg,
     pub in_amount: u64,
@@ -140,7 +139,7 @@ pub struct RouteInstruction {
     pub platform_fee_bps: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct WhirlpoolswapexactoutputInstruction {
     pub out_amount: u64,
     pub in_amount_with_slippage: AmountWithSlippage,
@@ -148,14 +147,14 @@ pub struct WhirlpoolswapexactoutputInstruction {
     pub platform_fee_bps: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct RaydiumswapexactoutputInstruction {
     pub out_amount: u64,
     pub in_amount_with_slippage: AmountWithSlippage,
     pub platform_fee_bps: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct RaydiumclmmswapexactoutputInstruction {
     pub out_amount: u64,
     pub in_amount_with_slippage: AmountWithSlippage,

--- a/packages/jupiter/src/v6/accounts.rs
+++ b/packages/jupiter/src/v6/accounts.rs
@@ -1,5 +1,4 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 use substreams_solana::block_view::InstructionView;
 
@@ -72,7 +71,7 @@ const IDX_EVENT_AUTHORITY: usize = 9;
 const IDX_PROGRAM: usize = 10;
 
 /// Accounts for the `exact_out_route` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ExactOutRouteAccounts {
     pub token_program: Pubkey,
     pub user_transfer_authority: Pubkey,
@@ -128,7 +127,7 @@ const IDX_RT_EVENT_AUTHORITY: usize = 7;
 const IDX_RT_PROGRAM: usize = 8;
 
 /// Accounts for the `route` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct RouteAccounts {
     pub token_program: Pubkey,
     pub user_transfer_authority: Pubkey,
@@ -181,7 +180,7 @@ const IDX_RTL_EVENT_AUTHORITY: usize = 8;
 const IDX_RTL_PROGRAM: usize = 9;
 
 /// Accounts for the `route_with_token_ledger` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct RouteWithTokenLedgerAccounts {
     pub token_program: Pubkey,
     pub user_transfer_authority: Pubkey,
@@ -239,7 +238,7 @@ const IDX_SA_EVENT_AUTHORITY: usize = 11;
 const IDX_SA_PROGRAM: usize = 12;
 
 /// Accounts for the `shared_accounts_exact_out_route` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SharedAccountsExactOutRouteAccounts {
     pub token_program: Pubkey,
     pub program_authority: Pubkey,
@@ -289,7 +288,7 @@ pub fn get_shared_accounts_exact_out_route_accounts(ix: &InstructionView) -> Res
 }
 
 /// Accounts for the `shared_accounts_route` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SharedAccountsRouteAccounts {
     pub token_program: Pubkey,
     pub program_authority: Pubkey,
@@ -341,7 +340,7 @@ pub fn get_shared_accounts_route_accounts(ix: &InstructionView) -> Result<Shared
 const IDX_SAL_TOKEN_LEDGER: usize = 11; // for with_token_ledger variant, before event_authority
 
 /// Accounts for the `shared_accounts_route_with_token_ledger` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SharedAccountsRouteWithTokenLedgerAccounts {
     pub token_program: Pubkey,
     pub program_authority: Pubkey,

--- a/packages/jupiter/src/v6/events.rs
+++ b/packages/jupiter/src/v6/events.rs
@@ -2,7 +2,6 @@
 
 use idls_common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
 // -----------------------------------------------------------------------------
@@ -15,7 +14,7 @@ const SWAP_FEE_LEN: usize = 72;
 // -----------------------------------------------------------------------------
 // High-level event enum (concise; rich docs live in each struct)
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum JupiterV6Event {
     /// Swap. See [`SwapEvent`].
     Swap(SwapEvent),
@@ -31,7 +30,7 @@ pub enum JupiterV6Event {
 // -----------------------------------------------------------------------------
 
 /// Emitted once Swap is executed.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapEvent {
     pub amm: Pubkey,
     pub input_mint: Pubkey,
@@ -41,7 +40,7 @@ pub struct SwapEvent {
 }
 
 /// Emitted once Fee is collected.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct FeeEvent {
     pub account: Pubkey,
     pub mint: Pubkey,

--- a/packages/jupiter/src/v6/instructions.rs
+++ b/packages/jupiter/src/v6/instructions.rs
@@ -2,39 +2,38 @@
 
 use idls_common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 
 // -----------------------------------------------------------------------------
 // Payload structs
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ClaimInstruction {
     pub id: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ClaimTokenInstruction {
     pub id: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CloseTokenInstruction {
     pub id: u8,
     pub burn_all: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreateProgramOpenOrdersInstruction {
     pub id: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreateTokenAccountInstruction {
     pub bump: u8,
 }
 
 /// Route by using program owned token accounts and open orders accounts.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SharedAccountsExactOutRouteInstruction {
     pub id: u8,
     /// Raw remaining instruction data (route plan and amounts).
@@ -42,14 +41,14 @@ pub struct SharedAccountsExactOutRouteInstruction {
 }
 
 /// Route by using program owned token accounts and open orders accounts.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SharedAccountsRouteInstruction {
     pub id: u8,
     /// Raw remaining instruction data (route plan and amounts).
     pub data: Vec<u8>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SharedAccountsRouteWithTokenLedgerInstruction {
     pub id: u8,
     /// Raw remaining instruction data (route plan and amounts).
@@ -57,18 +56,18 @@ pub struct SharedAccountsRouteWithTokenLedgerInstruction {
 }
 
 /// `route_plan` Topologically sorted trade DAG
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RouteInstruction {
     pub data: Vec<u8>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExactOutRouteInstruction {
     /// Raw route plan and arguments.
     pub data: Vec<u8>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RouteWithTokenLedgerInstruction {
     /// Raw route plan and arguments.
     pub data: Vec<u8>,
@@ -95,7 +94,7 @@ pub const SHARED_ACCOUNTS_ROUTE_WITH_TOKEN_LEDGER: [u8; 8] = [230, 121, 143, 80,
 // -----------------------------------------------------------------------------
 // Instruction enumeration
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum JupiterV6Instruction {
     Claim(ClaimInstruction),
     ClaimToken(ClaimTokenInstruction),

--- a/packages/meteora/Cargo.toml
+++ b/packages/meteora/Cargo.toml
@@ -9,10 +9,4 @@ substreams = { workspace = true }
 substreams-solana = { workspace = true }
 solana-program = { workspace = true }
 borsh = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
-thiserror = { workspace = true }
-serde-big-array = { workspace = true }
 
-[dev-dependencies]
-base64 = { workspace = true }

--- a/packages/meteora/src/amm/accounts.rs
+++ b/packages/meteora/src/amm/accounts.rs
@@ -1,5 +1,4 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 use substreams_solana::block_view::InstructionView;
 
@@ -9,7 +8,7 @@ use idls_common::accounts::AccountsError;
 // Accounts structs
 // -----------------------------------------------------------------------------
 /// Initialize a new permissioned pool.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializePermissionedPoolAccounts {
     /// Pool account (arbitrary address)
     pub pool: Pubkey,
@@ -101,7 +100,7 @@ pub fn get_initialize_permissioned_pool_accounts(ix: &InstructionView) -> Result
 }
 
 /// Initialize a new permissionless pool.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializePermissionlessPoolAccounts {
     /// Pool account (PDA address)
     pub pool: Pubkey,
@@ -197,7 +196,7 @@ pub fn get_initialize_permissionless_pool_accounts(ix: &InstructionView) -> Resu
 }
 
 /// Initialize a new permissionless pool with customized fee tier
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializePermissionlessPoolWithFeeTierAccounts {
     /// Pool account (PDA address)
     pub pool: Pubkey,
@@ -295,7 +294,7 @@ pub fn get_initialize_permissionless_pool_with_fee_tier_accounts(
 }
 
 /// Enable or disable a pool. A disabled pool allow only remove balanced liquidity operation.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct EnableOrDisablePoolAccounts {
     /// Pool account (PDA)
     pub pool: Pubkey,
@@ -323,7 +322,7 @@ pub fn get_enable_or_disable_pool_accounts(ix: &InstructionView) -> Result<Enabl
 }
 
 /// Swap token A to B, or vice versa. An amount of trading fee will be charged for liquidity provider, and the admin of the pool.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapAccounts {
     /// Pool account (PDA)
     pub pool: Pubkey,
@@ -390,7 +389,7 @@ pub fn get_swap_accounts(ix: &InstructionView) -> Result<SwapAccounts, AccountsE
 }
 
 /// Withdraw only single token from the pool. Only supported by pool with stable swap curve.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct RemoveLiquiditySingleSideAccounts {
     /// Pool account (PDA)
     pub pool: Pubkey,
@@ -457,7 +456,7 @@ pub fn get_remove_liquidity_single_side_accounts(ix: &InstructionView) -> Result
 }
 
 /// Deposit tokens to the pool in an imbalance ratio. Only supported by pool with stable swap curve.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AddImbalanceLiquidityAccounts {
     /// Pool account (PDA)
     pub pool: Pubkey,
@@ -527,7 +526,7 @@ pub fn get_add_imbalance_liquidity_accounts(ix: &InstructionView) -> Result<AddI
 }
 
 /// Withdraw tokens from the pool in a balanced ratio. User will still able to withdraw from pool even the pool is disabled. This allow user to exit their liquidity when there's some unforeseen event happen.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct RemoveBalanceLiquidityAccounts {
     /// Pool account (PDA)
     pub pool: Pubkey,
@@ -597,7 +596,7 @@ pub fn get_remove_balance_liquidity_accounts(ix: &InstructionView) -> Result<Rem
 }
 
 /// Deposit tokens to the pool in a balanced ratio.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AddBalanceLiquidityAccounts {
     /// Pool account (PDA)
     pub pool: Pubkey,
@@ -667,7 +666,7 @@ pub fn get_add_balance_liquidity_accounts(ix: &InstructionView) -> Result<AddBal
 }
 
 /// Update trading fee charged for liquidity provider, and admin.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SetPoolFeesAccounts {
     /// Pool account (PDA)
     pub pool: Pubkey,
@@ -696,7 +695,7 @@ pub fn get_set_pool_fees_accounts(ix: &InstructionView) -> Result<SetPoolFeesAcc
 
 /// Update swap curve parameters. This function do not allow update of curve type. For example: stable swap curve to constant product curve. Only supported by pool with stable swap curve.
 /// Only amp is allowed to be override. The other attributes of stable swap curve will be ignored.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct OverrideCurveParamAccounts {
     /// Pool account (PDA)
     pub pool: Pubkey,
@@ -724,7 +723,7 @@ pub fn get_override_curve_param_accounts(ix: &InstructionView) -> Result<Overrid
 }
 
 /// Get the general information of the pool.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct GetPoolInfoAccounts {
     /// Pool account (PDA)
     pub pool: Pubkey,
@@ -770,7 +769,7 @@ pub fn get_get_pool_info_accounts(ix: &InstructionView) -> Result<GetPoolInfoAcc
 }
 
 /// Bootstrap the pool when liquidity is depleted.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct BootstrapLiquidityAccounts {
     /// Pool account (PDA)
     pub pool: Pubkey,
@@ -840,7 +839,7 @@ pub fn get_bootstrap_liquidity_accounts(ix: &InstructionView) -> Result<Bootstra
 }
 
 /// Create mint metadata account for old pools
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreateMintMetadataAccounts {
     /// Pool account
     pub pool: Pubkey,
@@ -881,7 +880,7 @@ pub fn get_create_mint_metadata_accounts(ix: &InstructionView) -> Result<CreateM
 }
 
 /// Create lock account
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreateLockEscrowAccounts {
     /// Pool account
     pub pool: Pubkey,
@@ -920,7 +919,7 @@ pub fn get_create_lock_escrow_accounts(ix: &InstructionView) -> Result<CreateLoc
 }
 
 /// Lock Lp token
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct LockAccounts {
     /// Pool account
     pub pool: Pubkey,
@@ -981,7 +980,7 @@ pub fn get_lock_accounts(ix: &InstructionView) -> Result<LockAccounts, AccountsE
 }
 
 /// Claim fee
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ClaimFeeAccounts {
     /// Pool account
     pub pool: Pubkey,
@@ -1057,7 +1056,7 @@ pub fn get_claim_fee_accounts(ix: &InstructionView) -> Result<ClaimFeeAccounts, 
 }
 
 /// Create config
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreateConfigAccounts {
     pub config: Pubkey,
     pub admin: Pubkey,
@@ -1085,7 +1084,7 @@ pub fn get_create_config_accounts(ix: &InstructionView) -> Result<CreateConfigAc
 }
 
 /// Close config
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CloseConfigAccounts {
     pub config: Pubkey,
     pub admin: Pubkey,
@@ -1113,7 +1112,7 @@ pub fn get_close_config_accounts(ix: &InstructionView) -> Result<CloseConfigAcco
 }
 
 /// Initialize permissionless pool with config
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializePermissionlessConstantProductPoolWithConfigAccounts {
     /// Pool account (PDA address)
     pub pool: Pubkey,
@@ -1211,7 +1210,7 @@ pub fn get_initialize_permissionless_constant_product_pool_with_config_accounts(
 }
 
 /// Initialize permissionless pool with config 2
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializePermissionlessConstantProductPoolWithConfig2Accounts {
     /// Pool account (PDA address)
     pub pool: Pubkey,
@@ -1309,7 +1308,7 @@ pub fn get_initialize_permissionless_constant_product_pool_with_config2_accounts
 }
 
 /// Initialize permissionless pool with customizable params
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeCustomizablePermissionlessConstantProductPoolAccounts {
     /// Pool account (PDA address)
     pub pool: Pubkey,
@@ -1405,7 +1404,7 @@ pub fn get_initialize_customizable_permissionless_constant_product_pool_accounts
 }
 
 /// Update activation slot
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct UpdateActivationPointAccounts {
     /// Pool account (PDA)
     pub pool: Pubkey,
@@ -1433,7 +1432,7 @@ pub fn get_update_activation_point_accounts(ix: &InstructionView) -> Result<Upda
 }
 
 /// Withdraw protocol fee
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct WithdrawProtocolFeesAccounts {
     /// Pool account (PDA)
     pub pool: Pubkey,
@@ -1470,7 +1469,7 @@ pub fn get_withdraw_protocol_fees_accounts(ix: &InstructionView) -> Result<Withd
 }
 
 /// Set whitelisted vault
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SetWhitelistedVaultAccounts {
     pub pool: Pubkey,
     pub admin: Pubkey,
@@ -1496,7 +1495,7 @@ pub fn get_set_whitelisted_vault_accounts(ix: &InstructionView) -> Result<SetWhi
 }
 
 /// Partner claim fee
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct PartnerClaimFeeAccounts {
     /// Pool account (PDA)
     pub pool: Pubkey,

--- a/packages/meteora/src/amm/events.rs
+++ b/packages/meteora/src/amm/events.rs
@@ -2,12 +2,10 @@
 
 use idls_common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
-use serde_big_array::BigArray;
 use solana_program::pubkey::Pubkey;
 
 /// Multiplier for the pool token. Used to normalized token with different decimal into the same precision.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct TokenMultiplier {
     /// Multiplier for token A of the pool.
     pub token_a_multiplier: u64,
@@ -18,7 +16,7 @@ pub struct TokenMultiplier {
 }
 
 /// Information regarding fee charges
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct PoolFees {
     /// Trade fees are extra token amounts that are held inside the token
     /// accounts during a trade, making the value of liquidity tokens rise.
@@ -36,7 +34,7 @@ pub struct PoolFees {
 }
 
 /// Contains information for depeg pool
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct Depeg {
     /// The virtual price of staking / interest bearing token
     pub base_virtual_price: u64,
@@ -46,7 +44,7 @@ pub struct Depeg {
     pub depeg_type: DepegType,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ConfigParameters {
     pub trade_fee_numerator: u64,
     pub protocol_trade_fee_numerator: u64,
@@ -58,7 +56,7 @@ pub struct ConfigParameters {
     pub partner_fee_numerator: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CustomizableParams {
     /// Trading fee.
     pub trade_fee_numerator: u32,
@@ -69,12 +67,11 @@ pub struct CustomizableParams {
     /// Activation type
     pub activation_type: u8,
     /// Padding
-    #[serde(with = "BigArray")]
     pub padding: [u8; 90],
 }
 
 /// Padding for future pool fields
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct Padding {
     /// Padding 0
     pub padding0: [u8; 6],
@@ -84,7 +81,7 @@ pub struct Padding {
     pub padding2: [u64; 21],
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct PartnerInfo {
     pub fee_numerator: u64,
     pub partner_authority: Pubkey,
@@ -92,7 +89,7 @@ pub struct PartnerInfo {
     pub pending_fee_b: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct Bootstrapping {
     /// Activation point, can be slot or timestamp
     pub activation_point: u64,
@@ -105,28 +102,28 @@ pub struct Bootstrapping {
 }
 
 /// Type of the activation
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum ActivationType {
     Slot,
     Timestamp,
 }
 
 /// Rounding direction
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum RoundDirection {
     Floor,
     Ceiling,
 }
 
 /// Trade (swap) direction
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum TradeDirection {
     AtoB,
     BtoA,
 }
 
 /// Type of the swap curve
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum NewCurveType {
     ConstantProduct,
     Stable {
@@ -146,7 +143,7 @@ pub enum NewCurveType {
 }
 
 /// Type of the swap curve
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum CurveType {
     ConstantProduct,
     Stable {
@@ -162,7 +159,7 @@ pub enum CurveType {
 }
 
 /// Type of depeg pool
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum DepegType {
     None,
     Marinade,
@@ -171,14 +168,14 @@ pub enum DepegType {
 }
 
 /// Round up, down
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum Rounding {
     Up,
     Down,
 }
 
 /// Pool type
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum PoolType {
     Permissioned,
     Permissionless,
@@ -206,7 +203,7 @@ const CLOSE_CONFIG: [u8; 8] = [249, 181, 108, 89, 4, 150, 90, 174];
 const WITHDRAW_PROTOCOL_FEES: [u8; 8] = [30, 240, 207, 196, 139, 239, 79, 28];
 const PARTNER_CLAIM_FEES: [u8; 8] = [135, 131, 10, 94, 119, 209, 202, 48];
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum AmmEvent {
     AddLiquidity(AddLiquidity),
     RemoveLiquidity(RemoveLiquidity),
@@ -229,21 +226,21 @@ pub enum AmmEvent {
     Unknown,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AddLiquidity {
     pub lp_mint_amount: u64,
     pub token_a_amount: u64,
     pub token_b_amount: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct RemoveLiquidity {
     pub lp_unmint_amount: u64,
     pub token_a_out_amount: u64,
     pub token_b_out_amount: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct BootstrapLiquidity {
     pub lp_mint_amount: u64,
     pub token_a_amount: u64,
@@ -251,7 +248,7 @@ pub struct BootstrapLiquidity {
     pub pool: Pubkey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct Swap {
     pub in_amount: u64,
     pub out_amount: u64,
@@ -260,7 +257,7 @@ pub struct Swap {
     pub host_fee: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SetPoolFees {
     pub trade_fee_numerator: u64,
     pub trade_fee_denominator: u64,
@@ -269,7 +266,7 @@ pub struct SetPoolFees {
     pub pool: Pubkey,
 }
 
-#[derive(Debug, Clone, PartialEq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, BorshSerialize, BorshDeserialize)]
 pub struct PoolInfo {
     pub token_a_amount: u64,
     pub token_b_amount: u64,
@@ -277,21 +274,21 @@ pub struct PoolInfo {
     pub current_timestamp: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct TransferAdmin {
     pub admin: Pubkey,
     pub new_admin: Pubkey,
     pub pool: Pubkey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct OverrideCurveParam {
     pub new_amp: u64,
     pub updated_timestamp: u64,
     pub pool: Pubkey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct PoolCreated {
     pub lp_mint: Pubkey,
     pub token_a_mint: Pubkey,
@@ -300,13 +297,13 @@ pub struct PoolCreated {
     pub pool: Pubkey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct PoolEnabled {
     pub pool: Pubkey,
     pub enabled: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct MigrateFeeAccount {
     pub pool: Pubkey,
     pub new_admin_token_a_fee: Pubkey,
@@ -315,20 +312,20 @@ pub struct MigrateFeeAccount {
     pub token_b_amount: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreateLockEscrow {
     pub pool: Pubkey,
     pub owner: Pubkey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct Lock {
     pub pool: Pubkey,
     pub owner: Pubkey,
     pub amount: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ClaimFee {
     pub pool: Pubkey,
     pub owner: Pubkey,
@@ -337,19 +334,19 @@ pub struct ClaimFee {
     pub b_fee: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreateConfig {
     pub trade_fee_numerator: u64,
     pub protocol_trade_fee_numerator: u64,
     pub config: Pubkey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CloseConfig {
     pub config: Pubkey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct WithdrawProtocolFees {
     pub pool: Pubkey,
     pub protocol_a_fee: u64,
@@ -358,7 +355,7 @@ pub struct WithdrawProtocolFees {
     pub protocol_b_fee_owner: Pubkey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct PartnerClaimFees {
     pub pool: Pubkey,
     pub fee_a: u64,

--- a/packages/meteora/src/amm/instructions.rs
+++ b/packages/meteora/src/amm/instructions.rs
@@ -2,12 +2,10 @@
 
 use idls_common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
-use serde_big_array::BigArray;
 use solana_program::pubkey::Pubkey;
 
 /// Multiplier for the pool token. Used to normalized token with different decimal into the same precision.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct TokenMultiplier {
     /// Multiplier for token A of the pool.
     pub token_a_multiplier: u64,
@@ -18,7 +16,7 @@ pub struct TokenMultiplier {
 }
 
 /// Information regarding fee charges
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct PoolFees {
     /// Trade fees are extra token amounts that are held inside the token
     /// accounts during a trade, making the value of liquidity tokens rise.
@@ -36,7 +34,7 @@ pub struct PoolFees {
 }
 
 /// Contains information for depeg pool
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct Depeg {
     /// The virtual price of staking / interest bearing token
     pub base_virtual_price: u64,
@@ -46,7 +44,7 @@ pub struct Depeg {
     pub depeg_type: DepegType,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ConfigParameters {
     pub trade_fee_numerator: u64,
     pub protocol_trade_fee_numerator: u64,
@@ -58,7 +56,7 @@ pub struct ConfigParameters {
     pub partner_fee_numerator: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CustomizableParams {
     /// Trading fee.
     pub trade_fee_numerator: u32,
@@ -69,12 +67,11 @@ pub struct CustomizableParams {
     /// Activation type
     pub activation_type: u8,
     /// Padding
-    #[serde(with = "BigArray")]
     pub padding: [u8; 90],
 }
 
 /// Padding for future pool fields
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct Padding {
     /// Padding 0
     pub padding0: [u8; 6],
@@ -84,7 +81,7 @@ pub struct Padding {
     pub padding2: [u64; 21],
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct PartnerInfo {
     pub fee_numerator: u64,
     pub partner_authority: Pubkey,
@@ -92,7 +89,7 @@ pub struct PartnerInfo {
     pub pending_fee_b: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct Bootstrapping {
     /// Activation point, can be slot or timestamp
     pub activation_point: u64,
@@ -105,28 +102,28 @@ pub struct Bootstrapping {
 }
 
 /// Type of the activation
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum ActivationType {
     Slot,
     Timestamp,
 }
 
 /// Rounding direction
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum RoundDirection {
     Floor,
     Ceiling,
 }
 
 /// Trade (swap) direction
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum TradeDirection {
     AtoB,
     BtoA,
 }
 
 /// Type of the swap curve
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum NewCurveType {
     ConstantProduct,
     Stable {
@@ -146,7 +143,7 @@ pub enum NewCurveType {
 }
 
 /// Type of the swap curve
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum CurveType {
     ConstantProduct,
     Stable {
@@ -162,7 +159,7 @@ pub enum CurveType {
 }
 
 /// Type of depeg pool
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum DepegType {
     None,
     Marinade,
@@ -171,14 +168,14 @@ pub enum DepegType {
 }
 
 /// Round up, down
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum Rounding {
     Up,
     Down,
 }
 
 /// Pool type
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum PoolType {
     Permissioned,
     Permissionless,
@@ -217,7 +214,7 @@ pub const PARTNER_CLAIM_FEE: [u8; 8] = [62, 78, 142, 207, 84, 95, 7, 227];
 // -----------------------------------------------------------------------------
 // Instruction enumeration
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AmmInstruction {
     InitializePermissionedPool(InitializePermissionedPoolInstruction),
     InitializePermissionlessPool(InitializePermissionlessPoolInstruction),
@@ -252,13 +249,13 @@ pub enum AmmInstruction {
 // Payload structs
 // -----------------------------------------------------------------------------
 /// Initialize a new permissioned pool.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializePermissionedPoolInstruction {
     pub curve_type: CurveType,
 }
 
 /// Initialize a new permissionless pool.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializePermissionlessPoolInstruction {
     pub curve_type: CurveType,
     pub token_a_amount: u64,
@@ -266,7 +263,7 @@ pub struct InitializePermissionlessPoolInstruction {
 }
 
 /// Initialize a new permissionless pool with customized fee tier
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializePermissionlessPoolWithFeeTierInstruction {
     pub curve_type: CurveType,
     pub trade_fee_bps: u64,
@@ -275,27 +272,27 @@ pub struct InitializePermissionlessPoolWithFeeTierInstruction {
 }
 
 /// Enable or disable a pool. A disabled pool allow only remove balanced liquidity operation.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct EnableOrDisablePoolInstruction {
     pub enable: bool,
 }
 
 /// Swap token A to B, or vice versa. An amount of trading fee will be charged for liquidity provider, and the admin of the pool.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapInstruction {
     pub in_amount: u64,
     pub minimum_out_amount: u64,
 }
 
 /// Withdraw only single token from the pool. Only supported by pool with stable swap curve.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct RemoveLiquiditySingleSideInstruction {
     pub pool_token_amount: u64,
     pub minimum_out_amount: u64,
 }
 
 /// Deposit tokens to the pool in an imbalance ratio. Only supported by pool with stable swap curve.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AddImbalanceLiquidityInstruction {
     pub minimum_pool_token_amount: u64,
     pub token_a_amount: u64,
@@ -303,7 +300,7 @@ pub struct AddImbalanceLiquidityInstruction {
 }
 
 /// Withdraw tokens from the pool in a balanced ratio. User will still able to withdraw from pool even the pool is disabled. This allow user to exit their liquidity when there's some unforeseen event happen.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct RemoveBalanceLiquidityInstruction {
     pub pool_token_amount: u64,
     pub minimum_a_token_out: u64,
@@ -311,7 +308,7 @@ pub struct RemoveBalanceLiquidityInstruction {
 }
 
 /// Deposit tokens to the pool in a balanced ratio.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AddBalanceLiquidityInstruction {
     pub pool_token_amount: u64,
     pub maximum_token_a_amount: u64,
@@ -319,7 +316,7 @@ pub struct AddBalanceLiquidityInstruction {
 }
 
 /// Update trading fee charged for liquidity provider, and admin.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SetPoolFeesInstruction {
     pub fees: PoolFees,
     pub new_partner_fee_numerator: u64,
@@ -327,45 +324,45 @@ pub struct SetPoolFeesInstruction {
 
 /// Update swap curve parameters. This function do not allow update of curve type. For example: stable swap curve to constant product curve. Only supported by pool with stable swap curve.
 /// Only amp is allowed to be override. The other attributes of stable swap curve will be ignored.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct OverrideCurveParamInstruction {
     pub curve_type: CurveType,
 }
 
 /// Bootstrap the pool when liquidity is depleted.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct BootstrapLiquidityInstruction {
     pub token_a_amount: u64,
     pub token_b_amount: u64,
 }
 
 /// Lock Lp token
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct LockInstruction {
     pub max_amount: u64,
 }
 
 /// Claim fee
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ClaimFeeInstruction {
     pub max_amount: u64,
 }
 
 /// Create config
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreateConfigInstruction {
     pub config_parameters: ConfigParameters,
 }
 
 /// Initialize permissionless pool with config
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializePermissionlessConstantProductPoolWithConfigInstruction {
     pub token_a_amount: u64,
     pub token_b_amount: u64,
 }
 
 /// Initialize permissionless pool with config 2
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializePermissionlessConstantProductPoolWithConfig2Instruction {
     pub token_a_amount: u64,
     pub token_b_amount: u64,
@@ -373,7 +370,7 @@ pub struct InitializePermissionlessConstantProductPoolWithConfig2Instruction {
 }
 
 /// Initialize permissionless pool with customizable params
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeCustomizablePermissionlessConstantProductPoolInstruction {
     pub token_a_amount: u64,
     pub token_b_amount: u64,
@@ -381,19 +378,19 @@ pub struct InitializeCustomizablePermissionlessConstantProductPoolInstruction {
 }
 
 /// Update activation slot
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct UpdateActivationPointInstruction {
     pub new_activation_point: u64,
 }
 
 /// Set whitelisted vault
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SetWhitelistedVaultInstruction {
     pub whitelisted_vault: Pubkey,
 }
 
 /// Partner claim fee
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct PartnerClaimFeeInstruction {
     pub max_amount_a: u64,
     pub max_amount_b: u64,

--- a/packages/meteora/src/daam/accounts.rs
+++ b/packages/meteora/src/daam/accounts.rs
@@ -1,5 +1,4 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 use substreams_solana::block_view::InstructionView;
 
@@ -9,7 +8,7 @@ use idls_common::accounts::AccountsError;
 // AddLiquidity accounts
 // -----------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AddLiquidityAccounts {
     pub pool: Pubkey,
     pub position: Pubkey,
@@ -87,7 +86,7 @@ pub fn get_add_liquidity_accounts(ix: &InstructionView) -> Result<AddLiquidityAc
 // ClaimPartnerFee accounts
 // -----------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ClaimPartnerFeeAccounts {
     pub pool_authority: Pubkey,
     pub pool: Pubkey,
@@ -160,7 +159,7 @@ pub fn get_claim_partner_fee_accounts(ix: &InstructionView) -> Result<ClaimPartn
 // ClaimPositionFee accounts
 // -----------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ClaimPositionFeeAccounts {
     pub pool_authority: Pubkey,
     pub pool: Pubkey,
@@ -241,7 +240,7 @@ pub fn get_claim_position_fee_accounts(ix: &InstructionView) -> Result<ClaimPosi
 // ClaimProtocolFee accounts
 // -----------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ClaimProtocolFeeAccounts {
     pub pool_authority: Pubkey,
     pub pool: Pubkey,
@@ -319,7 +318,7 @@ pub fn get_claim_protocol_fee_accounts(ix: &InstructionView) -> Result<ClaimProt
 // ClaimReward accounts
 // -----------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ClaimRewardAccounts {
     pub pool_authority: Pubkey,
     pub pool: Pubkey,
@@ -381,7 +380,7 @@ pub fn get_claim_reward_accounts(ix: &InstructionView) -> Result<ClaimRewardAcco
 // CloseClaimFeeOperator accounts
 // -----------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CloseClaimFeeOperatorAccounts {
     pub claim_fee_operator: Pubkey,
     pub rent_receiver: Pubkey,
@@ -422,7 +421,7 @@ pub fn get_close_claim_fee_operator_accounts(ix: &InstructionView) -> Result<Clo
 // CloseConfig accounts
 // -----------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CloseConfigAccounts {
     pub config: Pubkey,
     pub admin: Pubkey,
@@ -463,7 +462,7 @@ pub fn get_close_config_accounts(ix: &InstructionView) -> Result<CloseConfigAcco
 // ClosePosition accounts
 // -----------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ClosePositionAccounts {
     /// position_nft_mint
     pub position_nft_mint: Pubkey,
@@ -523,7 +522,7 @@ pub fn get_close_position_accounts(ix: &InstructionView) -> Result<ClosePosition
 // CloseTokenBadge accounts
 // -----------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CloseTokenBadgeAccounts {
     pub token_badge: Pubkey,
     pub admin: Pubkey,
@@ -564,7 +563,7 @@ pub fn get_close_token_badge_accounts(ix: &InstructionView) -> Result<CloseToken
 // CreateClaimFeeOperator accounts
 // -----------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreateClaimFeeOperatorAccounts {
     pub claim_fee_operator: Pubkey,
     pub operator: Pubkey,
@@ -608,7 +607,7 @@ pub fn get_create_claim_fee_operator_accounts(ix: &InstructionView) -> Result<Cr
 // CreateConfig accounts
 // -----------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreateConfigAccounts {
     pub config: Pubkey,
     pub admin: Pubkey,
@@ -649,7 +648,7 @@ pub fn get_create_config_accounts(ix: &InstructionView) -> Result<CreateConfigAc
 // CreateDynamicConfig accounts
 // -----------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreateDynamicConfigAccounts {
     pub config: Pubkey,
     pub admin: Pubkey,
@@ -690,7 +689,7 @@ pub fn get_create_dynamic_config_accounts(ix: &InstructionView) -> Result<Create
 // CreatePosition accounts
 // -----------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreatePositionAccounts {
     pub owner: Pubkey,
     /// position_nft_mint
@@ -753,7 +752,7 @@ pub fn get_create_position_accounts(ix: &InstructionView) -> Result<CreatePositi
 // CreateTokenBadge accounts
 // -----------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreateTokenBadgeAccounts {
     pub token_badge: Pubkey,
     pub token_mint: Pubkey,
@@ -797,7 +796,7 @@ pub fn get_create_token_badge_accounts(ix: &InstructionView) -> Result<CreateTok
 // FundReward accounts
 // -----------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct FundRewardAccounts {
     pub pool: Pubkey,
     pub reward_vault: Pubkey,
@@ -847,7 +846,7 @@ pub fn get_fund_reward_accounts(ix: &InstructionView) -> Result<FundRewardAccoun
 // InitializeCustomizablePool accounts
 // -----------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeCustomizablePoolAccounts {
     pub creator: Pubkey,
     /// position_nft_mint
@@ -943,7 +942,7 @@ pub fn get_initialize_customizable_pool_accounts(ix: &InstructionView) -> Result
 // InitializePool accounts
 // -----------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializePoolAccounts {
     pub creator: Pubkey,
     /// position_nft_mint
@@ -1043,7 +1042,7 @@ pub fn get_initialize_pool_accounts(ix: &InstructionView) -> Result<InitializePo
 // InitializePoolWithDynamicConfig accounts
 // -----------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializePoolWithDynamicConfigAccounts {
     pub creator: Pubkey,
     /// position_nft_mint
@@ -1146,7 +1145,7 @@ pub fn get_initialize_pool_with_dynamic_config_accounts(ix: &InstructionView) ->
 // InitializeReward accounts
 // -----------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeRewardAccounts {
     pub pool_authority: Pubkey,
     pub pool: Pubkey,
@@ -1202,7 +1201,7 @@ pub fn get_initialize_reward_accounts(ix: &InstructionView) -> Result<Initialize
 // LockPosition accounts
 // -----------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct LockPositionAccounts {
     pub pool: Pubkey,
     pub position: Pubkey,
@@ -1257,7 +1256,7 @@ pub fn get_lock_position_accounts(ix: &InstructionView) -> Result<LockPositionAc
 // PermanentLockPosition accounts
 // -----------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct PermanentLockPositionAccounts {
     pub pool: Pubkey,
     pub position: Pubkey,
@@ -1303,7 +1302,7 @@ pub fn get_permanent_lock_position_accounts(ix: &InstructionView) -> Result<Perm
 // RefreshVesting accounts
 // -----------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct RefreshVestingAccounts {
     pub pool: Pubkey,
     pub position: Pubkey,
@@ -1342,7 +1341,7 @@ pub fn get_refresh_vesting_accounts(ix: &InstructionView) -> Result<RefreshVesti
 // RemoveAllLiquidity accounts
 // -----------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct RemoveAllLiquidityAccounts {
     pub pool_authority: Pubkey,
     pub pool: Pubkey,
@@ -1423,7 +1422,7 @@ pub fn get_remove_all_liquidity_accounts(ix: &InstructionView) -> Result<RemoveA
 // RemoveLiquidity accounts
 // -----------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct RemoveLiquidityAccounts {
     pub pool_authority: Pubkey,
     pub pool: Pubkey,
@@ -1504,7 +1503,7 @@ pub fn get_remove_liquidity_accounts(ix: &InstructionView) -> Result<RemoveLiqui
 // SetPoolStatus accounts
 // -----------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SetPoolStatusAccounts {
     pub pool: Pubkey,
     pub admin: Pubkey,
@@ -1542,7 +1541,7 @@ pub fn get_set_pool_status_accounts(ix: &InstructionView) -> Result<SetPoolStatu
 // SplitPosition accounts
 // -----------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SplitPositionAccounts {
     pub pool: Pubkey,
     /// The first position
@@ -1601,7 +1600,7 @@ pub fn get_split_position_accounts(ix: &InstructionView) -> Result<SplitPosition
 // Swap accounts
 // -----------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapAccounts {
     pub pool_authority: Pubkey,
     /// Pool account
@@ -1681,7 +1680,7 @@ pub fn get_swap_accounts(ix: &InstructionView) -> Result<SwapAccounts, AccountsE
 // UpdateRewardDuration accounts
 // -----------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct UpdateRewardDurationAccounts {
     pub pool: Pubkey,
     pub signer: Pubkey,
@@ -1719,7 +1718,7 @@ pub fn get_update_reward_duration_accounts(ix: &InstructionView) -> Result<Updat
 // UpdateRewardFunder accounts
 // -----------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct UpdateRewardFunderAccounts {
     pub pool: Pubkey,
     pub signer: Pubkey,
@@ -1757,7 +1756,7 @@ pub fn get_update_reward_funder_accounts(ix: &InstructionView) -> Result<UpdateR
 // WithdrawIneligibleReward accounts
 // -----------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct WithdrawIneligibleRewardAccounts {
     pub pool_authority: Pubkey,
     pub pool: Pubkey,

--- a/packages/meteora/src/daam/events.rs
+++ b/packages/meteora/src/daam/events.rs
@@ -6,7 +6,6 @@ use super::instructions::{
 };
 use idls_common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
 // -----------------------------------------------------------------------------
@@ -42,7 +41,7 @@ const ANCHOR_DISC: [u8; 8] = [0xe4, 0x45, 0xa5, 0x2e, 0x51, 0xcb, 0x9a, 0x1d];
 // -----------------------------------------------------------------------------
 // Event enumeration
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MeteoraDammEvent {
     EvtAddLiquidity(EvtAddLiquidity),
     EvtClaimPartnerFee(EvtClaimPartnerFee),
@@ -75,7 +74,7 @@ pub enum MeteoraDammEvent {
 // -----------------------------------------------------------------------------
 // Payload structs
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct EvtAddLiquidity {
     pub pool: Pubkey,
     pub position: Pubkey,
@@ -87,14 +86,14 @@ pub struct EvtAddLiquidity {
     pub total_amount_b: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct EvtClaimPartnerFee {
     pub pool: Pubkey,
     pub token_a_amount: u64,
     pub token_b_amount: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct EvtClaimPositionFee {
     pub pool: Pubkey,
     pub position: Pubkey,
@@ -103,14 +102,14 @@ pub struct EvtClaimPositionFee {
     pub fee_b_claimed: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct EvtClaimProtocolFee {
     pub pool: Pubkey,
     pub token_a_amount: u64,
     pub token_b_amount: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct EvtClaimReward {
     pub pool: Pubkey,
     pub position: Pubkey,
@@ -120,13 +119,13 @@ pub struct EvtClaimReward {
     pub total_reward: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct EvtCloseClaimFeeOperator {
     pub claim_fee_operator: Pubkey,
     pub operator: Pubkey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct EvtCloseConfig {
     /// Config pubkey
     pub config: Pubkey,
@@ -134,7 +133,7 @@ pub struct EvtCloseConfig {
     pub admin: Pubkey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct EvtClosePosition {
     pub pool: Pubkey,
     pub owner: Pubkey,
@@ -142,12 +141,12 @@ pub struct EvtClosePosition {
     pub position_nft_mint: Pubkey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct EvtCreateClaimFeeOperator {
     pub operator: Pubkey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct EvtCreateConfig {
     pub pool_fees: PoolFeeParameters,
     pub vault_config_key: Pubkey,
@@ -160,14 +159,14 @@ pub struct EvtCreateConfig {
     pub config: Pubkey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct EvtCreateDynamicConfig {
     pub config: Pubkey,
     pub pool_creator_authority: Pubkey,
     pub index: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct EvtCreatePosition {
     pub pool: Pubkey,
     pub owner: Pubkey,
@@ -175,12 +174,12 @@ pub struct EvtCreatePosition {
     pub position_nft_mint: Pubkey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct EvtCreateTokenBadge {
     pub token_mint: Pubkey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct EvtFundReward {
     pub pool: Pubkey,
     pub funder: Pubkey,
@@ -193,7 +192,7 @@ pub struct EvtFundReward {
     pub post_reward_rate: u128,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct EvtInitializePool {
     pub pool: Pubkey,
     pub token_a_mint: Pubkey,
@@ -218,7 +217,7 @@ pub struct EvtInitializePool {
     pub pool_type: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct EvtInitializeReward {
     pub pool: Pubkey,
     pub reward_mint: Pubkey,
@@ -228,7 +227,7 @@ pub struct EvtInitializeReward {
     pub reward_duration: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct EvtLockPosition {
     pub pool: Pubkey,
     pub position: Pubkey,
@@ -241,7 +240,7 @@ pub struct EvtLockPosition {
     pub number_of_period: u16,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct EvtPermanentLockPosition {
     pub pool: Pubkey,
     pub position: Pubkey,
@@ -249,7 +248,7 @@ pub struct EvtPermanentLockPosition {
     pub total_permanent_locked_liquidity: u128,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct EvtRemoveLiquidity {
     pub pool: Pubkey,
     pub position: Pubkey,
@@ -259,13 +258,13 @@ pub struct EvtRemoveLiquidity {
     pub token_b_amount: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct EvtSetPoolStatus {
     pub pool: Pubkey,
     pub status: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct EvtSplitPosition {
     pub pool: Pubkey,
     pub first_owner: Pubkey,
@@ -279,7 +278,7 @@ pub struct EvtSplitPosition {
     pub split_position_parameters: SplitPositionParameters,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct EvtSwap {
     pub pool: Pubkey,
     pub trade_direction: u8,
@@ -290,7 +289,7 @@ pub struct EvtSwap {
     pub current_timestamp: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct EvtUpdateRewardDuration {
     pub pool: Pubkey,
     pub reward_index: u8,
@@ -298,7 +297,7 @@ pub struct EvtUpdateRewardDuration {
     pub new_reward_duration: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct EvtUpdateRewardFunder {
     pub pool: Pubkey,
     pub reward_index: u8,
@@ -306,7 +305,7 @@ pub struct EvtUpdateRewardFunder {
     pub new_funder: Pubkey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct EvtWithdrawIneligibleReward {
     pub pool: Pubkey,
     pub reward_mint: Pubkey,

--- a/packages/meteora/src/daam/instructions.rs
+++ b/packages/meteora/src/daam/instructions.rs
@@ -2,13 +2,12 @@
 
 use idls_common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
 // -----------------------------------------------------------------------------
 // Custom types
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AddLiquidityParameters {
     /// delta liquidity
     pub liquidity_delta: u128,
@@ -18,7 +17,7 @@ pub struct AddLiquidityParameters {
     pub token_b_amount_threshold: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct BaseFeeParameters {
     pub cliff_fee_numerator: u64,
     pub number_of_period: u16,
@@ -27,12 +26,12 @@ pub struct BaseFeeParameters {
     pub fee_scheduler_mode: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct DynamicConfigParameters {
     pub pool_creator_authority: Pubkey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct DynamicFeeParameters {
     pub bin_step: u16,
     pub bin_step_u128: u128,
@@ -43,7 +42,7 @@ pub struct DynamicFeeParameters {
     pub variable_fee_control: u32,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeCustomizablePoolParameters {
     /// pool fees
     pub pool_fees: PoolFeeParameters,
@@ -65,7 +64,7 @@ pub struct InitializeCustomizablePoolParameters {
     pub activation_point: Option<u64>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializePoolParameters {
     /// initialize liquidity
     pub liquidity: u128,
@@ -75,7 +74,7 @@ pub struct InitializePoolParameters {
     pub activation_point: Option<u64>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct PoolFeeParameters {
     /// Base fee
     pub base_fee: BaseFeeParameters,
@@ -85,7 +84,7 @@ pub struct PoolFeeParameters {
     pub dynamic_fee: Option<DynamicFeeParameters>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct RemoveLiquidityParameters {
     /// delta liquidity
     pub liquidity_delta: u128,
@@ -95,7 +94,7 @@ pub struct RemoveLiquidityParameters {
     pub token_b_amount_threshold: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SplitAmountInfo {
     pub permanent_locked_liquidity: u128,
     pub unlocked_liquidity: u128,
@@ -105,7 +104,7 @@ pub struct SplitAmountInfo {
     pub reward_1: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SplitPositionInfo {
     pub liquidity: u128,
     pub fee_a: u64,
@@ -114,7 +113,7 @@ pub struct SplitPositionInfo {
     pub reward_1: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SplitPositionParameters {
     /// Percentage of unlocked liquidity to split to the second position
     pub unlocked_liquidity_percentage: u8,
@@ -132,7 +131,7 @@ pub struct SplitPositionParameters {
     pub padding: [u8; 16],
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct StaticConfigParameters {
     pub pool_fees: PoolFeeParameters,
     pub sqrt_min_price: u128,
@@ -143,13 +142,13 @@ pub struct StaticConfigParameters {
     pub collect_fee_mode: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapParameters {
     pub amount_in: u64,
     pub minimum_amount_out: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapResult {
     pub output_amount: u64,
     pub next_sqrt_price: u128,
@@ -159,7 +158,7 @@ pub struct SwapResult {
     pub referral_fee: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct VestingParameters {
     pub cliff_point: Option<u64>,
     pub period_frequency: u64,
@@ -205,7 +204,7 @@ pub const WITHDRAW_INELIGIBLE_REWARD: [u8; 8] = [148, 206, 42, 195, 247, 49, 103
 // -----------------------------------------------------------------------------
 // Instruction enumeration
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MeteoraDammInstruction {
     AddLiquidity(AddLiquidityInstruction),
     ClaimPartnerFee(ClaimPartnerFeeInstruction),
@@ -243,119 +242,119 @@ pub enum MeteoraDammInstruction {
 // -----------------------------------------------------------------------------
 // Payload structs
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AddLiquidityInstruction {
     pub params: AddLiquidityParameters,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ClaimPartnerFeeInstruction {
     pub max_amount_a: u64,
     pub max_amount_b: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ClaimProtocolFeeInstruction {
     pub max_amount_a: u64,
     pub max_amount_b: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ClaimRewardInstruction {
     pub reward_index: u8,
     pub skip_reward: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreateConfigInstruction {
     pub index: u64,
     pub config_parameters: StaticConfigParameters,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreateDynamicConfigInstruction {
     pub index: u64,
     pub config_parameters: DynamicConfigParameters,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct FundRewardInstruction {
     pub reward_index: u8,
     pub amount: u64,
     pub carry_forward: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeCustomizablePoolInstruction {
     pub params: InitializeCustomizablePoolParameters,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializePoolInstruction {
     pub params: InitializePoolParameters,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializePoolWithDynamicConfigInstruction {
     pub params: InitializeCustomizablePoolParameters,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeRewardInstruction {
     pub reward_index: u8,
     pub reward_duration: u64,
     pub funder: Pubkey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct LockPositionInstruction {
     pub params: VestingParameters,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct PermanentLockPositionInstruction {
     pub permanent_lock_liquidity: u128,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct RemoveAllLiquidityInstruction {
     pub token_a_amount_threshold: u64,
     pub token_b_amount_threshold: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct RemoveLiquidityInstruction {
     pub params: RemoveLiquidityParameters,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SetPoolStatusInstruction {
     pub status: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SplitPositionInstruction {
     pub params: SplitPositionParameters,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapInstruction {
     pub params: SwapParameters,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct UpdateRewardDurationInstruction {
     pub reward_index: u8,
     pub new_duration: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct UpdateRewardFunderInstruction {
     pub reward_index: u8,
     pub new_funder: Pubkey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct WithdrawIneligibleRewardInstruction {
     pub reward_index: u8,
 }

--- a/packages/meteora/src/dllm/accounts.rs
+++ b/packages/meteora/src/dllm/accounts.rs
@@ -1,12 +1,11 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 use substreams_solana::block_view::InstructionView;
 
 use idls_common::accounts::AccountsError;
 
 /// Accounts for the `add_liquidity` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AddLiquidityAccounts {
     pub position: Pubkey,
     pub lb_pair: Pubkey,
@@ -61,7 +60,7 @@ pub fn get_add_liquidity_accounts(ix: &InstructionView) -> Result<AddLiquidityAc
 }
 
 /// Accounts for the `add_liquidity2` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AddLiquidity2Accounts {
     pub position: Pubkey,
     pub lb_pair: Pubkey,
@@ -112,7 +111,7 @@ pub fn get_add_liquidity2_accounts(ix: &InstructionView) -> Result<AddLiquidity2
 }
 
 /// Accounts for the `add_liquidity_by_strategy` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AddLiquidityByStrategyAccounts {
     pub position: Pubkey,
     pub lb_pair: Pubkey,
@@ -167,7 +166,7 @@ pub fn get_add_liquidity_by_strategy_accounts(ix: &InstructionView) -> Result<Ad
 }
 
 /// Accounts for the `add_liquidity_by_strategy2` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AddLiquidityByStrategy2Accounts {
     pub position: Pubkey,
     pub lb_pair: Pubkey,
@@ -218,7 +217,7 @@ pub fn get_add_liquidity_by_strategy2_accounts(ix: &InstructionView) -> Result<A
 }
 
 /// Accounts for the `add_liquidity_by_strategy_one_side` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AddLiquidityByStrategyOneSideAccounts {
     pub position: Pubkey,
     pub lb_pair: Pubkey,
@@ -265,7 +264,7 @@ pub fn get_add_liquidity_by_strategy_one_side_accounts(ix: &InstructionView) -> 
 }
 
 /// Accounts for the `add_liquidity_by_weight` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AddLiquidityByWeightAccounts {
     pub position: Pubkey,
     pub lb_pair: Pubkey,
@@ -320,7 +319,7 @@ pub fn get_add_liquidity_by_weight_accounts(ix: &InstructionView) -> Result<AddL
 }
 
 /// Accounts for the `add_liquidity_one_side` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AddLiquidityOneSideAccounts {
     pub position: Pubkey,
     pub lb_pair: Pubkey,
@@ -367,7 +366,7 @@ pub fn get_add_liquidity_one_side_accounts(ix: &InstructionView) -> Result<AddLi
 }
 
 /// Accounts for the `add_liquidity_one_side_precise` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AddLiquidityOneSidePreciseAccounts {
     pub position: Pubkey,
     pub lb_pair: Pubkey,
@@ -414,7 +413,7 @@ pub fn get_add_liquidity_one_side_precise_accounts(ix: &InstructionView) -> Resu
 }
 
 /// Accounts for the `add_liquidity_one_side_precise2` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AddLiquidityOneSidePrecise2Accounts {
     pub position: Pubkey,
     pub lb_pair: Pubkey,
@@ -651,7 +650,7 @@ accounts!(
 );
 
 /// Accounts for the `go_to_a_bin` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct GoToABinAccounts {
     pub lb_pair: Pubkey,
     pub bin_array_bitmap_extension: Option<Pubkey>,
@@ -736,7 +735,7 @@ accounts!(
 );
 
 /// Accounts for the `initialize_customizable_permissionless_lb_pair` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeCustomizablePermissionlessLbPairAccounts {
     pub lb_pair: Pubkey,
     pub bin_array_bitmap_extension: Option<Pubkey>,
@@ -789,7 +788,7 @@ pub fn get_initialize_customizable_permissionless_lb_pair_accounts(
 }
 
 /// Accounts for the `initialize_customizable_permissionless_lb_pair2` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeCustomizablePermissionlessLbPair2Accounts {
     pub lb_pair: Pubkey,
     pub bin_array_bitmap_extension: Option<Pubkey>,
@@ -848,7 +847,7 @@ pub fn get_initialize_customizable_permissionless_lb_pair2_accounts(
 }
 
 /// Accounts for the `initialize_lb_pair` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeLbPairAccounts {
     pub lb_pair: Pubkey,
     pub bin_array_bitmap_extension: Option<Pubkey>,
@@ -899,7 +898,7 @@ pub fn get_initialize_lb_pair_accounts(ix: &InstructionView) -> Result<Initializ
 }
 
 /// Accounts for the `initialize_lb_pair2` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeLbPair2Accounts {
     pub lb_pair: Pubkey,
     pub bin_array_bitmap_extension: Option<Pubkey>,
@@ -954,7 +953,7 @@ pub fn get_initialize_lb_pair2_accounts(ix: &InstructionView) -> Result<Initiali
 }
 
 /// Accounts for the `initialize_permission_lb_pair` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializePermissionLbPairAccounts {
     pub base: Pubkey,
     pub lb_pair: Pubkey,
@@ -1083,7 +1082,7 @@ accounts!(
 );
 
 /// Accounts for the `initialize_reward` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeRewardAccounts {
     pub lb_pair: Pubkey,
     pub reward_vault: Pubkey,
@@ -1162,7 +1161,7 @@ accounts!(
 );
 
 /// Accounts for the `rebalance_liquidity` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct RebalanceLiquidityAccounts {
     pub position: Pubkey,
     pub lb_pair: Pubkey,
@@ -1219,7 +1218,7 @@ pub fn get_rebalance_liquidity_accounts(ix: &InstructionView) -> Result<Rebalanc
 }
 
 /// Accounts for the `remove_all_liquidity` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct RemoveAllLiquidityAccounts {
     pub position: Pubkey,
     pub lb_pair: Pubkey,
@@ -1274,7 +1273,7 @@ pub fn get_remove_all_liquidity_accounts(ix: &InstructionView) -> Result<RemoveA
 }
 
 /// Accounts for the `remove_liquidity` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct RemoveLiquidityAccounts {
     pub position: Pubkey,
     pub lb_pair: Pubkey,
@@ -1329,7 +1328,7 @@ pub fn get_remove_liquidity_accounts(ix: &InstructionView) -> Result<RemoveLiqui
 }
 
 /// Accounts for the `remove_liquidity2` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct RemoveLiquidity2Accounts {
     pub position: Pubkey,
     pub lb_pair: Pubkey,
@@ -1382,7 +1381,7 @@ pub fn get_remove_liquidity2_accounts(ix: &InstructionView) -> Result<RemoveLiqu
 }
 
 /// Accounts for the `remove_liquidity_by_range` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct RemoveLiquidityByRangeAccounts {
     pub position: Pubkey,
     pub lb_pair: Pubkey,
@@ -1437,7 +1436,7 @@ pub fn get_remove_liquidity_by_range_accounts(ix: &InstructionView) -> Result<Re
 }
 
 /// Accounts for the `remove_liquidity_by_range2` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct RemoveLiquidityByRange2Accounts {
     pub position: Pubkey,
     pub lb_pair: Pubkey,
@@ -1535,7 +1534,7 @@ accounts!(
 );
 
 /// Accounts for the `swap` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapAccounts {
     pub lb_pair: Pubkey,
     pub bin_array_bitmap_extension: Option<Pubkey>,
@@ -1588,7 +1587,7 @@ pub fn get_swap_accounts(ix: &InstructionView) -> Result<SwapAccounts, AccountsE
 }
 
 /// Accounts for the `swap2` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct Swap2Accounts {
     pub lb_pair: Pubkey,
     pub bin_array_bitmap_extension: Option<Pubkey>,
@@ -1643,7 +1642,7 @@ pub fn get_swap2_accounts(ix: &InstructionView) -> Result<Swap2Accounts, Account
 }
 
 /// Accounts for the `swap_exact_out` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapExactOutAccounts {
     pub lb_pair: Pubkey,
     pub bin_array_bitmap_extension: Option<Pubkey>,
@@ -1696,7 +1695,7 @@ pub fn get_swap_exact_out_accounts(ix: &InstructionView) -> Result<SwapExactOutA
 }
 
 /// Accounts for the `swap_exact_out2` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapExactOut2Accounts {
     pub lb_pair: Pubkey,
     pub bin_array_bitmap_extension: Option<Pubkey>,
@@ -1751,7 +1750,7 @@ pub fn get_swap_exact_out2_accounts(ix: &InstructionView) -> Result<SwapExactOut
 }
 
 /// Accounts for the `swap_with_price_impact` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapWithPriceImpactAccounts {
     pub lb_pair: Pubkey,
     pub bin_array_bitmap_extension: Option<Pubkey>,
@@ -1804,7 +1803,7 @@ pub fn get_swap_with_price_impact_accounts(ix: &InstructionView) -> Result<SwapW
 }
 
 /// Accounts for the `swap_with_price_impact2` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapWithPriceImpact2Accounts {
     pub lb_pair: Pubkey,
     pub bin_array_bitmap_extension: Option<Pubkey>,

--- a/packages/meteora/src/dllm/events.rs
+++ b/packages/meteora/src/dllm/events.rs
@@ -2,7 +2,6 @@
 
 use idls_common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
 // -----------------------------------------------------------------------------
@@ -38,7 +37,7 @@ const ANCHOR_DISC: [u8; 8] = [0xe4, 0x45, 0xa5, 0x2e, 0x51, 0xcb, 0x9a, 0x1d];
 // -----------------------------------------------------------------------------
 // High-level event enum
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MeteoraDllmEvent {
     Swap(SwapEvent),
     // AddLiquidity,
@@ -69,7 +68,7 @@ pub enum MeteoraDllmEvent {
 }
 
 /// Emitted when swap occurs.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapEvent {
     pub lb_pair: Pubkey,
     pub from: Pubkey,

--- a/packages/meteora/src/dllm/instructions.rs
+++ b/packages/meteora/src/dllm/instructions.rs
@@ -2,11 +2,9 @@
 
 use idls_common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
-use serde_big_array::BigArray;
 use solana_program::pubkey::Pubkey;
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum AccountsType {
     TransferHookX,
     TransferHookY,
@@ -15,13 +13,13 @@ pub enum AccountsType {
 }
 
 /// Type of the activation
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum ActivationType {
     Slot,
     Timestamp,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AddLiquidityParams {
     pub min_delta_id: i32,
 
@@ -42,14 +40,14 @@ pub struct AddLiquidityParams {
     pub padding: [u8; 16],
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AddLiquiditySingleSidePreciseParameter {
     pub bins: Vec<CompressedBinDepositAmount>,
 
     pub decompress_multiplier: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AddLiquiditySingleSidePreciseParameter2 {
     pub bins: Vec<CompressedBinDepositAmount>,
 
@@ -58,7 +56,7 @@ pub struct AddLiquiditySingleSidePreciseParameter2 {
     pub max_amount: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct BaseFeeParameter {
     /// Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee
     pub protocol_share: u16,
@@ -68,7 +66,7 @@ pub struct BaseFeeParameter {
     pub base_fee_power_factor: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct BinLiquidityDistribution {
     /// Define the bin ID wish to deposit to.
     pub bin_id: i32,
@@ -78,7 +76,7 @@ pub struct BinLiquidityDistribution {
     pub distribution_y: u16,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct BinLiquidityDistributionByWeight {
     /// Define the bin ID wish to deposit to.
     pub bin_id: i32,
@@ -86,21 +84,21 @@ pub struct BinLiquidityDistributionByWeight {
     pub weight: u16,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct BinLiquidityReduction {
     pub bin_id: i32,
 
     pub bps_to_remove: u16,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CompressedBinDepositAmount {
     pub bin_id: i32,
 
     pub amount: u32,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CustomizableParams {
     /// Pool price
     pub active_id: i32,
@@ -119,11 +117,10 @@ pub struct CustomizableParams {
     /// Base fee power factor
     pub base_fee_power_factor: u8,
     /// Padding, for future use
-    #[serde(with = "BigArray")]
     pub padding: [u8; 62],
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct DummyIx {
     pub _pair_status: PairStatus,
 
@@ -138,7 +135,7 @@ pub struct DummyIx {
     pub _rounding: Rounding,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct DynamicFeeParameter {
     /// Filter period determine high frequency trading time window.
     pub filter_period: u16,
@@ -152,7 +149,7 @@ pub struct DynamicFeeParameter {
     pub max_volatility_accumulator: u32,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitPermissionPairIx {
     pub active_id: i32,
 
@@ -167,7 +164,7 @@ pub struct InitPermissionPairIx {
     pub protocol_share: u16,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitPresetParameters2Ix {
     pub index: u16,
     /// Bin step. Represent the price increment / decrement.
@@ -190,7 +187,7 @@ pub struct InitPresetParameters2Ix {
     pub base_fee_power_factor: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitPresetParametersIx {
     /// Bin step. Represent the price increment / decrement.
     pub bin_step: u16,
@@ -210,16 +207,15 @@ pub struct InitPresetParametersIx {
     pub protocol_share: u16,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeLbPair2Params {
     /// Pool price
     pub active_id: i32,
     /// Padding, for future use
-    #[serde(with = "BigArray")]
     pub padding: [u8; 96],
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct LiquidityOneSideParameter {
     /// Amount of X token or Y token to deposit
     pub amount: u64,
@@ -231,7 +227,7 @@ pub struct LiquidityOneSideParameter {
     pub bin_liquidity_dist: Vec<BinLiquidityDistributionByWeight>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct LiquidityParameter {
     /// Amount of X token to deposit
     pub amount_x: u64,
@@ -241,7 +237,7 @@ pub struct LiquidityParameter {
     pub bin_liquidity_dist: Vec<BinLiquidityDistribution>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct LiquidityParameterByStrategy {
     /// Amount of X token to deposit
     pub amount_x: u64,
@@ -255,7 +251,7 @@ pub struct LiquidityParameterByStrategy {
     pub strategy_parameters: StrategyParameters,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct LiquidityParameterByStrategyOneSide {
     /// Amount of X token or Y token to deposit
     pub amount: u64,
@@ -267,7 +263,7 @@ pub struct LiquidityParameterByStrategyOneSide {
     pub strategy_parameters: StrategyParameters,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct LiquidityParameterByWeight {
     /// Amount of X token to deposit
     pub amount_x: u64,
@@ -282,14 +278,14 @@ pub struct LiquidityParameterByWeight {
 }
 
 /// Pair status. 0 = Enabled, 1 = Disabled. Putting 0 as enabled for backward compatibility.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum PairStatus {
     Enabled,
     Disabled,
 }
 
 /// Type of the Pair. 0 = Permissionless, 1 = Permission, 2 = CustomizablePermissionless. Putting 0 as permissionless for backward compatibility.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum PairType {
     Permissionless,
     Permission,
@@ -297,7 +293,7 @@ pub enum PairType {
     PermissionlessV2,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct RebalanceLiquidityParams {
     /// active id
     pub active_id: i32,
@@ -323,19 +319,19 @@ pub struct RebalanceLiquidityParams {
     pub adds: Vec<AddLiquidityParams>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct RemainingAccountsInfo {
     pub slices: Vec<RemainingAccountsSlice>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct RemainingAccountsSlice {
     pub accounts_type: AccountsType,
 
     pub length: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct RemoveLiquidityParams {
     pub min_bin_id: Option<i32>,
 
@@ -347,19 +343,19 @@ pub struct RemoveLiquidityParams {
 }
 
 /// Side of resize, 0 for lower and 1 for upper
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum ResizeSide {
     Lower,
     Upper,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum Rounding {
     Up,
     Down,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct StrategyParameters {
     /// min bin id
     pub min_bin_id: i32,
@@ -368,11 +364,10 @@ pub struct StrategyParameters {
     /// strategy type
     pub strategy_type: StrategyType,
     /// parameters
-    #[serde(with = "BigArray")]
     pub parameteres: [u8; 64],
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum StrategyType {
     SpotOneSide,
     CurveOneSide,
@@ -385,7 +380,7 @@ pub enum StrategyType {
     BidAskImBalanced,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum TokenProgramFlags {
     TokenProgram,
     TokenProgram2022,
@@ -466,7 +461,7 @@ pub const WITHDRAW_PROTOCOL_FEE: [u8; 8] = [158, 201, 158, 189, 33, 93, 162, 103
 // -----------------------------------------------------------------------------
 // Instruction enumeration
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MeteoraDllmInstruction {
     AddLiquidity(AddLiquidityInstruction),
     AddLiquidity2(AddLiquidity2Instruction),
@@ -542,58 +537,58 @@ pub enum MeteoraDllmInstruction {
 // -----------------------------------------------------------------------------
 // Payload structs
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AddLiquidityInstruction {
     pub liquidity_parameter: LiquidityParameter,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AddLiquidity2Instruction {
     pub liquidity_parameter: LiquidityParameter,
 
     pub remaining_accounts_info: RemainingAccountsInfo,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AddLiquidityByStrategyInstruction {
     pub liquidity_parameter: LiquidityParameterByStrategy,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AddLiquidityByStrategy2Instruction {
     pub liquidity_parameter: LiquidityParameterByStrategy,
 
     pub remaining_accounts_info: RemainingAccountsInfo,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AddLiquidityByStrategyOneSideInstruction {
     pub liquidity_parameter: LiquidityParameterByStrategyOneSide,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AddLiquidityByWeightInstruction {
     pub liquidity_parameter: LiquidityParameterByWeight,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AddLiquidityOneSideInstruction {
     pub liquidity_parameter: LiquidityOneSideParameter,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AddLiquidityOneSidePreciseInstruction {
     pub parameter: AddLiquiditySingleSidePreciseParameter,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AddLiquidityOneSidePrecise2Instruction {
     pub liquidity_parameter: AddLiquiditySingleSidePreciseParameter2,
 
     pub remaining_accounts_info: RemainingAccountsInfo,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ClaimFee2Instruction {
     pub min_bin_id: i32,
 
@@ -602,12 +597,12 @@ pub struct ClaimFee2Instruction {
     pub remaining_accounts_info: RemainingAccountsInfo,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ClaimRewardInstruction {
     pub reward_index: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ClaimReward2Instruction {
     pub reward_index: u64,
 
@@ -618,19 +613,19 @@ pub struct ClaimReward2Instruction {
     pub remaining_accounts_info: RemainingAccountsInfo,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct DecreasePositionLengthInstruction {
     pub length_to_remove: u16,
 
     pub side: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ForIdlTypeGenerationDoNotCallInstruction {
     pub _ix: DummyIx,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct FundRewardInstruction {
     pub reward_index: u64,
 
@@ -641,63 +636,63 @@ pub struct FundRewardInstruction {
     pub remaining_accounts_info: RemainingAccountsInfo,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct GoToABinInstruction {
     pub bin_id: i32,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct IncreaseOracleLengthInstruction {
     pub length_to_add: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct IncreasePositionLengthInstruction {
     pub length_to_add: u16,
 
     pub side: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeBinArrayInstruction {
     pub index: i64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeCustomizablePermissionlessLbPairInstruction {
     pub params: CustomizableParams,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeCustomizablePermissionlessLbPair2Instruction {
     pub params: CustomizableParams,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeLbPairInstruction {
     pub active_id: i32,
 
     pub bin_step: u16,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeLbPair2Instruction {
     pub params: InitializeLbPair2Params,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializePermissionLbPairInstruction {
     pub ix_data: InitPermissionPairIx,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializePositionInstruction {
     pub lower_bin_id: i32,
 
     pub width: i32,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializePositionByOperatorInstruction {
     pub lower_bin_id: i32,
 
@@ -708,24 +703,24 @@ pub struct InitializePositionByOperatorInstruction {
     pub lock_release_point: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializePositionPdaInstruction {
     pub lower_bin_id: i32,
 
     pub width: i32,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializePresetParameterInstruction {
     pub ix: InitPresetParametersIx,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializePresetParameter2Instruction {
     pub ix: InitPresetParameters2Ix,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeRewardInstruction {
     pub reward_index: u64,
 
@@ -734,26 +729,26 @@ pub struct InitializeRewardInstruction {
     pub funder: Pubkey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct RebalanceLiquidityInstruction {
     pub params: RebalanceLiquidityParams,
 
     pub remaining_accounts_info: RemainingAccountsInfo,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct RemoveLiquidityInstruction {
     pub bin_liquidity_removal: Vec<BinLiquidityReduction>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct RemoveLiquidity2Instruction {
     pub bin_liquidity_removal: Vec<BinLiquidityReduction>,
 
     pub remaining_accounts_info: RemainingAccountsInfo,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct RemoveLiquidityByRangeInstruction {
     pub from_bin_id: i32,
 
@@ -762,7 +757,7 @@ pub struct RemoveLiquidityByRangeInstruction {
     pub bps_to_remove: u16,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct RemoveLiquidityByRange2Instruction {
     pub from_bin_id: i32,
 
@@ -773,39 +768,39 @@ pub struct RemoveLiquidityByRange2Instruction {
     pub remaining_accounts_info: RemainingAccountsInfo,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SetActivationPointInstruction {
     pub activation_point: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SetPairStatusInstruction {
     pub status: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SetPairStatusPermissionlessInstruction {
     pub status: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SetPreActivationDurationInstruction {
     pub pre_activation_duration: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SetPreActivationSwapAddressInstruction {
     pub pre_activation_swap_address: Pubkey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapInstruction {
     pub amount_in: u64,
 
     pub min_amount_out: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct Swap2Instruction {
     pub amount_in: u64,
 
@@ -814,14 +809,14 @@ pub struct Swap2Instruction {
     pub remaining_accounts_info: RemainingAccountsInfo,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapExactOutInstruction {
     pub max_in_amount: u64,
 
     pub out_amount: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapExactOut2Instruction {
     pub max_in_amount: u64,
 
@@ -830,7 +825,7 @@ pub struct SwapExactOut2Instruction {
     pub remaining_accounts_info: RemainingAccountsInfo,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapWithPriceImpactInstruction {
     pub amount_in: u64,
 
@@ -839,7 +834,7 @@ pub struct SwapWithPriceImpactInstruction {
     pub max_price_impact_bps: u16,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapWithPriceImpact2Instruction {
     pub amount_in: u64,
 
@@ -850,50 +845,50 @@ pub struct SwapWithPriceImpact2Instruction {
     pub remaining_accounts_info: RemainingAccountsInfo,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct UpdateBaseFeeParametersInstruction {
     pub fee_parameter: BaseFeeParameter,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct UpdateDynamicFeeParametersInstruction {
     pub fee_parameter: DynamicFeeParameter,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct UpdateFeesAndReward2Instruction {
     pub min_bin_id: i32,
 
     pub max_bin_id: i32,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct UpdatePositionOperatorInstruction {
     pub operator: Pubkey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct UpdateRewardDurationInstruction {
     pub reward_index: u64,
 
     pub new_duration: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct UpdateRewardFunderInstruction {
     pub reward_index: u64,
 
     pub new_funder: Pubkey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct WithdrawIneligibleRewardInstruction {
     pub reward_index: u64,
 
     pub remaining_accounts_info: RemainingAccountsInfo,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct WithdrawProtocolFeeInstruction {
     pub max_amount_x: u64,
 

--- a/packages/orca/Cargo.toml
+++ b/packages/orca/Cargo.toml
@@ -9,10 +9,4 @@ substreams = { workspace = true }
 substreams-solana = { workspace = true }
 solana-program = { workspace = true }
 borsh = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
-thiserror = { workspace = true }
-serde-big-array = { workspace = true }
 
-[dev-dependencies]
-base64 = { workspace = true }

--- a/packages/orca/src/whirlpool/accounts.rs
+++ b/packages/orca/src/whirlpool/accounts.rs
@@ -1,5 +1,4 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 use substreams_solana::block_view::InstructionView;
 

--- a/packages/orca/src/whirlpool/events.rs
+++ b/packages/orca/src/whirlpool/events.rs
@@ -2,20 +2,19 @@
 
 use idls_common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum LockType {
     Permanent,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum LockTypeLabel {
     Permanent,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AdaptiveFeeConstants {
     pub filter_period: u16,
     pub decay_period: u16,
@@ -27,7 +26,7 @@ pub struct AdaptiveFeeConstants {
     pub reserved: [u8; 16],
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AdaptiveFeeVariables {
     pub last_reference_update_timestamp: u64,
     pub last_major_swap_timestamp: u64,
@@ -37,24 +36,24 @@ pub struct AdaptiveFeeVariables {
     pub reserved: [u8; 16],
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct OpenPositionBumps {
     pub position_bump: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct OpenPositionWithMetadataBumps {
     pub position_bump: u8,
     pub metadata_bump: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct PositionRewardInfo {
     pub growth_inside_checkpoint: u128,
     pub amount_owed: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct Tick {
     pub initialized: bool,
     pub liquidity_net: i128,
@@ -64,12 +63,12 @@ pub struct Tick {
     pub reward_growths_outside: [u128; 3],
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct WhirlpoolBumps {
     pub whirlpool_bump: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct WhirlpoolRewardInfo {
     pub mint: Pubkey,
     pub vault: Pubkey,
@@ -78,7 +77,7 @@ pub struct WhirlpoolRewardInfo {
     pub growth_global_x64: u128,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum AccountsType {
     TransferHookA,
     TransferHookB,
@@ -91,12 +90,12 @@ pub enum AccountsType {
     SupplementalTickArraysTwo,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct RemainingAccountsInfo {
     pub slices: Vec<RemainingAccountsSlice>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct RemainingAccountsSlice {
     pub accounts_type: AccountsType,
     pub length: u8,
@@ -107,7 +106,7 @@ const LIQUIDITY_INCREASED: [u8; 8] = [30, 7, 144, 181, 102, 254, 155, 161];
 const POOL_INITIALIZED: [u8; 8] = [100, 118, 173, 87, 12, 198, 254, 229];
 const TRADED: [u8; 8] = [225, 202, 73, 175, 147, 43, 160, 150];
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WhirlpoolEvent {
     LiquidityDecreased(LiquidityDecreased),
     LiquidityIncreased(LiquidityIncreased),
@@ -116,7 +115,7 @@ pub enum WhirlpoolEvent {
     Unknown,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct LiquidityDecreased {
     pub whirlpool: Pubkey,
     pub position: Pubkey,
@@ -129,7 +128,7 @@ pub struct LiquidityDecreased {
     pub token_b_transfer_fee: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct LiquidityIncreased {
     pub whirlpool: Pubkey,
     pub position: Pubkey,
@@ -142,7 +141,7 @@ pub struct LiquidityIncreased {
     pub token_b_transfer_fee: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct PoolInitialized {
     pub whirlpool: Pubkey,
     pub whirlpools_config: Pubkey,
@@ -156,7 +155,7 @@ pub struct PoolInitialized {
     pub initial_sqrt_price: u128,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct Traded {
     pub whirlpool: Pubkey,
     pub a_to_b: bool,

--- a/packages/orca/src/whirlpool/instructions.rs
+++ b/packages/orca/src/whirlpool/instructions.rs
@@ -2,20 +2,19 @@
 
 use idls_common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum LockType {
     Permanent,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum LockTypeLabel {
     Permanent,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AdaptiveFeeConstants {
     pub filter_period: u16,
     pub decay_period: u16,
@@ -27,7 +26,7 @@ pub struct AdaptiveFeeConstants {
     pub reserved: [u8; 16],
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AdaptiveFeeVariables {
     pub last_reference_update_timestamp: u64,
     pub last_major_swap_timestamp: u64,
@@ -37,24 +36,24 @@ pub struct AdaptiveFeeVariables {
     pub reserved: [u8; 16],
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct OpenPositionBumps {
     pub position_bump: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct OpenPositionWithMetadataBumps {
     pub position_bump: u8,
     pub metadata_bump: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct PositionRewardInfo {
     pub growth_inside_checkpoint: u128,
     pub amount_owed: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct Tick {
     pub initialized: bool,
     pub liquidity_net: i128,
@@ -64,12 +63,12 @@ pub struct Tick {
     pub reward_growths_outside: [u128; 3],
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct WhirlpoolBumps {
     pub whirlpool_bump: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct WhirlpoolRewardInfo {
     pub mint: Pubkey,
     pub vault: Pubkey,
@@ -78,7 +77,7 @@ pub struct WhirlpoolRewardInfo {
     pub growth_global_x64: u128,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum AccountsType {
     TransferHookA,
     TransferHookB,
@@ -91,12 +90,12 @@ pub enum AccountsType {
     SupplementalTickArraysTwo,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct RemainingAccountsInfo {
     pub slices: Vec<RemainingAccountsSlice>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct RemainingAccountsSlice {
     pub accounts_type: AccountsType,
     pub length: u8,
@@ -161,7 +160,7 @@ pub const SET_TOKEN_BADGE_AUTHORITY: [u8; 8] = [207, 202, 4, 32, 205, 79, 13, 17
 pub const INITIALIZE_TOKEN_BADGE: [u8; 8] = [253, 77, 205, 95, 27, 224, 89, 223];
 pub const DELETE_TOKEN_BADGE: [u8; 8] = [53, 146, 68, 8, 18, 117, 17, 185];
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WhirlpoolInstruction {
     InitializeConfig(InitializeConfigInstruction),
     InitializePool(InitializePoolInstruction),
@@ -223,7 +222,7 @@ pub enum WhirlpoolInstruction {
     DeleteTokenBadge,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeConfigInstruction {
     pub fee_authority: Pubkey,
     pub collect_protocol_fees_authority: Pubkey,
@@ -231,69 +230,69 @@ pub struct InitializeConfigInstruction {
     pub default_protocol_fee_rate: u16,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializePoolInstruction {
     pub bumps: WhirlpoolBumps,
     pub tick_spacing: u16,
     pub initial_sqrt_price: u128,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeTickArrayInstruction {
     pub start_tick_index: i32,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeFeeTierInstruction {
     pub tick_spacing: u16,
     pub default_fee_rate: u16,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeRewardInstruction {
     pub reward_index: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SetRewardEmissionsInstruction {
     pub reward_index: u8,
     pub emissions_per_second_x64: u128,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct OpenPositionInstruction {
     pub bumps: OpenPositionBumps,
     pub tick_lower_index: i32,
     pub tick_upper_index: i32,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct OpenPositionWithMetadataInstruction {
     pub bumps: OpenPositionWithMetadataBumps,
     pub tick_lower_index: i32,
     pub tick_upper_index: i32,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct IncreaseLiquidityInstruction {
     pub liquidity_amount: u128,
     pub token_max_a: u64,
     pub token_max_b: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct DecreaseLiquidityInstruction {
     pub liquidity_amount: u128,
     pub token_min_a: u64,
     pub token_min_b: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CollectRewardInstruction {
     pub reward_index: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapInstruction {
     pub amount: u64,
     pub other_amount_threshold: u64,
@@ -302,37 +301,37 @@ pub struct SwapInstruction {
     pub a_to_b: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SetDefaultFeeRateInstruction {
     pub default_fee_rate: u16,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SetDefaultProtocolFeeRateInstruction {
     pub default_protocol_fee_rate: u16,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SetFeeRateInstruction {
     pub fee_rate: u16,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SetProtocolFeeRateInstruction {
     pub protocol_fee_rate: u16,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SetRewardAuthorityInstruction {
     pub reward_index: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SetRewardAuthorityBySuperAuthorityInstruction {
     pub reward_index: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct TwoHopSwapInstruction {
     pub amount: u64,
     pub other_amount_threshold: u64,
@@ -343,37 +342,37 @@ pub struct TwoHopSwapInstruction {
     pub sqrt_price_limit_two: u128,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct OpenBundledPositionInstruction {
     pub bundle_index: u16,
     pub tick_lower_index: i32,
     pub tick_upper_index: i32,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CloseBundledPositionInstruction {
     pub bundle_index: u16,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct OpenPositionWithTokenExtensionsInstruction {
     pub tick_lower_index: i32,
     pub tick_upper_index: i32,
     pub with_token_metadata_extension: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct LockPositionInstruction {
     pub lock_type: LockType,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ResetPositionRangeInstruction {
     pub new_tick_lower_index: i32,
     pub new_tick_upper_index: i32,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeAdaptiveFeeTierInstruction {
     pub fee_tier_index: u16,
     pub tick_spacing: u16,
@@ -389,12 +388,12 @@ pub struct InitializeAdaptiveFeeTierInstruction {
     pub major_swap_threshold_ticks: u16,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SetDefaultBaseFeeRateInstruction {
     pub default_base_fee_rate: u16,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SetPresetAdaptiveFeeConstantsInstruction {
     pub filter_period: u16,
     pub decay_period: u16,
@@ -405,34 +404,34 @@ pub struct SetPresetAdaptiveFeeConstantsInstruction {
     pub major_swap_threshold_ticks: u16,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializePoolWithAdaptiveFeeInstruction {
     pub initial_sqrt_price: u128,
     pub trade_enable_timestamp: Option<u64>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SetFeeRateByDelegatedFeeAuthorityInstruction {
     pub fee_rate: u16,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CollectFeesV2Instruction {
     pub remaining_accounts_info: Option<RemainingAccountsInfo>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CollectProtocolFeesV2Instruction {
     pub remaining_accounts_info: Option<RemainingAccountsInfo>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CollectRewardV2Instruction {
     pub reward_index: u8,
     pub remaining_accounts_info: Option<RemainingAccountsInfo>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct DecreaseLiquidityV2Instruction {
     pub liquidity_amount: u128,
     pub token_min_a: u64,
@@ -440,7 +439,7 @@ pub struct DecreaseLiquidityV2Instruction {
     pub remaining_accounts_info: Option<RemainingAccountsInfo>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct IncreaseLiquidityV2Instruction {
     pub liquidity_amount: u128,
     pub token_max_a: u64,
@@ -448,24 +447,24 @@ pub struct IncreaseLiquidityV2Instruction {
     pub remaining_accounts_info: Option<RemainingAccountsInfo>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializePoolV2Instruction {
     pub tick_spacing: u16,
     pub initial_sqrt_price: u128,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeRewardV2Instruction {
     pub reward_index: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SetRewardEmissionsV2Instruction {
     pub reward_index: u8,
     pub emissions_per_second_x64: u128,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapV2Instruction {
     pub amount: u64,
     pub other_amount_threshold: u64,
@@ -475,7 +474,7 @@ pub struct SwapV2Instruction {
     pub remaining_accounts_info: Option<RemainingAccountsInfo>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct TwoHopSwapV2Instruction {
     pub amount: u64,
     pub other_amount_threshold: u64,

--- a/packages/phoenix/Cargo.toml
+++ b/packages/phoenix/Cargo.toml
@@ -9,10 +9,4 @@ substreams = { workspace = true }
 substreams-solana = { workspace = true }
 solana-program = { workspace = true }
 borsh = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
-thiserror = { workspace = true }
-serde-big-array = { workspace = true }
 
-[dev-dependencies]
-base64 = { workspace = true }

--- a/packages/phonenix/Cargo.toml
+++ b/packages/phonenix/Cargo.toml
@@ -9,10 +9,4 @@ substreams = { workspace = true }
 substreams-solana = { workspace = true }
 solana-program = { workspace = true }
 borsh = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
-thiserror = { workspace = true }
-serde-big-array = { workspace = true }
 
-[dev-dependencies]
-base64 = { workspace = true }

--- a/packages/phonenix/src/accounts.rs
+++ b/packages/phonenix/src/accounts.rs
@@ -1,5 +1,4 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 use substreams_solana::block_view::InstructionView;
 

--- a/packages/phonenix/src/events.rs
+++ b/packages/phonenix/src/events.rs
@@ -2,7 +2,6 @@
 
 use idls_common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
 // -----------------------------------------------------------------------------
@@ -13,7 +12,7 @@ pub const FILL_EVENT: u8 = 2;
 // -----------------------------------------------------------------------------
 // Event enumeration
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PhonenixEvent {
     Fill(FillEvent),
     Unknown,
@@ -22,7 +21,7 @@ pub enum PhonenixEvent {
 // -----------------------------------------------------------------------------
 // Payload structs
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct FillEvent {
     pub index: u16,
     pub maker_id: Pubkey,

--- a/packages/phonenix/src/instructions.rs
+++ b/packages/phonenix/src/instructions.rs
@@ -2,7 +2,6 @@
 
 use idls_common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 
 // -----------------------------------------------------------------------------
 // Discriminators
@@ -13,7 +12,7 @@ pub const SWAP_WITH_FREE_FUNDS: u8 = 1;
 // -----------------------------------------------------------------------------
 // Instruction enumeration
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PhonenixInstruction {
     Swap(SwapInstruction),
     SwapWithFreeFunds(SwapWithFreeFundsInstruction),
@@ -23,13 +22,13 @@ pub enum PhonenixInstruction {
 // -----------------------------------------------------------------------------
 // Payload structs
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapInstruction {
     /// Raw order packet payload
     pub order_packet: Vec<u8>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapWithFreeFundsInstruction {
     /// Raw order packet payload
     pub order_packet: Vec<u8>,

--- a/packages/pumpfun/Cargo.toml
+++ b/packages/pumpfun/Cargo.toml
@@ -9,10 +9,4 @@ substreams = { workspace = true }
 substreams-solana = { workspace = true }
 solana-program = { workspace = true }
 borsh = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
-thiserror = { workspace = true }
-serde-big-array = { workspace = true }
 
-[dev-dependencies]
-base64 = { workspace = true }

--- a/packages/pumpfun/src/amm/accounts.rs
+++ b/packages/pumpfun/src/amm/accounts.rs
@@ -1,5 +1,4 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 use substreams_solana::block_view::InstructionView;
 

--- a/packages/pumpfun/src/amm/events.rs
+++ b/packages/pumpfun/src/amm/events.rs
@@ -2,7 +2,6 @@
 
 use idls_common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
 // -------------------------------------------------------------------------
@@ -23,7 +22,7 @@ const WITHDRAW_EVENT: [u8; 8] = [22, 9, 133, 26, 160, 44, 71, 192];
 // -------------------------------------------------------------------------
 // Event enumeration
 // -------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PumpFunAmmEvent {
     BuyEventV1(BuyEventV1),
     BuyEventV2(BuyEventV2),
@@ -44,7 +43,7 @@ pub enum PumpFunAmmEvent {
 // -------------------------------------------------------------------------
 // Payload structs
 // -------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct BuyEventV1 {
     pub timestamp: i64,
     pub base_amount_out: u64,
@@ -71,7 +70,7 @@ pub struct BuyEventV1 {
 // -------------------------------------------------------------------------
 // Payload structs
 // -------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct BuyEventV2 {
     pub timestamp: i64,
     pub base_amount_out: u64,
@@ -99,7 +98,7 @@ pub struct BuyEventV2 {
     pub coin_creator_fee: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SellEventV1 {
     pub timestamp: i64,
     pub base_amount_in: u64,
@@ -123,7 +122,7 @@ pub struct SellEventV1 {
     pub protocol_fee_recipient_token_account: Pubkey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SellEventV2 {
     pub timestamp: i64,
     pub base_amount_in: u64,
@@ -151,7 +150,7 @@ pub struct SellEventV2 {
     pub coin_creator_fee: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreateConfigEvent {
     pub timestamp: i64,
     pub admin: Pubkey,
@@ -159,7 +158,7 @@ pub struct CreateConfigEvent {
     pub protocol_fee_basis_points: u64,
     pub protocol_fee_recipients: [Pubkey; 8],
 }
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreatePoolEventV1 {
     pub timestamp: i64,
     pub index: u16,
@@ -182,7 +181,7 @@ pub struct CreatePoolEventV1 {
     pub user_quote_token_account: Pubkey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreatePoolEventV2 {
     pub timestamp: i64,
     pub index: u16,
@@ -207,7 +206,7 @@ pub struct CreatePoolEventV2 {
     pub coin_creator: Pubkey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct DepositEvent {
     pub timestamp: i64,
     pub lp_token_amount_out: u64,
@@ -226,7 +225,7 @@ pub struct DepositEvent {
     pub user_quote_token_account: Pubkey,
     pub user_pool_token_account: Pubkey,
 }
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct DisableEvent {
     pub timestamp: i64,
     pub admin: Pubkey,
@@ -236,7 +235,7 @@ pub struct DisableEvent {
     pub disable_buy: bool,
     pub disable_sell: bool,
 }
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ExtendAccountEvent {
     pub timestamp: i64,
     pub account: Pubkey,
@@ -245,13 +244,13 @@ pub struct ExtendAccountEvent {
     pub new_size: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct UpdateAdminEvent {
     pub timestamp: i64,
     pub admin: Pubkey,
     pub new_admin: Pubkey,
 }
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct UpdateFeeConfigEvent {
     pub timestamp: i64,
     pub admin: Pubkey,
@@ -259,7 +258,7 @@ pub struct UpdateFeeConfigEvent {
     pub protocol_fee_basis_points: u64,
     pub protocol_fee_recipients: [Pubkey; 8],
 }
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct WithdrawEvent {
     pub timestamp: i64,
     pub lp_token_amount_in: u64,

--- a/packages/pumpfun/src/amm/instructions.rs
+++ b/packages/pumpfun/src/amm/instructions.rs
@@ -2,7 +2,6 @@
 
 use idls_common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
 // -------------------------------------------------------------------------
@@ -24,7 +23,7 @@ const WITHDRAW: [u8; 8] = [183, 18, 70, 156, 148, 109, 161, 34];
 // -------------------------------------------------------------------------
 // Instruction enumeration
 // -------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum PumpFunAmmInstruction {
     Buy(BuyInstruction),
     CreateConfig(CreateConfigInstruction),
@@ -43,39 +42,39 @@ pub enum PumpFunAmmInstruction {
 // -------------------------------------------------------------------------
 // Payload structs
 // -------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct BuyInstruction {
     pub base_amount_out: u64,
     pub max_quote_amount_in: u64,
 }
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreateConfigInstruction {
     pub lp_fee_basis_points: u64,
     pub protocol_fee_basis_points: u64,
     pub protocol_fee_recipients: [Pubkey; 8],
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreatePoolInstructionV1 {
     pub index: u16,
     pub base_amount_in: u64,
     pub quote_amount_in: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreatePoolInstructionV2 {
     pub index: u16,
     pub base_amount_in: u64,
     pub quote_amount_in: u64,
     pub coin_creator: Pubkey,
 }
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct DepositInstruction {
     pub lp_token_amount_out: u64,
     pub max_base_amount_in: u64,
     pub max_quote_amount_in: u64,
 }
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct DisableInstruction {
     pub disable_create_pool: bool,
     pub disable_deposit: bool,
@@ -83,18 +82,18 @@ pub struct DisableInstruction {
     pub disable_buy: bool,
     pub disable_sell: bool,
 }
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SellInstruction {
     pub base_amount_in: u64,
     pub min_quote_amount_out: u64,
 }
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct UpdateFeeConfigInstruction {
     pub lp_fee_basis_points: u64,
     pub protocol_fee_basis_points: u64,
     pub protocol_fee_recipients: [Pubkey; 8],
 }
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct WithdrawInstruction {
     pub lp_token_amount_in: u64,
     pub min_base_amount_out: u64,

--- a/packages/pumpfun/src/amm/logs.rs
+++ b/packages/pumpfun/src/amm/logs.rs
@@ -2,7 +2,6 @@
 
 use idls_common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
 // -------------------------------------------------------------------------
@@ -14,7 +13,7 @@ const SELL_LOG: [u8; 8] = [62, 47, 55, 10, 165, 3, 220, 42]; // 3e2f370aa503dc2a
 // -------------------------------------------------------------------------
 // enumeration
 // -------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PumpFunAmmLog {
     BuyLog(BuyLog),
     SellLog(SellLog),
@@ -28,7 +27,7 @@ pub enum PumpFunAmmLog {
 // -------------------------------------------------------------------------
 // Payload structs
 // -------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct BuyLog {
     pub timestamp: i64,
     pub base_amount_out: u64,
@@ -52,7 +51,7 @@ pub struct BuyLog {
     pub protocol_fee_recipient_token_account: Pubkey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SellLog {
     pub timestamp: i64,
     pub base_amount_in: u64,

--- a/packages/pumpfun/src/bonding_curve/accounts.rs
+++ b/packages/pumpfun/src/bonding_curve/accounts.rs
@@ -1,5 +1,4 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 use substreams_solana::block_view::InstructionView;
 

--- a/packages/pumpfun/src/bonding_curve/events.rs
+++ b/packages/pumpfun/src/bonding_curve/events.rs
@@ -2,7 +2,6 @@
 
 use idls_common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
 // -----------------------------------------------------------------------------
@@ -19,7 +18,7 @@ pub const TRADE_LEN_V2: usize = 233 - 16;
 // -----------------------------------------------------------------------------
 // High-level event enum (concise; rich docs live in each struct)
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PumpFunEvent {
     /// Pool created. See [`CreateEvent`].
     Create(CreateEvent),
@@ -44,7 +43,7 @@ pub enum PumpFunEvent {
 // -----------------------------------------------------------------------------
 
 /// Emitted once when a new bonding-curve pool is created.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreateEvent {
     /// Name of the pool, e.g., "Pump.fun".
     pub name: String,
@@ -84,7 +83,7 @@ pub struct CreateEvent {
 }
 
 /// Emitted on every buy or sell.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct TradeEventV0 {
     pub mint: Pubkey,
     /// Lamports moved (positive on buys, negative on sells).
@@ -101,7 +100,7 @@ pub struct TradeEventV0 {
 }
 
 /// Emitted on every buy or sell.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct TradeEventV1 {
     pub mint: Pubkey,
     /// Lamports moved (positive on buys, negative on sells).
@@ -124,7 +123,7 @@ pub struct TradeEventV1 {
 /// https://github.com/pump-fun/pump-public-docs
 /// On every trade the original creator of the coin receives 0.05 % of all trade fees.
 /// This is applicable for all coins that were present on the bonding curve or PumpSwap from the date of May 13 2025.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct TradeEventV2 {
     pub mint: Pubkey,
     /// Lamports moved (positive on buys, negative on sells).
@@ -153,7 +152,7 @@ pub struct TradeEventV2 {
 }
 
 /// Emitted whenever pool parameters change.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SetParamsEvent {
     /// New protocol-fee recipient.
     pub fee_recipient: Pubkey,
@@ -170,7 +169,7 @@ pub struct SetParamsEvent {
 }
 
 /// Emitted when a pool is closed / liquidity exhausted.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CompleteEvent {
     /// Wallet that triggered completion (last trade).
     pub user: Pubkey,

--- a/packages/pumpfun/src/bonding_curve/instructions.rs
+++ b/packages/pumpfun/src/bonding_curve/instructions.rs
@@ -1,7 +1,6 @@
 //! Pump.fun on-chain instruction definitions and Borsh deserialisation helpers.
 use idls_common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
 // -----------------------------------------------------------------------------
@@ -17,7 +16,7 @@ const WITHDRAW: [u8; 8] = [183, 18, 70, 156, 148, 109, 161, 34];
 // ──────────────────────────────────────────────────────────────────────────────
 // High-level enum
 // ──────────────────────────────────────────────────────────────────────────────
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum PumpFunInstruction {
     /// Initialise global state (no payload).
     Initialize,
@@ -138,7 +137,7 @@ pub enum PumpFunInstruction {
 // -----------------------------------------------------------------------------
 
 /// Instruction data for [`PumpFunInstruction::SetParams`]
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SetParamsInstruction {
     /// Account that will collect protocol fees going forward.
     pub fee_recipient: Pubkey,
@@ -154,7 +153,7 @@ pub struct SetParamsInstruction {
     pub fee_basis_points: u64,
 }
 /// Instruction data for [`PumpFunInstruction::Create`]
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreateInstruction {
     /// Display name for the token pool (UTF-8).
     pub name: String,
@@ -167,7 +166,7 @@ pub struct CreateInstruction {
 }
 
 /// Instruction data for [`PumpFunInstruction::Buy`].
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct BuyInstruction {
     /// Amount of tokens to purchase.
     pub amount: u64,
@@ -176,7 +175,7 @@ pub struct BuyInstruction {
 }
 
 /// Instruction data for [`PumpFunInstruction::Sell`].
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SellInstruction {
     /// Number of tokens to sell.
     pub amount: u64,

--- a/packages/raydium/Cargo.toml
+++ b/packages/raydium/Cargo.toml
@@ -9,10 +9,6 @@ substreams = { workspace = true }
 substreams-solana = { workspace = true }
 solana-program = { workspace = true }
 borsh = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
-thiserror = { workspace = true }
-serde-big-array = { workspace = true }
 
 [dev-dependencies]
 base64 = { workspace = true }

--- a/packages/raydium/src/amm/v4/accounts.rs
+++ b/packages/raydium/src/amm/v4/accounts.rs
@@ -1,5 +1,4 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 use substreams_solana::block_view::InstructionView;
 
@@ -27,7 +26,7 @@ const IDX_UER_SOURCE_TOKEN_ACCOUNT: usize = 15;
 const IDX_UER_DESTINATION_TOKEN_ACCOUNT: usize = 16;
 const IDX_USER_SOURCE_OWNER: usize = 17;
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapBaseAccounts {
     pub token_program: Pubkey,
     pub amm: Pubkey,

--- a/packages/raydium/src/amm/v4/instructions.rs
+++ b/packages/raydium/src/amm/v4/instructions.rs
@@ -4,7 +4,6 @@
 // https://github.com/raydium-io/raydium-amm/blob/master/program/src/instruction.rs
 use idls_common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 // use solana_program::pubkey::Pubkey;
 
 // -----------------------------------------------------------------------------
@@ -40,7 +39,7 @@ const SWAP_LEN: usize = 16; // Length of the swap instructions (excluding discri
 // High-level enum
 // ──────────────────────────────────────────────────────────────────────────────
 /// Instructions supported by the Raydium-v4 AMM program.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum RaydiumV4Instruction {
     // ─────────────────────────────────────────────────────────────────────
     // Pool creation
@@ -319,7 +318,7 @@ pub enum RaydiumV4Instruction {
 // Payload structs
 // -----------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapBaseInInstruction {
     /// Amount of base token to swap in.
     pub amount_in: u64,
@@ -328,7 +327,7 @@ pub struct SwapBaseInInstruction {
     pub minimum_amount_out: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapBaseOutInstruction {
     /// Maximum amount of base token to swap in.
     pub max_amount_in: u64,
@@ -336,7 +335,7 @@ pub struct SwapBaseOutInstruction {
     /// Amount of output token to receive.
     pub amount_out: u64,
 }
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeInstruction {
     /// Nonce used to derive the pool-authority PDA
     nonce: u8,
@@ -344,7 +343,7 @@ pub struct InitializeInstruction {
     open_time: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct Initialize2Instruction {
     /// Nonce used to derive the pool-authority PDA
     nonce: u8,
@@ -356,13 +355,13 @@ pub struct Initialize2Instruction {
     init_coin_amount: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct PreInitializeInstruction {
     /// Nonce used to derive the pool-authority PDA (legacy helper)
     nonce: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct MonitorStepInstruction {
     /// Upper bound on the number of *planned* orders to check this crank
     plan_order_limit: u16,
@@ -372,7 +371,7 @@ pub struct MonitorStepInstruction {
     cancel_order_limit: u16,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct DepositInstruction {
     /// Max base-token (**coin**) the user is willing to deposit
     max_coin_amount: u64,
@@ -384,7 +383,7 @@ pub struct DepositInstruction {
     other_amount_min: Option<u64>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct WithdrawInstruction {
     /// LP-token amount to burn for the withdrawal
     amount: u64,
@@ -394,7 +393,7 @@ pub struct WithdrawInstruction {
     min_pc_amount: Option<u64>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SetParamsInstruction {
     /// Discriminator selecting which parameter is being updated
     param: u8,
@@ -405,13 +404,13 @@ pub struct SetParamsInstruction {
     /* other Raydium-specific fields (fees, last_order_distance) omitted */
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct WithdrawSrmInstruction {
     /// (M)SRM amount to withdraw from the fee-discount vault
     amount: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SimulateInstruction {
     /// Discriminator from `SimulateParams` choosing what to simulate
     param: u8,
@@ -421,13 +420,13 @@ pub struct SimulateInstruction {
     swap_base_out_value: Option<SwapBaseOutInstruction>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct AdminCancelOrdersInstruction {
     /// Maximum number of orders the admin crank will cancel this call
     limit: u16,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ConfigArgs {
     /// Field selector (0 = owner, 1 = admin, 2 = create_pool_fee, …)
     param: u8,

--- a/packages/raydium/src/amm/v4/logs.rs
+++ b/packages/raydium/src/amm/v4/logs.rs
@@ -3,7 +3,6 @@
 
 use idls_common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
 /// ------------------------------------------------------------------------
@@ -21,7 +20,7 @@ pub const SWAP_OUT: u8 = 4;
 // -----------------------------------------------------------------------------
 // High-level event enum (concise; rich docs live in each struct)
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RaydiumV4Log {
     /// New pool initialised. See [`InitLog`].
     Init(InitLog),
@@ -46,7 +45,7 @@ pub enum RaydiumV4Log {
 // Payload structs
 // -----------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitLog {
     pub log_type: u8,
     pub time: u64,
@@ -59,7 +58,7 @@ pub struct InitLog {
     pub market: Pubkey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct DepositLog {
     pub log_type: u8,
     // input
@@ -78,7 +77,7 @@ pub struct DepositLog {
     pub mint_lp: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct WithdrawLog {
     pub log_type: u8,
     // input
@@ -96,7 +95,7 @@ pub struct WithdrawLog {
     pub out_pc: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapBaseInLog {
     pub log_type: u8,
     // input
@@ -112,7 +111,7 @@ pub struct SwapBaseInLog {
     pub out_amount: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapBaseOutLog {
     pub log_type: u8,
     // input

--- a/packages/raydium/src/clmm/v3/accounts.rs
+++ b/packages/raydium/src/clmm/v3/accounts.rs
@@ -1,12 +1,11 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 use substreams_solana::block_view::InstructionView;
 
 use idls_common::accounts::AccountsError;
 
 /// Accounts for the `close_position` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ClosePositionAccounts {
     /// The position nft owner
     pub nft_owner: Pubkey,
@@ -46,7 +45,7 @@ pub fn get_close_position_accounts(ix: &InstructionView) -> Result<ClosePosition
 }
 
 /// Accounts for the `collect_fund_fee` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CollectFundFeeAccounts {
     /// Only admin or fund_owner can collect fee now
     pub owner: Pubkey,
@@ -102,7 +101,7 @@ pub fn get_collect_fund_fee_accounts(ix: &InstructionView) -> Result<CollectFund
 }
 
 /// Accounts for the `collect_protocol_fee` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CollectProtocolFeeAccounts {
     /// Only admin or config owner can collect fee now
     pub owner: Pubkey,
@@ -158,7 +157,7 @@ pub fn get_collect_protocol_fee_accounts(ix: &InstructionView) -> Result<Collect
 }
 
 /// Accounts for the `collect_remaining_rewards` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CollectRemainingRewardsAccounts {
     /// The founder who init reward info previously
     pub reward_funder: Pubkey,
@@ -204,7 +203,7 @@ pub fn get_collect_remaining_rewards_accounts(ix: &InstructionView) -> Result<Co
 }
 
 /// Accounts for the `create_amm_config` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreateAmmConfigAccounts {
     /// Address to be set as protocol owner.
     pub owner: Pubkey,
@@ -235,7 +234,7 @@ pub fn get_create_amm_config_accounts(ix: &InstructionView) -> Result<CreateAmmC
 }
 
 /// Accounts for the `create_operation_account` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreateOperationAccountAccounts {
     /// Address to be set as operation account owner.
     pub owner: Pubkey,
@@ -266,7 +265,7 @@ pub fn get_create_operation_account_accounts(ix: &InstructionView) -> Result<Cre
 }
 
 /// Accounts for the `create_pool` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreatePoolAccounts {
     /// Address paying to create the pool. Can be anyone
     pub pool_creator: Pubkey,
@@ -328,7 +327,7 @@ pub fn get_create_pool_accounts(ix: &InstructionView) -> Result<CreatePoolAccoun
 }
 
 /// Accounts for the `create_support_mint_associated` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreateSupportMintAssociatedAccounts {
     /// Address to be set as protocol owner.
     pub owner: Pubkey,
@@ -362,7 +361,7 @@ pub fn get_create_support_mint_associated_accounts(ix: &InstructionView) -> Resu
 }
 
 /// Accounts for the `decrease_liquidity` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct DecreaseLiquidityAccounts {
     /// The position owner or delegated authority
     pub nft_owner: Pubkey,
@@ -419,7 +418,7 @@ pub fn get_decrease_liquidity_accounts(ix: &InstructionView) -> Result<DecreaseL
 }
 
 /// Accounts for the `decrease_liquidity_v2` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct DecreaseLiquidityV2Accounts {
     /// The position owner or delegated authority
     pub nft_owner: Pubkey,
@@ -488,7 +487,7 @@ pub fn get_decrease_liquidity_v2_accounts(ix: &InstructionView) -> Result<Decrea
 }
 
 /// Accounts for the `increase_liquidity` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct IncreaseLiquidityAccounts {
     /// Pays to mint the position
     pub nft_owner: Pubkey,
@@ -545,7 +544,7 @@ pub fn get_increase_liquidity_accounts(ix: &InstructionView) -> Result<IncreaseL
 }
 
 /// Accounts for the `increase_liquidity_v2` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct IncreaseLiquidityV2Accounts {
     /// Pays to mint the position
     pub nft_owner: Pubkey,
@@ -611,7 +610,7 @@ pub fn get_increase_liquidity_v2_accounts(ix: &InstructionView) -> Result<Increa
 }
 
 /// Accounts for the `initialize_reward` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeRewardAccounts {
     /// The founder deposit reward token to vault
     pub reward_funder: Pubkey,
@@ -660,7 +659,7 @@ pub fn get_initialize_reward_accounts(ix: &InstructionView) -> Result<Initialize
 }
 
 /// Accounts for the `open_position` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct OpenPositionAccounts {
     /// Pays to mint the position
     pub payer: Pubkey,
@@ -738,7 +737,7 @@ pub fn get_open_position_accounts(ix: &InstructionView) -> Result<OpenPositionAc
 }
 
 /// Accounts for the `open_position_v2` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct OpenPositionV2Accounts {
     /// Pays to mint the position
     pub payer: Pubkey,
@@ -824,7 +823,7 @@ pub fn get_open_position_v2_accounts(ix: &InstructionView) -> Result<OpenPositio
 }
 
 /// Accounts for the `open_position_with_token22_nft` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct OpenPositionWithToken22NftAccounts {
     /// Pays to mint the position
     pub payer: Pubkey,
@@ -903,7 +902,7 @@ pub fn get_open_position_with_token22_nft_accounts(ix: &InstructionView) -> Resu
 }
 
 /// Accounts for the `set_reward_params` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SetRewardParamsAccounts {
     /// Address to be set as protocol owner. It pays to create factory state account.
     pub authority: Pubkey,
@@ -942,7 +941,7 @@ pub fn get_set_reward_params_accounts(ix: &InstructionView) -> Result<SetRewardP
 }
 
 /// Accounts for the `swap` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapAccounts {
     /// The user performing the swap
     pub payer: Pubkey,
@@ -994,7 +993,7 @@ pub fn get_swap_accounts(ix: &InstructionView) -> Result<SwapAccounts, AccountsE
 }
 
 /// Accounts for the `swap_router_base_in` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapRouterBaseInAccounts {
     /// The user performing the swap
     pub payer: Pubkey,
@@ -1035,7 +1034,7 @@ pub fn get_swap_router_base_in_accounts(ix: &InstructionView) -> Result<SwapRout
 }
 
 /// Accounts for the `swap_v2` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapV2Accounts {
     /// The user performing the swap
     pub payer: Pubkey,
@@ -1097,7 +1096,7 @@ pub fn get_swap_v2_accounts(ix: &InstructionView) -> Result<SwapV2Accounts, Acco
 }
 
 /// Accounts for the `transfer_reward_owner` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct TransferRewardOwnerAccounts {
     /// Address to be set as operation account owner.
     pub authority: Pubkey,
@@ -1125,7 +1124,7 @@ pub fn get_transfer_reward_owner_accounts(ix: &InstructionView) -> Result<Transf
 }
 
 /// Accounts for the `update_amm_config` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct UpdateAmmConfigAccounts {
     /// The amm config owner or admin
     pub owner: Pubkey,
@@ -1154,7 +1153,7 @@ pub fn get_update_amm_config_accounts(ix: &InstructionView) -> Result<UpdateAmmC
 }
 
 /// Accounts for the `update_operation_account` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct UpdateOperationAccountAccounts {
     /// Address to be set as operation account owner.
     pub owner: Pubkey,
@@ -1185,7 +1184,7 @@ pub fn get_update_operation_account_accounts(ix: &InstructionView) -> Result<Upd
 }
 
 /// Accounts for the `update_pool_status` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct UpdatePoolStatusAccounts {
     pub authority: Pubkey,
     pub pool_state: Pubkey,
@@ -1212,7 +1211,7 @@ pub fn get_update_pool_status_accounts(ix: &InstructionView) -> Result<UpdatePoo
 }
 
 /// Accounts for the `update_reward_infos` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct UpdateRewardInfosAccounts {
     /// The liquidity pool for which reward info to update
     pub pool_state: Pubkey,

--- a/packages/raydium/src/clmm/v3/events.rs
+++ b/packages/raydium/src/clmm/v3/events.rs
@@ -2,7 +2,6 @@
 
 use idls_common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
 // -----------------------------------------------------------------------------
@@ -23,7 +22,7 @@ pub const UPDATE_REWARD_INFOS_EVENT: [u8; 8] = [109, 127, 186, 78, 114, 65, 37, 
 // -----------------------------------------------------------------------------
 // Event enumeration
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RaydiumClmmEvent {
     CollectPersonalFeeEvent(CollectPersonalFeeEvent),
     CollectProtocolFeeEvent(CollectProtocolFeeEvent),
@@ -43,7 +42,7 @@ pub enum RaydiumClmmEvent {
 // Payload structs
 // -----------------------------------------------------------------------------
 /// Emitted when tokens are collected for a position
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CollectPersonalFeeEvent {
     /// The ID of the token for which underlying tokens were collected
     pub position_nft_mint: Pubkey,
@@ -58,7 +57,7 @@ pub struct CollectPersonalFeeEvent {
 }
 
 /// Emitted when the collected protocol fees are withdrawn by the factory owner
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CollectProtocolFeeEvent {
     /// The pool whose protocol fee is collected
     pub pool_state: Pubkey,
@@ -73,7 +72,7 @@ pub struct CollectProtocolFeeEvent {
 }
 
 /// Emitted when create or update a config
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ConfigChangeEvent {
     pub index: u16,
     pub owner: Pubkey,
@@ -85,7 +84,7 @@ pub struct ConfigChangeEvent {
 }
 
 /// Emitted when create a new position
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreatePersonalPositionEvent {
     /// The pool for which liquidity was added
     pub pool_state: Pubkey,
@@ -110,7 +109,7 @@ pub struct CreatePersonalPositionEvent {
 }
 
 /// Emitted when liquidity is decreased.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct DecreaseLiquidityEvent {
     /// The ID of the token for which liquidity was decreased
     pub position_nft_mint: Pubkey,
@@ -132,7 +131,7 @@ pub struct DecreaseLiquidityEvent {
 }
 
 /// Emitted when liquidity is increased.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct IncreaseLiquidityEvent {
     /// The ID of the token for which liquidity was increased
     pub position_nft_mint: Pubkey,
@@ -149,7 +148,7 @@ pub struct IncreaseLiquidityEvent {
 }
 
 /// Emitted when liquidity decreased or increase.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct LiquidityCalculateEvent {
     /// The pool liquidity before decrease or increase
     pub pool_liquidity: u128,
@@ -171,7 +170,7 @@ pub struct LiquidityCalculateEvent {
 }
 
 /// Emitted pool liquidity change when increase and decrease liquidity
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct LiquidityChangeEvent {
     /// The pool for swap
     pub pool_state: Pubkey,
@@ -189,7 +188,7 @@ pub struct LiquidityChangeEvent {
 
 /// Emitted when a pool is created and initialized with a starting price
 ///
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct PoolCreatedEvent {
     /// The first token of the pool by address sort order
     pub token_mint_0: Pubkey,
@@ -210,7 +209,7 @@ pub struct PoolCreatedEvent {
 }
 
 /// Emitted by when a swap is performed for a pool
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapEvent {
     /// The pool for which token_0 and token_1 were swapped
     pub pool_state: Pubkey,
@@ -241,7 +240,7 @@ pub struct SwapEvent {
 }
 
 /// Emitted when Reward are updated for a pool
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct UpdateRewardInfosEvent {
     /// Reward info
     pub reward_growth_global_x64: [u128; 3],

--- a/packages/raydium/src/clmm/v3/instructions.rs
+++ b/packages/raydium/src/clmm/v3/instructions.rs
@@ -2,10 +2,9 @@
 
 use idls_common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeRewardParam {
     /// Reward open time
     pub open_time: u64,
@@ -47,7 +46,7 @@ pub const UPDATE_REWARD_INFOS: [u8; 8] = [163, 172, 224, 52, 11, 154, 106, 223];
 // -----------------------------------------------------------------------------
 // Instruction enumeration
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RaydiumClmmInstruction {
     ClosePosition,
     CollectFundFee(CollectFundFeeInstruction),
@@ -88,7 +87,7 @@ pub enum RaydiumClmmInstruction {
 /// * `amount_0_requested` - The maximum amount of token_0 to send, can be 0 to collect fees in only token_1
 /// * `amount_1_requested` - The maximum amount of token_1 to send, can be 0 to collect fees in only token_0
 ///
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CollectFundFeeInstruction {
     pub amount_0_requested: u64,
     pub amount_1_requested: u64,
@@ -102,7 +101,7 @@ pub struct CollectFundFeeInstruction {
 /// * `amount_0_requested` - The maximum amount of token_0 to send, can be 0 to collect fees in only token_1
 /// * `amount_1_requested` - The maximum amount of token_1 to send, can be 0 to collect fees in only token_0
 ///
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CollectProtocolFeeInstruction {
     pub amount_0_requested: u64,
     pub amount_1_requested: u64,
@@ -115,7 +114,7 @@ pub struct CollectProtocolFeeInstruction {
 /// * `ctx`- The context of accounts
 /// * `reward_index` - the index to reward info
 ///
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CollectRemainingRewardsInstruction {
     pub reward_index: u8,
 }
@@ -129,7 +128,7 @@ pub struct CollectRemainingRewardsInstruction {
 /// * `protocol_fee_rate` - The rate of protocol fee within trade fee.
 /// * `fund_fee_rate` - The rate of fund fee within trade fee.
 ///
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreateAmmConfigInstruction {
     pub index: u16,
     pub tick_spacing: u16,
@@ -145,7 +144,7 @@ pub struct CreateAmmConfigInstruction {
 /// * `ctx`- The context of accounts
 /// * `sqrt_price_x64` - the initial sqrt price (amount_token_1 / amount_token_0) of the pool as a Q64.64
 ///   Note: The open_time must be smaller than the current block_timestamp on chain.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreatePoolInstruction {
     pub sqrt_price_x64: u128,
     pub open_time: u64,
@@ -161,7 +160,7 @@ pub struct CreatePoolInstruction {
 /// * `amount_0_min` - The minimum amount of token_0 that should be accounted for the burned liquidity
 /// * `amount_1_min` - The minimum amount of token_1 that should be accounted for the burned liquidity
 ///
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct DecreaseLiquidityInstruction {
     pub liquidity: u128,
     pub amount_0_min: u64,
@@ -177,7 +176,7 @@ pub struct DecreaseLiquidityInstruction {
 /// * `amount_0_min` - The minimum amount of token_0 that should be accounted for the burned liquidity
 /// * `amount_1_min` - The minimum amount of token_1 that should be accounted for the burned liquidity
 ///
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct DecreaseLiquidityV2Instruction {
     pub liquidity: u128,
     pub amount_0_min: u64,
@@ -194,7 +193,7 @@ pub struct DecreaseLiquidityV2Instruction {
 /// * `amount_0_max` - The max amount of token_0 to spend, which serves as a slippage check
 /// * `amount_1_max` - The max amount of token_1 to spend, which serves as a slippage check
 ///
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct IncreaseLiquidityInstruction {
     pub liquidity: u128,
     pub amount_0_max: u64,
@@ -211,7 +210,7 @@ pub struct IncreaseLiquidityInstruction {
 /// * `amount_1_max` - The max amount of token_1 to spend, which serves as a slippage check
 /// * `base_flag` - must be specified if liquidity is zero, true: calculate liquidity base amount_0_max otherwise base amount_1_max
 ///
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct IncreaseLiquidityV2Instruction {
     pub liquidity: u128,
     pub amount_0_max: u64,
@@ -229,7 +228,7 @@ pub struct IncreaseLiquidityV2Instruction {
 /// * `end_time` - reward end timestamp
 /// * `emissions_per_second_x64` - Token reward per second are earned per unit of liquidity.
 ///
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeRewardInstruction {
     pub param: InitializeRewardParam,
 }
@@ -248,7 +247,7 @@ pub struct InitializeRewardInstruction {
 /// * `amount_0_max` - The max amount of token_0 to spend, which serves as a slippage check
 /// * `amount_1_max` - The max amount of token_1 to spend, which serves as a slippage check
 ///
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct OpenPositionInstruction {
     pub tick_lower_index: i32,
     pub tick_upper_index: i32,
@@ -275,7 +274,7 @@ pub struct OpenPositionInstruction {
 /// * `with_metadata` - The flag indicating whether to create NFT mint metadata
 /// * `base_flag` - if the liquidity specified as zero, true: calculate liquidity base amount_0_max otherwise base amount_1_max
 ///
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct OpenPositionV2Instruction {
     pub tick_lower_index: i32,
     pub tick_upper_index: i32,
@@ -303,7 +302,7 @@ pub struct OpenPositionV2Instruction {
 /// * `with_metadata` - The flag indicating whether to create NFT mint metadata
 /// * `base_flag` - if the liquidity specified as zero, true: calculate liquidity base amount_0_max otherwise base amount_1_max
 ///
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct OpenPositionWithToken22NftInstruction {
     pub tick_lower_index: i32,
     pub tick_upper_index: i32,
@@ -327,7 +326,7 @@ pub struct OpenPositionWithToken22NftInstruction {
 /// * `open_time` - reward open timestamp, must be set when starting a new cycle
 /// * `end_time` - reward end timestamp
 ///
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SetRewardParamsInstruction {
     pub reward_index: u8,
     pub emissions_per_second_x64: u128,
@@ -346,7 +345,7 @@ pub struct SetRewardParamsInstruction {
 /// * `sqrt_price_limit` - The Q64.64 sqrt price √P limit. If zero for one, the price cannot
 /// * `is_base_input` - swap base input or swap base output
 ///
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapInstruction {
     pub amount: u64,
     pub other_amount_threshold: u64,
@@ -362,7 +361,7 @@ pub struct SwapInstruction {
 /// * `amount_in` - Token amount to be swapped in
 /// * `amount_out_minimum` - Panic if output amount is below minimum amount. For slippage.
 ///
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapRouterBaseInInstruction {
     pub amount_in: u64,
     pub amount_out_minimum: u64,
@@ -375,7 +374,7 @@ pub struct SwapRouterBaseInInstruction {
 /// * `ctx`- The context of accounts
 /// * `new_owner`- new owner pubkey
 ///
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct TransferRewardOwnerInstruction {
     pub new_owner: Pubkey,
 }
@@ -393,7 +392,7 @@ pub struct TransferRewardOwnerInstruction {
 /// * `new_fund_owner`- The config's new fund owner, be set when `param` is 4
 /// * `param`- The value can be 0 | 1 | 2 | 3 | 4, otherwise will report a error
 ///
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct UpdateAmmConfigInstruction {
     pub param: u8,
     pub value: u32,
@@ -410,7 +409,7 @@ pub struct UpdateAmmConfigInstruction {
 ///   update whitelist mint when the `param` is 2
 ///   remove whitelist mint when the `param` is 3
 ///
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct UpdateOperationAccountInstruction {
     pub param: u8,
     pub keys: Vec<Pubkey>,
@@ -423,7 +422,7 @@ pub struct UpdateOperationAccountInstruction {
 /// * `ctx`- The context of accounts
 /// * `status` - The value of status
 ///
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct UpdatePoolStatusInstruction {
     pub status: u8,
 }

--- a/packages/raydium/src/cpmm/accounts.rs
+++ b/packages/raydium/src/cpmm/accounts.rs
@@ -1,12 +1,11 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 use substreams_solana::block_view::InstructionView;
 
 use idls_common::accounts::AccountsError;
 
 /// Accounts for the `close_permission_pda` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ClosePermissionPdaAccounts {
     pub owner: Pubkey,
     pub permission_authority: Pubkey,
@@ -38,7 +37,7 @@ pub fn get_close_permission_pda_accounts(ix: &InstructionView) -> Result<ClosePe
 }
 
 /// Accounts for the `collect_creator_fee` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CollectCreatorFeeAccounts {
     /// Only pool creator can collect fee
     pub creator: Pubkey,
@@ -102,7 +101,7 @@ pub fn get_collect_creator_fee_accounts(ix: &InstructionView) -> Result<CollectC
 }
 
 /// Accounts for the `collect_fund_fee` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CollectFundFeeAccounts {
     /// Only admin or fund_owner can collect fee now
     pub owner: Pubkey,
@@ -160,7 +159,7 @@ pub fn get_collect_fund_fee_accounts(ix: &InstructionView) -> Result<CollectFund
 }
 
 /// Accounts for the `collect_protocol_fee` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CollectProtocolFeeAccounts {
     /// Only admin or owner can collect fee now
     pub owner: Pubkey,
@@ -218,7 +217,7 @@ pub fn get_collect_protocol_fee_accounts(ix: &InstructionView) -> Result<Collect
 }
 
 /// Accounts for the `create_amm_config` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreateAmmConfigAccounts {
     /// Address to be set as protocol owner.
     pub owner: Pubkey,
@@ -249,7 +248,7 @@ pub fn get_create_amm_config_accounts(ix: &InstructionView) -> Result<CreateAmmC
 }
 
 /// Accounts for the `create_permission_pda` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreatePermissionPdaAccounts {
     pub owner: Pubkey,
     pub permission_authority: Pubkey,
@@ -281,7 +280,7 @@ pub fn get_create_permission_pda_accounts(ix: &InstructionView) -> Result<Create
 }
 
 /// Accounts for the `deposit` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct DepositAccounts {
     /// Pays to mint the position
     pub owner: Pubkey,
@@ -341,7 +340,7 @@ pub fn get_deposit_accounts(ix: &InstructionView) -> Result<DepositAccounts, Acc
 }
 
 /// Accounts for the `initialize` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeAccounts {
     /// Address paying to create the pool. Can be anyone
     pub creator: Pubkey,
@@ -430,7 +429,7 @@ pub fn get_initialize_accounts(ix: &InstructionView) -> Result<InitializeAccount
 }
 
 /// Accounts for the `initialize_with_permission` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeWithPermissionAccounts {
     /// Address paying to create the pool. Can be anyone
     pub payer: Pubkey,
@@ -520,7 +519,7 @@ pub fn get_initialize_with_permission_accounts(ix: &InstructionView) -> Result<I
 }
 
 /// Accounts for the `swap_base_input` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapBaseInputAccounts {
     /// The user performing the swap
     pub payer: Pubkey,
@@ -581,7 +580,7 @@ pub fn get_swap_base_input_accounts(ix: &InstructionView) -> Result<SwapBaseInpu
 }
 
 /// Accounts for the `swap_base_output` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapBaseOutputAccounts {
     /// The user performing the swap
     pub payer: Pubkey,
@@ -642,7 +641,7 @@ pub fn get_swap_base_output_accounts(ix: &InstructionView) -> Result<SwapBaseOut
 }
 
 /// Accounts for the `update_amm_config` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct UpdateAmmConfigAccounts {
     /// The amm config owner or admin
     pub owner: Pubkey,
@@ -671,7 +670,7 @@ pub fn get_update_amm_config_accounts(ix: &InstructionView) -> Result<UpdateAmmC
 }
 
 /// Accounts for the `update_pool_status` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct UpdatePoolStatusAccounts {
     pub authority: Pubkey,
     pub pool_state: Pubkey,
@@ -698,7 +697,7 @@ pub fn get_update_pool_status_accounts(ix: &InstructionView) -> Result<UpdatePoo
 }
 
 /// Accounts for the `withdraw` instruction.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct WithdrawAccounts {
     /// Pays to mint the position
     pub owner: Pubkey,

--- a/packages/raydium/src/cpmm/events.rs
+++ b/packages/raydium/src/cpmm/events.rs
@@ -2,7 +2,6 @@
 
 use idls_common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
 // -----------------------------------------------------------------------------
@@ -16,7 +15,7 @@ const SWAP_EVENT_V2_PAYLOAD_LEN: usize = SWAP_EVENT_V1_PAYLOAD_LEN + 32 + 32 + 8
 // -----------------------------------------------------------------------------
 // Event enumeration
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RaydiumCpmmEvent {
     LpChangeEvent(LpChangeEvent),
     SwapEventV1(SwapEventV1),
@@ -28,7 +27,7 @@ pub enum RaydiumCpmmEvent {
 // Payload structs
 // -----------------------------------------------------------------------------
 /// Emitted when deposit and withdraw
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct LpChangeEvent {
     pub pool_id: Pubkey,
     pub lp_amount_before: u64,
@@ -45,7 +44,7 @@ pub struct LpChangeEvent {
     pub change_type: u8,
 }
 /// Emitted when swap
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapEventV1 {
     pub pool_id: Pubkey,
     /// pool vault sub trade fees
@@ -63,7 +62,7 @@ pub struct SwapEventV1 {
 }
 
 /// Emitted when swap
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapEventV2 {
     pub pool_id: Pubkey,
     /// pool vault sub trade fees

--- a/packages/raydium/src/cpmm/instructions.rs
+++ b/packages/raydium/src/cpmm/instructions.rs
@@ -2,7 +2,6 @@
 
 use idls_common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 
 // -----------------------------------------------------------------------------
 // Discriminators
@@ -25,7 +24,7 @@ pub const WITHDRAW: [u8; 8] = [183, 18, 70, 156, 148, 109, 161, 34];
 // -----------------------------------------------------------------------------
 // Instruction enumeration
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RaydiumCpmmInstruction {
     ClosePermissionPda,
     CollectCreatorFee,
@@ -55,7 +54,7 @@ pub enum RaydiumCpmmInstruction {
 /// * `amount_0_requested` - The maximum amount of token_0 to send, can be 0 to collect fees in only token_1
 /// * `amount_1_requested` - The maximum amount of token_1 to send, can be 0 to collect fees in only token_0
 ///
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CollectFundFeeInstruction {
     pub amount_0_requested: u64,
     pub amount_1_requested: u64,
@@ -69,7 +68,7 @@ pub struct CollectFundFeeInstruction {
 /// * `amount_0_requested` - The maximum amount of token_0 to send, can be 0 to collect fees in only token_1
 /// * `amount_1_requested` - The maximum amount of token_1 to send, can be 0 to collect fees in only token_0
 ///
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CollectProtocolFeeInstruction {
     pub amount_0_requested: u64,
     pub amount_1_requested: u64,
@@ -83,7 +82,7 @@ pub struct CollectProtocolFeeInstruction {
 /// * `protocol_fee_rate` - The rate of protocol fee within trade fee.
 /// * `fund_fee_rate` - The rate of fund fee within trade fee.
 ///
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreateAmmConfigInstruction {
     pub index: u16,
     pub trade_fee_rate: u64,
@@ -102,7 +101,7 @@ pub struct CreateAmmConfigInstruction {
 /// * `maximum_token_0_amount` -  Maximum token 0 amount to deposit, prevents excessive slippage
 /// * `maximum_token_1_amount` - Maximum token 1 amount to deposit, prevents excessive slippage
 ///
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct DepositInstruction {
     pub lp_token_amount: u64,
     pub maximum_token_0_amount: u64,
@@ -118,7 +117,7 @@ pub struct DepositInstruction {
 /// * `init_amount_1` - the initial amount_1 to deposit
 /// * `open_time` - the timestamp allowed for swap
 ///
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeInstruction {
     pub init_amount_0: u64,
     pub init_amount_1: u64,
@@ -135,7 +134,7 @@ pub struct InitializeInstruction {
 /// * `open_time` - the timestamp allowed for swap
 /// * `creator_fee_on` - creator fee model, 0：both token0 and token1 (depends on the input), 1: only token0, 2: only token1
 ///
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeWithPermissionInstruction {
     pub init_amount_0: u64,
     pub init_amount_1: u64,
@@ -151,7 +150,7 @@ pub struct InitializeWithPermissionInstruction {
 /// * `amount_in` -  input amount to transfer, output to DESTINATION is based on the exchange rate
 /// * `minimum_amount_out` -  Minimum amount of output token, prevents excessive slippage
 ///
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapBaseInputInstruction {
     pub amount_in: u64,
     pub minimum_amount_out: u64,
@@ -165,7 +164,7 @@ pub struct SwapBaseInputInstruction {
 /// * `max_amount_in` -  input amount prevents excessive slippage
 /// * `amount_out` -  amount of output token
 ///
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapBaseOutputInstruction {
     pub max_amount_in: u64,
     pub amount_out: u64,
@@ -184,7 +183,7 @@ pub struct SwapBaseOutputInstruction {
 /// * `new_fund_owner`- The config's new fund owner, be set when `param` is 4
 /// * `param`- The value can be 0 | 1 | 2 | 3 | 4, otherwise will report a error
 ///
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct UpdateAmmConfigInstruction {
     pub param: u8,
     pub value: u64,
@@ -197,7 +196,7 @@ pub struct UpdateAmmConfigInstruction {
 /// * `ctx`- The context of accounts
 /// * `status` - The value of status
 ///
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct UpdatePoolStatusInstruction {
     pub status: u8,
 }
@@ -211,14 +210,14 @@ pub struct UpdatePoolStatusInstruction {
 /// * `minimum_token_0_amount` -  Minimum amount of token 0 to receive, prevents excessive slippage
 /// * `minimum_token_1_amount` -  Minimum amount of token 1 to receive, prevents excessive slippage
 ///
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct WithdrawInstruction {
     pub lp_token_amount: u64,
     pub minimum_token_0_amount: u64,
     pub minimum_token_1_amount: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum CreatorFeeOn {
     BothToken,
     OnlyToken0,

--- a/packages/raydium/src/launchpad/accounts.rs
+++ b/packages/raydium/src/launchpad/accounts.rs
@@ -1,5 +1,4 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 use substreams_solana::block_view::InstructionView;
 

--- a/packages/raydium/src/launchpad/events.rs
+++ b/packages/raydium/src/launchpad/events.rs
@@ -2,7 +2,6 @@
 
 use idls_common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
 // -----------------------------------------------------------------------------
@@ -17,7 +16,7 @@ const ANCHOR_DISC: [u8; 8] = [0xe4, 0x45, 0xa5, 0x2e, 0x51, 0xcb, 0x9a, 0x1d];
 // -----------------------------------------------------------------------------
 // Event enumeration
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RaydiumLaunchpadEvent {
     ClaimVestedEvent(ClaimVestedEvent),
     CreateVestingEvent(CreateVestingEvent),
@@ -30,7 +29,7 @@ pub enum RaydiumLaunchpadEvent {
 // Payload structs
 // -----------------------------------------------------------------------------
 /// Emitted when vesting token claimed by beneficiary
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ClaimVestedEvent {
     pub pool_state: Pubkey,
     pub beneficiary: Pubkey,
@@ -38,7 +37,7 @@ pub struct ClaimVestedEvent {
 }
 
 /// Emitted when vest_account created
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct CreateVestingEvent {
     pub pool_state: Pubkey,
     pub beneficiary: Pubkey,
@@ -46,7 +45,7 @@ pub struct CreateVestingEvent {
 }
 
 /// Emitted when pool created
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct PoolCreateEvent {
     pub pool_state: Pubkey,
     pub creator: Pubkey,
@@ -58,7 +57,7 @@ pub struct PoolCreateEvent {
 }
 
 /// Emitted when trade process
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct TradeEvent {
     pub pool_state: Pubkey,
     pub total_base_sell: u64,
@@ -82,7 +81,7 @@ pub struct TradeEvent {
 // -----------------------------------------------------------------------------
 // Additional types
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct MintParams {
     pub decimals: u8,
     pub name: String,
@@ -90,14 +89,14 @@ pub struct MintParams {
     pub uri: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum CurveParams {
     Constant { data: ConstantCurve },
     Fixed { data: FixedCurve },
     Linear { data: LinearCurve },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ConstantCurve {
     pub supply: u64,
     pub total_base_sell: u64,
@@ -105,40 +104,40 @@ pub struct ConstantCurve {
     pub migrate_type: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct FixedCurve {
     pub supply: u64,
     pub total_quote_fund_raising: u64,
     pub migrate_type: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct LinearCurve {
     pub supply: u64,
     pub total_quote_fund_raising: u64,
     pub migrate_type: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct VestingParams {
     pub total_locked_amount: u64,
     pub cliff_period: u64,
     pub unlock_period: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum AmmCreatorFeeOn {
     QuoteToken,
     BothToken,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum TradeDirection {
     Buy,
     Sell,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum PoolStatus {
     Fund,
     Migrate,

--- a/packages/raydium/src/launchpad/instructions.rs
+++ b/packages/raydium/src/launchpad/instructions.rs
@@ -2,7 +2,6 @@
 
 use idls_common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 
 // -----------------------------------------------------------------------------
 // Discriminators
@@ -15,7 +14,7 @@ pub const SELL_EXACT_OUT: [u8; 8] = [95, 200, 71, 34, 8, 9, 11, 166];
 // -----------------------------------------------------------------------------
 // Instruction enumeration
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RaydiumLaunchpadInstruction {
     BuyExactIn(BuyExactInInstruction),
     BuyExactOut(BuyExactOutInstruction),
@@ -28,7 +27,7 @@ pub enum RaydiumLaunchpadInstruction {
 // Payload structs
 // -----------------------------------------------------------------------------
 /// Use the given amount of quote tokens to purchase base tokens.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct BuyExactInInstruction {
     /// Amount of quote token to purchase
     pub amount_in: u64,
@@ -39,7 +38,7 @@ pub struct BuyExactInInstruction {
 }
 
 /// Use quote tokens to purchase the given amount of base tokens.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct BuyExactOutInstruction {
     /// Amount of base token to receive
     pub amount_out: u64,
@@ -50,7 +49,7 @@ pub struct BuyExactOutInstruction {
 }
 
 /// Use the given amount of base tokens to sell for quote tokens.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SellExactInInstruction {
     /// Amount of base token to sell
     pub amount_in: u64,
@@ -61,7 +60,7 @@ pub struct SellExactInInstruction {
 }
 
 /// Sell base tokens for the given amount of quote tokens.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SellExactOutInstruction {
     /// Amount of quote token to receive
     pub amount_out: u64,

--- a/packages/raydium/src/stable/accounts.rs
+++ b/packages/raydium/src/stable/accounts.rs
@@ -1,5 +1,4 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 use substreams_solana::block_view::InstructionView;
 

--- a/packages/raydium/src/stable/events.rs
+++ b/packages/raydium/src/stable/events.rs
@@ -2,7 +2,6 @@
 
 use idls_common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 
 // -----------------------------------------------------------------------------
 // Discriminators
@@ -13,7 +12,7 @@ pub const SWAP_EVENT: [u8; 8] = [64, 198, 205, 232, 38, 8, 113, 226];
 // -----------------------------------------------------------------------------
 // Event enumeration
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RaydiumStableEvent {
     /// Emitted when a swap occurs.
     SwapEvent(SwapEvent),
@@ -28,7 +27,7 @@ pub enum RaydiumStableEvent {
 ///
 /// The payload layout is:
 /// `[u8 dex][u64 amount_in][u64 amount_out]`.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapEvent {
     /// DEX identifier as defined by Jupiter's aggregator.
     pub dex: u8,

--- a/packages/raydium/src/stable/instructions.rs
+++ b/packages/raydium/src/stable/instructions.rs
@@ -1,7 +1,6 @@
 //! Raydium Stable AMM instructions.
 
 use idls_common::ParseError;
-use serde::{Deserialize, Serialize};
 use borsh::{BorshDeserialize, BorshSerialize};
 
 // -----------------------------------------------------------------------------
@@ -17,7 +16,7 @@ pub const SWAP_BASE_OUT: u8 = 11;
 // -----------------------------------------------------------------------------
 // Instruction enumeration
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RaydiumStableInstruction {
     Initialize(InitializeInstruction),
     Deposit(DepositInstruction),
@@ -31,36 +30,36 @@ pub enum RaydiumStableInstruction {
 // -----------------------------------------------------------------------------
 // Payload structs
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct InitializeInstruction {
     pub nonce: u8,
     pub open_time: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct PreInitializeInstruction {
     pub nonce: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct DepositInstruction {
     pub max_coin_amount: u64,
     pub max_pc_amount: u64,
     pub base_side: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct WithdrawInstruction {
     pub amount: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapBaseInInstruction {
     pub amount_in: u64,
     pub minimum_amount_out: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapBaseOutInstruction {
     pub max_amount_in: u64,
     pub amount_out: u64,

--- a/packages/stabble/Cargo.toml
+++ b/packages/stabble/Cargo.toml
@@ -9,10 +9,4 @@ substreams = { workspace = true }
 substreams-solana = { workspace = true }
 solana-program = { workspace = true }
 borsh = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
-thiserror = { workspace = true }
-serde-big-array = { workspace = true }
 
-[dev-dependencies]
-base64 = { workspace = true }

--- a/packages/stabble/src/accounts.rs
+++ b/packages/stabble/src/accounts.rs
@@ -1,5 +1,4 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 use substreams_solana::block_view::InstructionView;
 

--- a/packages/stabble/src/events.rs
+++ b/packages/stabble/src/events.rs
@@ -2,7 +2,6 @@
 
 use idls_common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
 // -----------------------------------------------------------------------------
@@ -14,7 +13,7 @@ pub const POOL_UPDATED_EVENT: [u8; 8] = [128, 39, 94, 221, 230, 222, 127, 141];
 // -----------------------------------------------------------------------------
 // Event enumeration
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StabbleEvent {
     PoolBalanceUpdatedEvent(PoolBalanceUpdatedEvent),
     PoolUpdatedEvent(PoolUpdatedEvent),
@@ -24,24 +23,24 @@ pub enum StabbleEvent {
 // -----------------------------------------------------------------------------
 // Payload structs
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct PoolBalanceUpdatedEvent {
     pub pubkey: Pubkey,
     pub data: PoolBalanceUpdatedData,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct PoolBalanceUpdatedData {
     pub balances: Vec<u64>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct PoolUpdatedEvent {
     pub pubkey: Pubkey,
     pub data: PoolUpdatedData,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct PoolUpdatedData {
     pub is_active: bool,
     pub swap_fee: u64,

--- a/packages/stabble/src/instructions.rs
+++ b/packages/stabble/src/instructions.rs
@@ -2,7 +2,6 @@
 
 use idls_common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 
 // -----------------------------------------------------------------------------
 // Discriminators
@@ -14,7 +13,7 @@ pub const SWAP: [u8; 8] = [248, 198, 158, 145, 225, 117, 135, 200];
 // -----------------------------------------------------------------------------
 // Instruction enumeration
 // -----------------------------------------------------------------------------
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StabbleInstruction {
     Deposit(DepositInstruction),
     Withdraw(WithdrawInstruction),
@@ -26,21 +25,21 @@ pub enum StabbleInstruction {
 // Payload structs
 // -----------------------------------------------------------------------------
 /// Add liquidity to the pool.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct DepositInstruction {
     pub amounts: Vec<u64>,
     pub minimum_amount_out: u64,
 }
 
 /// Remove liquidity from the pool.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct WithdrawInstruction {
     pub amount: u64,
     pub minimum_amounts_out: Vec<u64>,
 }
 
 /// Swap tokens through the pool.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SwapInstruction {
     pub amount_in: Option<u64>,
     pub minimum_amount_out: u64,


### PR DESCRIPTION
## Summary
- drop serde, serde_json, and serde-big-array from workspace
- strip unused serde derives and thiserror/base64 deps across crates
- document minimal dependency set in README

## Testing
- `cargo test -q`


------
https://chatgpt.com/codex/tasks/task_b_68c5c04dfcd08328816641f1ca234fb6