### PR TITLE
feat: add pancakeswap swap instruction and event parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,6 +782,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pancakeswap"
+version = "0.1.0"
+dependencies = [
+ "base64 0.22.1",
+ "borsh 1.5.7",
+ "common",
+ "solana-program",
+ "substreams",
+ "substreams-solana",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2102,6 +2114,7 @@ dependencies = [
  "jupiter",
  "meteora",
  "orca",
+ "pancakeswap",
  "phoenix",
  "pumpfun",
  "raydium",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "packages/orca",
     "packages/phoenix",
     "packages/stabble",
+    "packages/pancakeswap",
 ]
 
 [dependencies]
@@ -27,6 +28,7 @@ phoenix = { version = "0.1.0", path = "packages/phoenix" }
 pumpfun = { version = "0.1.0", path = "packages/pumpfun" }
 raydium = { version = "0.1.0", path = "packages/raydium" }
 stabble = { version = "0.1.0", path = "packages/stabble" }
+pancakeswap = { version = "0.1.0", path = "packages/pancakeswap" }
 
 [workspace.dependencies]
 substreams = "0.6.2"

--- a/packages/pancakeswap/Cargo.toml
+++ b/packages/pancakeswap/Cargo.toml
@@ -10,3 +10,6 @@ substreams = { workspace = true }
 substreams-solana = { workspace = true }
 solana-program = { workspace = true }
 borsh = { workspace = true }
+
+[dev-dependencies]
+base64 = { workspace = true }

--- a/packages/pancakeswap/src/README.md
+++ b/packages/pancakeswap/src/README.md
@@ -1,0 +1,5 @@
+# PancakeSwap
+
+Program-specific instruction and event codecs for the PancakeSwap concentrated liquidity AMM on Solana.
+
+<https://solscan.io/account/HpNfyc2Saw7RKkQd8nEL4khUcuPhQ7WwY1B2qjx8jxFq>

--- a/packages/pancakeswap/src/accounts.rs
+++ b/packages/pancakeswap/src/accounts.rs
@@ -1,0 +1,35 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+use solana_program::pubkey::Pubkey;
+use substreams_solana::block_view::InstructionView;
+
+use common::accounts;
+
+// -----------------------------------------------------------------------------
+// Swap accounts
+// -----------------------------------------------------------------------------
+accounts!(
+    SwapAccounts,
+    get_swap_accounts,
+    {
+        /// The user performing the swap
+        payer,
+        /// The factory state to read protocol fees
+        amm_config,
+        /// The program account of the pool in which the swap will be performed
+        pool_state,
+        /// The user token account for input token
+        input_token_account,
+        /// The user token account for output token
+        output_token_account,
+        /// The vault token account for input token
+        input_vault,
+        /// The vault token account for output token
+        output_vault,
+        /// The program account for the most recent oracle observation
+        observation_state,
+        /// SPL program for token transfers
+        token_program,
+        /// Tick array account used in the swap
+        tick_array
+    }
+);

--- a/packages/pancakeswap/src/events.rs
+++ b/packages/pancakeswap/src/events.rs
@@ -1,0 +1,62 @@
+//! PancakeSwap AMM on-chain events.
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use common::ParseError;
+use solana_program::pubkey::Pubkey;
+
+// -----------------------------------------------------------------------------
+// Discriminators
+// -----------------------------------------------------------------------------
+const SWAP_EVENT: [u8; 8] = [64, 198, 205, 232, 38, 8, 113, 226];
+
+// -----------------------------------------------------------------------------
+// Event enumeration
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PancakeSwapEvent {
+    Swap(SwapEvent),
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Payload structs
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct SwapEvent {
+    pub pool_state: Pubkey,
+    pub sender: Pubkey,
+    pub token_account_0: Pubkey,
+    pub token_account_1: Pubkey,
+    pub amount_0: u64,
+    pub transfer_fee_0: u64,
+    pub amount_1: u64,
+    pub transfer_fee_1: u64,
+    pub zero_for_one: bool,
+    pub sqrt_price_x64: u128,
+    pub liquidity: u128,
+    pub tick: i32,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for PancakeSwapEvent {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.len() < 8 {
+            return Err(ParseError::TooShort(data.len()));
+        }
+        let (disc, payload) = data.split_at(8);
+        let discriminator: [u8; 8] = disc.try_into().expect("slice len 8");
+        Ok(match discriminator {
+            SWAP_EVENT => Self::Swap(SwapEvent::try_from_slice(payload)?),
+            other => return Err(ParseError::Unknown(other)),
+        })
+    }
+}
+
+/// Convenience wrapper that forwards to `TryFrom`.
+pub fn unpack(data: &[u8]) -> Result<PancakeSwapEvent, ParseError> {
+    PancakeSwapEvent::try_from(data)
+}

--- a/packages/pancakeswap/src/instructions.rs
+++ b/packages/pancakeswap/src/instructions.rs
@@ -1,0 +1,53 @@
+//! PancakeSwap AMM on-chain instructions.
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use common::ParseError;
+
+// -----------------------------------------------------------------------------
+// Discriminators
+// -----------------------------------------------------------------------------
+const SWAP: [u8; 8] = [248, 198, 158, 145, 225, 117, 135, 200];
+
+// -----------------------------------------------------------------------------
+// Instruction enumeration
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PancakeSwapInstruction {
+    Swap(SwapInstruction),
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Payload structs
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct SwapInstruction {
+    pub amount: u64,
+    pub other_amount_threshold: u64,
+    pub sqrt_price_limit_x64: u128,
+    pub is_base_input: bool,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for PancakeSwapInstruction {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.len() < 8 {
+            return Err(ParseError::TooShort(data.len()));
+        }
+        let (disc, payload) = data.split_at(8);
+        let discriminator: [u8; 8] = disc.try_into().expect("slice len 8");
+        Ok(match discriminator {
+            SWAP => Self::Swap(SwapInstruction::try_from_slice(payload)?),
+            other => return Err(ParseError::Unknown(other)),
+        })
+    }
+}
+
+/// Convenience wrapper that forwards to `TryFrom`.
+pub fn unpack(data: &[u8]) -> Result<PancakeSwapInstruction, ParseError> {
+    PancakeSwapInstruction::try_from(data)
+}

--- a/packages/pancakeswap/src/lib.rs
+++ b/packages/pancakeswap/src/lib.rs
@@ -1,0 +1,11 @@
+extern crate common;
+use substreams_solana::b58;
+
+pub mod accounts;
+pub mod events;
+pub mod instructions;
+
+/// PancakeSwap concentrated liquidity AMM program
+///
+/// https://solscan.io/account/HpNfyc2Saw7RKkQd8nEL4khUcuPhQ7WwY1B2qjx8jxFq
+pub const PROGRAM_ID: [u8; 32] = b58!("HpNfyc2Saw7RKkQd8nEL4khUcuPhQ7WwY1B2qjx8jxFq");

--- a/packages/pancakeswap/tests/pancakeswap.rs
+++ b/packages/pancakeswap/tests/pancakeswap.rs
@@ -1,0 +1,54 @@
+#[cfg(test)]
+mod tests {
+    use base64::prelude::*;
+    use pancakeswap;
+    use substreams::hex;
+
+    #[test]
+    fn swap_instruction() {
+        let bytes = hex!("f8c69e91e17587c8001bb70000000000ffffffffffffffff0000000000000000000000000000000000");
+        match pancakeswap::instructions::unpack(&bytes).expect("decode instruction") {
+            pancakeswap::instructions::PancakeSwapInstruction::Swap(ix) => {
+                assert_eq!(
+                    ix,
+                    pancakeswap::instructions::SwapInstruction {
+                        amount: 12_000_000,
+                        other_amount_threshold: u64::MAX,
+                        sqrt_price_limit_x64: 0,
+                        is_base_input: false,
+                    }
+                );
+            }
+            _ => panic!("Expected SwapInstruction"),
+        }
+    }
+
+    #[test]
+    fn swap_event() {
+        let bytes = BASE64_STANDARD
+            .decode("QMbN6CYIceJ7JcKWCueJDroD6zdLF7C8Scs5WVmrkFzhFFxokePKiSMs7ScTXdfDnZnirgrntvRpZY8iIJA0U4ZGOOkDB1xy01xyr7Wn83b59FUflt8S+3YR7TDsa5HnmGozMQoBxqOKe+XwJSlYektM0QaH8s/H6HLIQhCF7BhBgqiQQbr8zC4EHwAAAAAAAAAAAAAAAAAAG7cAAAAAAAAAAAAAAAAAATY2amoJdgFuAgAAAAAAAAB65SHmCgAAAAAAAAAAAAAAXEUAAA==")
+            .expect("base64 decode");
+        match pancakeswap::events::unpack(&bytes).expect("decode event") {
+            pancakeswap::events::PancakeSwapEvent::Swap(event) => {
+                assert_eq!(
+                    event,
+                    pancakeswap::events::SwapEvent {
+                        pool_state: "9HiYSTWK5otBxVc9e9bTNhpRDiDKjki65o9YxRhPWyQC".parse().unwrap(),
+                        sender: "3NK19Y8KQyr3HmJVEmn1gjaXDDDpsVVQtBWmHkwZXkAm".parse().unwrap(),
+                        token_account_0: "FE4na6rdS6xsCf2WbebozF4tizMW6JXUMX2tdBsyKmsG".parse().unwrap(),
+                        token_account_1: "AKaqdf9yFtgArvdXG9LNx6dsR8dC7WAVjRzmJD4gSMUf".parse().unwrap(),
+                        amount_0: 2_032_686,
+                        transfer_fee_0: 0,
+                        amount_1: 12_000_000,
+                        transfer_fee_1: 0,
+                        zero_for_one: true,
+                        sqrt_price_x64: 44_820_234_749_380_015_670,
+                        liquidity: 46_810_654_074,
+                        tick: 17_756,
+                    }
+                );
+            }
+            _ => panic!("Expected SwapEvent"),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub use common;
 pub use jupiter;
 pub use meteora;
 pub use orca;
+pub use pancakeswap;
 pub use phoenix;
 pub use pumpfun;
 pub use raydium;


### PR DESCRIPTION
## Summary
- add PancakeSwap instruction & event modules
- decode swap instruction and SwapEvent logs with tests
- expose PancakeSwap crate in workspace

## Testing
- `cargo test -p pancakeswap`
- `cargo test -p substreams-solana-idls`


------
https://chatgpt.com/codex/tasks/task_b_68c6f08f41008328b14d365019772bbf