### PR TITLE
Add Solfi v1 swap instruction and event parsing

### DIFF
--- a/packages/solfi/src/lib.rs
+++ b/packages/solfi/src/lib.rs
@@ -1,3 +1,4 @@
 extern crate common;
 
+pub mod v1;
 pub mod v2;

--- a/packages/solfi/src/v1/events.rs
+++ b/packages/solfi/src/v1/events.rs
@@ -1,0 +1,55 @@
+//! Solfi V1 on-chain events and their Borsh-deserialisation helpers.
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use common::ParseError;
+use solana_program::pubkey::Pubkey;
+
+// -----------------------------------------------------------------------------
+// Discriminators (first 8 bytes of the emitted log's data)
+// -----------------------------------------------------------------------------
+const SWAP: [u8; 8] = [79, 54, 102, 82, 188, 211, 62, 178];
+
+// -----------------------------------------------------------------------------
+// High-level event enum
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SolfiEvent {
+    /// Swap. See [`SwapEvent`].
+    Swap(SwapEvent),
+    /// Discriminator did not match any known event.
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Payload structs
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct SwapEvent {
+    pub user: Pubkey,
+    pub amount_in: u64,
+    pub amount_out: u64,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for SolfiEvent {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.len() < 8 {
+            return Err(ParseError::TooShort(data.len()));
+        }
+        let disc: [u8; 8] = data[0..8].try_into().expect("slice len 8");
+        let payload = &data[8..];
+        Ok(match disc {
+            SWAP => Self::Swap(SwapEvent::try_from_slice(payload)?),
+            other => return Err(ParseError::Unknown(other)),
+        })
+    }
+}
+
+/// Convenience wrapper that forwards to `TryFrom`.
+pub fn unpack(data: &[u8]) -> Result<SolfiEvent, ParseError> {
+    SolfiEvent::try_from(data)
+}

--- a/packages/solfi/src/v1/instructions.rs
+++ b/packages/solfi/src/v1/instructions.rs
@@ -1,0 +1,51 @@
+//! Solfi V1 on-chain instructions.
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use common::ParseError;
+
+// -----------------------------------------------------------------------------
+// Discriminators
+// -----------------------------------------------------------------------------
+pub const SWAP: u8 = 6;
+
+// -----------------------------------------------------------------------------
+// Payload structs
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct SwapInstruction {
+    /// Raw instruction data following the discriminator.
+    pub data: Vec<u8>,
+}
+
+// -----------------------------------------------------------------------------
+// Instruction enumeration
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SolfiInstruction {
+    Swap(SwapInstruction),
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for SolfiInstruction {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.is_empty() {
+            return Err(ParseError::TooShort(data.len()));
+        }
+
+        let (disc, payload) = data.split_at(1);
+        Ok(match disc[0] {
+            SWAP => Self::Swap(SwapInstruction { data: payload.to_vec() }),
+            other => return Err(ParseError::RaydiumUnknown(other)),
+        })
+    }
+}
+
+/// Convenience wrapper that forwards to `TryFrom`.
+pub fn unpack(data: &[u8]) -> Result<SolfiInstruction, ParseError> {
+    SolfiInstruction::try_from(data)
+}

--- a/packages/solfi/src/v1/mod.rs
+++ b/packages/solfi/src/v1/mod.rs
@@ -1,0 +1,9 @@
+use substreams_solana::b58;
+
+pub mod events;
+pub mod instructions;
+
+/// Solfi V1 program
+///
+/// https://solscan.io/account/SoLFiHG9TfgtdUXUjWAxi3LtvYuFyDLVhBWxdMZxyCe
+pub const PROGRAM_ID: [u8; 32] = b58!("SoLFiHG9TfgtdUXUjWAxi3LtvYuFyDLVhBWxdMZxyCe");

--- a/packages/solfi/tests/solfi_v1.rs
+++ b/packages/solfi/tests/solfi_v1.rs
@@ -1,0 +1,32 @@
+#[cfg(test)]
+mod tests {
+    use base64::Engine;
+    use solfi::v1;
+    use substreams::hex;
+
+    #[test]
+    fn decode_swap_instruction() {
+        let bytes = hex!("06faffffffffffffffad99f644000000004322dd1500000000d1e2534999010000e8030000000000000b23dd150000000001060000000000000000000000000000665ad1c1110000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+        match v1::instructions::unpack(&bytes).expect("decode instruction") {
+            v1::instructions::SolfiInstruction::Swap(ix) => {
+                assert_eq!(ix.data.len(), bytes.len() - 1);
+                assert_eq!(&ix.data[0..8], &hex!("faffffffffffffff"));
+            }
+            _ => panic!("expected Swap"),
+        }
+    }
+
+    #[test]
+    fn decode_swap_event() {
+        let base64 = "TzZmUrzTPrLxizcYaVilIUxKK9ig82ou11DM0Gbvv3U02w8BAAAAAEIi3RUAAAAAAAAAAAAAAAA=";
+        let bytes = base64::engine::general_purpose::STANDARD.decode(base64).expect("decode base64");
+        match v1::events::unpack(&bytes).expect("decode event") {
+            v1::events::SolfiEvent::Swap(event) => {
+                assert_eq!(event.user.to_string(), "HFtNuvz6jj2FbLp43M6Ean4mn3imJrmLzdgVQQNikAvK");
+                assert_eq!(event.amount_in, 366_813_762);
+                assert_eq!(event.amount_out, 0);
+            }
+            _ => panic!("expected Swap"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- expose Solfi v1 program with swap instruction parsing
- parse and decode swap events for Solfi v1
- add tests covering swap instruction and event logs

## Testing
- `cargo test -p solfi`


------
https://chatgpt.com/codex/tasks/task_b_68c6ffadd0f883288bca48abd730656e