### PR TITLE
feat: add solfi v2 instruction and event parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2066,6 +2066,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "solfi"
+version = "0.1.0"
+dependencies = [
+ "base64 0.22.1",
+ "borsh 1.5.7",
+ "common",
+ "solana-program",
+ "substreams",
+ "substreams-solana",
+]
+
+[[package]]
 name = "stabble"
 version = "0.1.0"
 dependencies = [
@@ -2150,6 +2162,7 @@ dependencies = [
  "phoenix",
  "pumpfun",
  "raydium",
+ "solfi",
  "stabble",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "packages/phoenix",
     "packages/stabble",
     "packages/pancakeswap",
+    "packages/solfi",
 ]
 
 [dependencies]
@@ -31,6 +32,7 @@ raydium = { version = "0.1.0", path = "packages/raydium" }
 stabble = { version = "0.1.0", path = "packages/stabble" }
 drift = { version = "0.1.0", path = "packages/drift" }
 pancakeswap = { version = "0.1.0", path = "packages/pancakeswap" }
+solfi = { version = "0.1.0", path = "packages/solfi" }
 
 [workspace.dependencies]
 substreams = "0.6.2"

--- a/packages/solfi/Cargo.toml
+++ b/packages/solfi/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "solfi"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+common = { path = "../common" }
+substreams = { workspace = true }
+substreams-solana = { workspace = true }
+solana-program = { workspace = true }
+borsh = { workspace = true }
+
+[dev-dependencies]
+base64 = { workspace = true }

--- a/packages/solfi/src/lib.rs
+++ b/packages/solfi/src/lib.rs
@@ -1,0 +1,3 @@
+extern crate common;
+
+pub mod v2;

--- a/packages/solfi/src/v2/events.rs
+++ b/packages/solfi/src/v2/events.rs
@@ -1,0 +1,56 @@
+//! Solfi V2 on-chain events and their Borsh-deserialisation helpers.
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use common::ParseError;
+use solana_program::pubkey::Pubkey;
+
+// -----------------------------------------------------------------------------
+// Discriminators (first 8 bytes of the emitted log's data)
+// -----------------------------------------------------------------------------
+const SWAP: [u8; 8] = [75, 117, 66, 193, 72, 85, 240, 37];
+
+// -----------------------------------------------------------------------------
+// High-level event enum
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SolfiEvent {
+    /// Swap. See [`SwapEvent`].
+    Swap(SwapEvent),
+    /// Discriminator did not match any known event.
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Payload structs
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct SwapEvent {
+    pub user: Pubkey,
+    pub amount_in: u64,
+    pub amount_out: u64,
+    pub unknown: u64,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for SolfiEvent {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.len() < 8 {
+            return Err(ParseError::TooShort(data.len()));
+        }
+        let disc: [u8; 8] = data[0..8].try_into().expect("slice len 8");
+        let payload = &data[8..];
+        Ok(match disc {
+            SWAP => Self::Swap(SwapEvent::try_from_slice(payload)?),
+            other => return Err(ParseError::Unknown(other)),
+        })
+    }
+}
+
+/// Convenience wrapper that forwards to `TryFrom`.
+pub fn unpack(data: &[u8]) -> Result<SolfiEvent, ParseError> {
+    SolfiEvent::try_from(data)
+}

--- a/packages/solfi/src/v2/instructions.rs
+++ b/packages/solfi/src/v2/instructions.rs
@@ -1,0 +1,52 @@
+//! Solfi V2 on-chain instructions.
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use common::ParseError;
+
+// -----------------------------------------------------------------------------
+// Discriminators
+// -----------------------------------------------------------------------------
+pub const SWAP: u8 = 7;
+
+// -----------------------------------------------------------------------------
+// Payload structs
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct SwapInstruction {
+    pub amount_in: u64,
+    pub minimum_out: u64,
+    pub direction: u8,
+}
+
+// -----------------------------------------------------------------------------
+// Instruction enumeration
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SolfiInstruction {
+    Swap(SwapInstruction),
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for SolfiInstruction {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.len() < 1 {
+            return Err(ParseError::TooShort(data.len()));
+        }
+
+        let (disc, payload) = data.split_at(1);
+        Ok(match disc[0] {
+            SWAP => Self::Swap(SwapInstruction::try_from_slice(payload)?),
+            other => return Err(ParseError::RaydiumUnknown(other)),
+        })
+    }
+}
+
+/// Convenience wrapper that forwards to `TryFrom`.
+pub fn unpack(data: &[u8]) -> Result<SolfiInstruction, ParseError> {
+    SolfiInstruction::try_from(data)
+}

--- a/packages/solfi/src/v2/mod.rs
+++ b/packages/solfi/src/v2/mod.rs
@@ -1,0 +1,9 @@
+use substreams_solana::b58;
+
+pub mod events;
+pub mod instructions;
+
+/// Solfi V2 program
+///
+/// https://solscan.io/account/SV2EYYJyRz2YhfXwXnhNAevDEui5Q6yrfyo13WtupPF
+pub const PROGRAM_ID: [u8; 32] = b58!("SV2EYYJyRz2YhfXwXnhNAevDEui5Q6yrfyo13WtupPF");

--- a/packages/solfi/tests/solfi_v2.rs
+++ b/packages/solfi/tests/solfi_v2.rs
@@ -1,0 +1,34 @@
+#[cfg(test)]
+mod tests {
+    use base64::Engine;
+    use solfi::v2;
+    use substreams::hex;
+
+    #[test]
+    fn decode_swap_instruction() {
+        let bytes = hex!("075ceb260200000000000000000000000001");
+        match v2::instructions::unpack(&bytes).expect("decode instruction") {
+            v2::instructions::SolfiInstruction::Swap(ix) => {
+                assert_eq!(ix.amount_in, 36_105_052);
+                assert_eq!(ix.minimum_out, 0);
+                assert_eq!(ix.direction, 1);
+            }
+            _ => panic!("expected Swap"),
+        }
+    }
+
+    #[test]
+    fn decode_swap_event() {
+        let base64 = "S3VCwUhV8CXSyrcV3EtPUNCsQJvXpBqCGUobEJZVRnnjiR0AAAAAAEob3RUAAAAAAAAAAAAAAAAAAAAAAAAAAA==";
+        let bytes = base64::engine::general_purpose::STANDARD.decode(base64).expect("decode base64");
+        match v2::events::unpack(&bytes).expect("decode event") {
+            v2::events::SolfiEvent::Swap(event) => {
+                assert_eq!(event.user.to_string(), "FBqu8mSDS32rbTLC3SUA17PLPLpXJb5qc8NBwLtmymjm");
+                assert_eq!(event.amount_in, 366_811_978);
+                assert_eq!(event.amount_out, 0);
+                assert_eq!(event.unknown, 0);
+            }
+            _ => panic!("expected Swap"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add solfi v2 crate with program ID `SV2EYYJyRz2YhfXwXnhNAevDEui5Q6yrfyo13WtupPF`
- implement swap instruction and swap event parsers
- cover instruction and event decoding with tests

## Testing
- `cargo test -p solfi`


------
https://chatgpt.com/codex/tasks/task_b_68c6fd733ee48328bbc7f4c3a05cce8a