### PR TITLE
Add Drift v2 instruction and event decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,6 +380,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "drift"
+version = "0.1.0"
+dependencies = [
+ "base64 0.22.1",
+ "borsh 1.5.7",
+ "common",
+ "solana-program",
+ "substreams",
+ "substreams-solana",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2099,6 +2111,7 @@ version = "0.5.5"
 dependencies = [
  "bonkswap",
  "common",
+ "drift",
  "jupiter",
  "meteora",
  "orca",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "packages/jupiter",
     "packages/meteora",
     "packages/orca",
+    "packages/drift",
     "packages/phoenix",
     "packages/stabble",
 ]
@@ -27,6 +28,7 @@ phoenix = { version = "0.1.0", path = "packages/phoenix" }
 pumpfun = { version = "0.1.0", path = "packages/pumpfun" }
 raydium = { version = "0.1.0", path = "packages/raydium" }
 stabble = { version = "0.1.0", path = "packages/stabble" }
+drift = { version = "0.1.0", path = "packages/drift" }
 
 [workspace.dependencies]
 substreams = "0.6.2"

--- a/packages/drift/Cargo.toml
+++ b/packages/drift/Cargo.toml
@@ -10,3 +10,6 @@ substreams = { workspace = true }
 substreams-solana = { workspace = true }
 solana-program = { workspace = true }
 borsh = { workspace = true }
+
+[dev-dependencies]
+base64 = { workspace = true }

--- a/packages/drift/src/lib.rs
+++ b/packages/drift/src/lib.rs
@@ -1,0 +1,4 @@
+#[macro_use]
+extern crate common;
+
+pub mod v2;

--- a/packages/drift/src/v2/accounts.rs
+++ b/packages/drift/src/v2/accounts.rs
@@ -1,0 +1,42 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+use solana_program::pubkey::Pubkey;
+use substreams_solana::block_view::InstructionView;
+
+// -----------------------------------------------------------------------------
+// Account structs
+// -----------------------------------------------------------------------------
+accounts!(
+    BeginSwapAccounts,
+    get_begin_swap_accounts,
+    {
+        state,
+        user,
+        user_stats,
+        authority,
+        out_spot_market_vault,
+        in_spot_market_vault,
+        out_token_account,
+        in_token_account,
+        token_program,
+        drift_signer,
+        instructions
+    }
+);
+
+accounts!(
+    EndSwapAccounts,
+    get_end_swap_accounts,
+    {
+        state,
+        user,
+        user_stats,
+        authority,
+        out_spot_market_vault,
+        in_spot_market_vault,
+        out_token_account,
+        in_token_account,
+        token_program,
+        drift_signer,
+        instructions
+    }
+);

--- a/packages/drift/src/v2/events.rs
+++ b/packages/drift/src/v2/events.rs
@@ -1,0 +1,77 @@
+//! Drift v2 on-chain events.
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use common::ParseError;
+use solana_program::pubkey::Pubkey;
+
+// -----------------------------------------------------------------------------
+// Discriminators
+// -----------------------------------------------------------------------------
+pub const SPOT_INTEREST_RECORD: [u8; 8] = [183, 186, 203, 186, 225, 187, 95, 130];
+pub const SWAP_RECORD: [u8; 8] = [162, 187, 123, 194, 138, 56, 250, 241];
+
+// -----------------------------------------------------------------------------
+// Event enumeration
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DriftEvent {
+    SpotInterestRecord(SpotInterestRecord),
+    SwapRecord(SwapRecord),
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Payload structs
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct SpotInterestRecord {
+    pub ts: i64,
+    pub market_index: u16,
+    pub deposit_balance: u128,
+    pub cumulative_deposit_interest: u128,
+    pub borrow_balance: u128,
+    pub cumulative_borrow_interest: u128,
+    pub optimal_utilization: u32,
+    pub optimal_borrow_rate: u32,
+    pub max_borrow_rate: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct SwapRecord {
+    pub ts: i64,
+    pub user: Pubkey,
+    pub amount_out: u64,
+    pub amount_in: u64,
+    pub out_market_index: u16,
+    pub in_market_index: u16,
+    pub out_oracle_price: i64,
+    pub in_oracle_price: i64,
+    pub fee: u64,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for DriftEvent {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.len() < 8 {
+            return Err(ParseError::TooShort(data.len()));
+        }
+
+        let (disc, payload) = data.split_at(8);
+        let discriminator: [u8; 8] = disc.try_into().expect("slice len 8");
+
+        Ok(match discriminator {
+            SPOT_INTEREST_RECORD => Self::SpotInterestRecord(SpotInterestRecord::try_from_slice(payload)?),
+            SWAP_RECORD => Self::SwapRecord(SwapRecord::try_from_slice(payload)?),
+            _ => Self::Unknown,
+        })
+    }
+}
+
+/// Convenience wrapper that forwards to `TryFrom`.
+pub fn unpack(data: &[u8]) -> Result<DriftEvent, ParseError> {
+    DriftEvent::try_from(data)
+}

--- a/packages/drift/src/v2/instructions.rs
+++ b/packages/drift/src/v2/instructions.rs
@@ -1,0 +1,74 @@
+//! Drift v2 on-chain instructions.
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use common::ParseError;
+
+// -----------------------------------------------------------------------------
+// Custom types
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub enum SwapReduceOnly {
+    In,
+    Out,
+}
+
+// -----------------------------------------------------------------------------
+// Payload structs
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct BeginSwapInstruction {
+    pub in_market_index: u16,
+    pub out_market_index: u16,
+    pub amount_in: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct EndSwapInstruction {
+    pub in_market_index: u16,
+    pub out_market_index: u16,
+    pub limit_price: Option<u64>,
+    pub reduce_only: Option<SwapReduceOnly>,
+}
+
+// -----------------------------------------------------------------------------
+// Discriminators
+// -----------------------------------------------------------------------------
+pub const BEGIN_SWAP: [u8; 8] = [174, 109, 228, 1, 242, 105, 232, 105];
+pub const END_SWAP: [u8; 8] = [177, 184, 27, 193, 34, 13, 210, 145];
+
+// -----------------------------------------------------------------------------
+// Instruction enumeration
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub enum DriftInstruction {
+    BeginSwap(BeginSwapInstruction),
+    EndSwap(EndSwapInstruction),
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for DriftInstruction {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.len() < 8 {
+            return Err(ParseError::TooShort(data.len()));
+        }
+
+        let (disc, payload) = data.split_at(8);
+        let discriminator: [u8; 8] = disc.try_into().expect("slice len 8");
+
+        Ok(match discriminator {
+            BEGIN_SWAP => Self::BeginSwap(BeginSwapInstruction::try_from_slice(payload)?),
+            END_SWAP => Self::EndSwap(EndSwapInstruction::try_from_slice(payload)?),
+            other => return Err(ParseError::Unknown(other)),
+        })
+    }
+}
+
+/// Convenience wrapper that forwards to `TryFrom`.
+pub fn unpack(data: &[u8]) -> Result<DriftInstruction, ParseError> {
+    DriftInstruction::try_from(data)
+}

--- a/packages/drift/src/v2/mod.rs
+++ b/packages/drift/src/v2/mod.rs
@@ -1,0 +1,10 @@
+use substreams_solana::b58;
+
+pub mod accounts;
+pub mod events;
+pub mod instructions;
+
+/// Drift v2 program
+///
+/// https://solscan.io/account/dRiftyHA39MWEi3m9aunc5MzRF1JYuBsbn6VPcn33UH
+pub const PROGRAM_ID: [u8; 32] = b58!("dRiftyHA39MWEi3m9aunc5MzRF1JYuBsbn6VPcn33UH");

--- a/packages/drift/tests/drift_v2.rs
+++ b/packages/drift/tests/drift_v2.rs
@@ -1,0 +1,67 @@
+#[cfg(test)]
+mod tests {
+    use base64::Engine;
+    use drift::v2;
+    use substreams::hex;
+
+    #[test]
+    fn decode_begin_swap() {
+        let bytes = hex!("ae6de401f269e86921002200cace200c00000000");
+        match v2::instructions::unpack(&bytes).expect("decode instruction") {
+            v2::instructions::DriftInstruction::BeginSwap(ix) => {
+                assert_eq!(ix.in_market_index, 33);
+                assert_eq!(ix.out_market_index, 34);
+                assert_eq!(ix.amount_in, 203_476_682);
+            }
+            _ => panic!("expected BeginSwap"),
+        }
+
+        let base64 = "t7rLuuG7X4Kz78ZoAAAAACIAlBzegf+f7gAAAAAAAAAAANpNL28CAAAAAAAAAAAAAAAsF72HcZTGAAAAAAAAAAAABI3KfgIAAAAAAAAAAAAAAAA1DAAUzQAAoLsNAA==";
+        let bytes = base64::engine::general_purpose::STANDARD.decode(base64).expect("decode base64");
+        match v2::events::unpack(&bytes).expect("decode event") {
+            v2::events::DriftEvent::SpotInterestRecord(event) => {
+                assert_eq!(event.ts, 1_757_867_955);
+                assert_eq!(event.market_index, 34);
+                assert_eq!(event.deposit_balance, 67_166_964_201_430_164u128);
+                assert_eq!(event.cumulative_deposit_interest, 10_455_305_690u128);
+                assert_eq!(event.borrow_balance, 55_895_260_718_241_580u128);
+                assert_eq!(event.cumulative_borrow_interest, 10_717_138_180u128);
+                assert_eq!(event.optimal_utilization, 800_000);
+                assert_eq!(event.optimal_borrow_rate, 52_500);
+                assert_eq!(event.max_borrow_rate, 900_000);
+            }
+            _ => panic!("expected SpotInterestRecord"),
+        }
+    }
+
+    #[test]
+    fn decode_end_swap() {
+        let bytes = hex!("b1b81bc1220dd291210022000000");
+        match v2::instructions::unpack(&bytes).expect("decode instruction") {
+            v2::instructions::DriftInstruction::EndSwap(ix) => {
+                assert_eq!(ix.in_market_index, 33);
+                assert_eq!(ix.out_market_index, 34);
+                assert!(ix.limit_price.is_none());
+                assert!(ix.reduce_only.is_none());
+            }
+            _ => panic!("expected EndSwap"),
+        }
+
+        let base64 = "ort7woo4+vGz78ZoAAAAAM+cjY9Ys484qMhhiydb7T65y+yoAqScK1eP11GYiHBWAIyGRwAAAADBtB0MAAAAACIAIQDZQQ8AAAAAADcJWgAAAAAAAAAAAAAAAAA=";
+        let bytes = base64::engine::general_purpose::STANDARD.decode(base64).expect("decode base64");
+        match v2::events::unpack(&bytes).expect("decode event") {
+            v2::events::DriftEvent::SwapRecord(event) => {
+                assert_eq!(event.ts, 1_757_867_955);
+                assert_eq!(event.user.to_string(), "EyRrHJuMqqiE2yMQSecHJ4hK1Y9MM7QUB39coLpc2RLq");
+                assert_eq!(event.amount_out, 1_200_000_000);
+                assert_eq!(event.amount_in, 203_273_409);
+                assert_eq!(event.out_market_index, 34);
+                assert_eq!(event.in_market_index, 33);
+                assert_eq!(event.out_oracle_price, 999_897);
+                assert_eq!(event.in_oracle_price, 5_900_599);
+                assert_eq!(event.fee, 0);
+            }
+            _ => panic!("expected SwapRecord"),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub use bonkswap;
 pub use common;
+pub use drift;
 pub use jupiter;
 pub use meteora;
 pub use orca;


### PR DESCRIPTION
## Summary
- add drift v2 crate with program id
- decode BeginSwap and EndSwap instructions and related events
- test drift swap instructions and events against on-chain data

## Testing
- `cargo test -p drift`


------
https://chatgpt.com/codex/tasks/task_b_68c6f2ba9ee8832883b68aa11a77e0d4