### PR TITLE
Handle new Raydium Launchpad trade event format

### DIFF
--- a/tests/raydium_launchpad.rs
+++ b/tests/raydium_launchpad.rs
@@ -8,7 +8,7 @@ mod tests {
     fn unpack_launchpad_trade_event() {
         let bytes = hex!("e445a52e51cb9a1dbddb7fd34ee661eef5e31a347d6c0ffb5c1019f78d2c2244f6c99c6e873d3928bf94d281f65888bf0078c5fb51d10200de740e3ee9cf0300d7af30fc060000005ba7ef1db2a002006c872c7f0f000000577b4148b3a00200f2a5427f0f0000001c69160000000000fcd3512a01000000590e0000000000005f39000000000000de020000000000000000000000000000000001");
         match launchpad::events::unpack(&bytes).expect("decode event") {
-            launchpad::events::RaydiumLaunchpadEvent::TradeEvent(event) => {
+            launchpad::events::RaydiumLaunchpadEvent::TradeEventV1(event) => {
                 assert_eq!(event.pool_state.to_string(), "HYqjiMv2jVE41qMoBDXAE5SEeNcyaEQMaEuVHCuisB4A", "pool_state");
                 assert_eq!(event.total_base_sell, 793_100_000_000_000, "total_base_sell");
                 assert_eq!(event.virtual_base, 1_073_025_605_596_382, "virtual_base");
@@ -27,7 +27,32 @@ mod tests {
                 assert!(matches!(event.pool_status, launchpad::events::PoolStatus::Fund), "pool_status");
                 assert!(event.exact_in, "exact_in");
             }
-            _ => panic!("Expected TradeEvent"),
+            _ => panic!("Expected TradeEventV1"),
+        }
+    }
+
+    #[test]
+    fn unpack_launchpad_trade_event_2() {
+        let bytes = hex!("e445a52e51cb9a1dbddb7fd34ee661ee98f7bd21e067c6d32836f1fedec18b74080417ae1639b740c2ae2cf1ed4d166b0078c5fb51d10200de740e3ee9cf0300d7af30fc06000000bd19242496bc0200960933c61100000035f94e2496bc0200710d33c611000000e80300000000000078df2a000000000003000000000000000a0000000000000000000000000000000000");
+        match launchpad::events::unpack(&bytes).expect("decode event") {
+            launchpad::events::RaydiumLaunchpadEvent::TradeEventV2(event) => {
+                assert_eq!(event.pool_state.to_string(), "BJ859ZCoKvCrq6Fv9aJGChHy9UnG7o2ZhLVpsYw8wyPp", "pool_state");
+                assert_eq!(event.total_base_sell, 793_100_000_000_000, "total_base_sell");
+                assert_eq!(event.virtual_base, 1_073_025_605_596_382, "virtual_base");
+                assert_eq!(event.virtual_quote, 30_000_852_951, "virtual_quote");
+                assert_eq!(event.real_base_before, 770_302_990_883_261, "real_base_before");
+                assert_eq!(event.real_quote_before, 76_339_677_590, "real_quote_before");
+                assert_eq!(event.real_base_after, 770_302_993_692_981, "real_base_after");
+                assert_eq!(event.real_quote_after, 76_339_678_577, "real_quote_after");
+                assert_eq!(event.amount_in, 1_000, "amount_in");
+                assert_eq!(event.amount_out, 2_809_720, "amount_out");
+                assert_eq!(event.protocol_fee, 3, "protocol_fee");
+                assert_eq!(event.platform_fee, 10, "platform_fee");
+                assert_eq!(event.share_fee, 0, "share_fee");
+                assert!(matches!(event.trade_direction, launchpad::events::TradeDirection::Buy), "trade_direction");
+                assert!(matches!(event.pool_status, launchpad::events::PoolStatus::Fund), "pool_status");
+            }
+            _ => panic!("Expected TradeEventV2"),
         }
     }
 }


### PR DESCRIPTION
## Summary
- split Raydium Launchpad TradeEvent into V1 and V2 structs, matching payload length
- dispatch TradeEventV1/V2 based on data length instead of optional fields
- test decoding of both trade event versions

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_68c5bb88d8a883288dcd37c42ea3c68c