### PR TITLE
Add OKX Dex v2 instruction support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,6 +770,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "okx"
+version = "0.1.0"
+dependencies = [
+ "borsh 1.5.7",
+ "common",
+ "solana-program",
+ "substreams",
+ "substreams-solana",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2157,6 +2168,7 @@ dependencies = [
  "drift",
  "jupiter",
  "meteora",
+ "okx",
  "orca",
  "pancakeswap",
  "phoenix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "packages/bonkswap",
     "packages/jupiter",
     "packages/meteora",
+    "packages/okx",
     "packages/orca",
     "packages/drift",
     "packages/phoenix",
@@ -33,6 +34,7 @@ stabble = { version = "0.1.0", path = "packages/stabble" }
 drift = { version = "0.1.0", path = "packages/drift" }
 pancakeswap = { version = "0.1.0", path = "packages/pancakeswap" }
 solfi = { version = "0.1.0", path = "packages/solfi" }
+okx = { version = "0.1.0", path = "packages/okx" }
 
 [workspace.dependencies]
 substreams = "0.6.2"

--- a/packages/okx/src/lib.rs
+++ b/packages/okx/src/lib.rs
@@ -1,0 +1,3 @@
+extern crate common;
+
+pub mod v2;

--- a/packages/okx/src/v2/instructions.rs
+++ b/packages/okx/src/v2/instructions.rs
@@ -1,0 +1,150 @@
+//! OKX Dex v2 on-chain instructions.
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use common::ParseError;
+
+// -----------------------------------------------------------------------------
+// Custom types
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct SwapArgs {
+    pub amount_in: u64,
+    pub expect_amount_out: u64,
+    pub min_return: u64,
+    pub amounts: Vec<u64>,
+    pub routes: Vec<Vec<Route>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct Route {
+    pub dexes: Vec<Dex>,
+    pub weights: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub enum Dex {
+    SplTokenSwap,
+    StableSwap,
+    Whirlpool,
+    MeteoraDynamicpool,
+    RaydiumSwap,
+    RaydiumStableSwap,
+    RaydiumClmmSwap,
+    AldrinExchangeV1,
+    AldrinExchangeV2,
+    LifinityV1,
+    LifinityV2,
+    RaydiumClmmSwapV2,
+    FluxBeam,
+    MeteoraDlmm,
+    RaydiumCpmmSwap,
+    OpenBookV2,
+    WhirlpoolV2,
+    Phoenix,
+    ObricV2,
+    SanctumAddLiq,
+    SanctumRemoveLiq,
+    SanctumNonWsolSwap,
+    SanctumWsolSwap,
+    PumpfunBuy,
+    PumpfunSell,
+    StabbleSwap,
+    SanctumRouter,
+    MeteoraVaultDeposit,
+    MeteoraVaultWithdraw,
+    Saros,
+    MeteoraLst,
+    Solfi,
+    QualiaSwap,
+    Zerofi,
+    PumpfunammBuy,
+    PumpfunammSell,
+    Virtuals,
+    VertigoBuy,
+    VertigoSell,
+    PerpetualsAddLiq,
+    PerpetualsRemoveLiq,
+    PerpetualsSwap,
+    RaydiumLaunchpad,
+    LetsBonkFun,
+    Woofi,
+    MeteoraDbc,
+    MeteoraDlmmSwap2,
+    MeteoraDAMMV2,
+    Gavel,
+    BoopfunBuy,
+    BoopfunSell,
+    MeteoraDbc2,
+    GooseFX,
+    Dooar,
+    Numeraire,
+    SaberDecimalWrapperDeposit,
+    SaberDecimalWrapperWithdraw,
+    SarosDlmm,
+    OneDexSwap,
+    Manifest,
+    ByrealClmm,
+    PancakeSwapV3Swap,
+    PancakeSwapV3SwapV2,
+    Tessera,
+    SolRfq,
+    PumpfunBuy2,
+    PumpfunammBuy2,
+    Humidifi,
+    HeavenBuy,
+    HeavenSell,
+    SolfiV2,
+    PumpfunBuy3,
+    PumpfunSell3,
+    PumpfunammBuy3,
+    PumpfunammSell3,
+}
+
+// -----------------------------------------------------------------------------
+// Discriminators
+// -----------------------------------------------------------------------------
+pub const SWAP_V3: [u8; 8] = [240, 224, 38, 33, 176, 31, 241, 175];
+
+// -----------------------------------------------------------------------------
+// Instruction payloads
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct SwapV3Instruction {
+    pub args: SwapArgs,
+    pub commission_info: u32,
+    pub platform_fee_rate: u16,
+    pub order_id: u64,
+}
+
+// -----------------------------------------------------------------------------
+// Instruction enumeration
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OkxV2Instruction {
+    SwapV3(SwapV3Instruction),
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for OkxV2Instruction {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.len() < 8 {
+            return Err(ParseError::TooShort(data.len()));
+        }
+        let (disc, payload) = data.split_at(8);
+        let discriminator: [u8; 8] = disc.try_into().expect("slice len 8");
+        Ok(match discriminator {
+            SWAP_V3 => Self::SwapV3(SwapV3Instruction::try_from_slice(payload)?),
+            other => return Err(ParseError::Unknown(other)),
+        })
+    }
+}
+
+/// Convenience wrapper that forwards to `TryFrom`.
+pub fn unpack(data: &[u8]) -> Result<OkxV2Instruction, ParseError> {
+    OkxV2Instruction::try_from(data)
+}

--- a/packages/okx/src/v2/mod.rs
+++ b/packages/okx/src/v2/mod.rs
@@ -1,0 +1,8 @@
+use substreams_solana::b58;
+
+pub mod instructions;
+
+/// OKX Dex program
+///
+/// https://solscan.io/account/6m2CDdhRgxpH4WjvdzxAYbGxwdGUz5MziiL5jek2kBma
+pub const PROGRAM_ID: [u8; 32] = b58!("6m2CDdhRgxpH4WjvdzxAYbGxwdGUz5MziiL5jek2kBma");

--- a/packages/okx/tests/okx_v2.rs
+++ b/packages/okx/tests/okx_v2.rs
@@ -1,0 +1,43 @@
+#[cfg(test)]
+mod tests {
+    use okx::v2::instructions::{self, Dex, Route, SwapArgs, SwapV3Instruction};
+    use substreams::hex;
+
+    #[test]
+    fn swap_v3_instruction() {
+        let bytes = hex!("f0e02621b01ff1af78e8692600000000add6d4007a00000063cd6f09730000000100000078e86926000000000100000003000000010000000501000000640200000012120200000050140100000049010000006420b3818010270000000000000000");
+        match instructions::unpack(&bytes).expect("decode instruction") {
+            instructions::OkxV2Instruction::SwapV3(ix) => {
+                assert_eq!(
+                    ix,
+                    SwapV3Instruction {
+                        args: SwapArgs {
+                            amount_in: 644_475_000,
+                            expect_amount_out: 523_999_958_701,
+                            min_return: 494_079_561_059,
+                            amounts: vec![644_475_000],
+                            routes: vec![vec![
+                                Route {
+                                    dexes: vec![Dex::RaydiumStableSwap],
+                                    weights: vec![100],
+                                },
+                                Route {
+                                    dexes: vec![Dex::ObricV2, Dex::ObricV2],
+                                    weights: vec![80, 20],
+                                },
+                                Route {
+                                    dexes: vec![Dex::PumpfunammBuy3],
+                                    weights: vec![100],
+                                },
+                            ]],
+                        },
+                        commission_info: 2_155_983_648,
+                        platform_fee_rate: 10_000,
+                        order_id: 0,
+                    }
+                );
+            }
+            _ => panic!("expected SwapV3"),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub use common;
 pub use drift;
 pub use jupiter;
 pub use meteora;
+pub use okx;
 pub use orca;
 pub use pancakeswap;
 pub use phoenix;


### PR DESCRIPTION
## Summary
- add OKX Dex v2 package with SwapV3 instruction decoder
- wire okx crate into workspace and exports
- test SwapV3 decoding against known transaction

## Testing
- `cargo test -p okx`

------
https://chatgpt.com/codex/tasks/task_b_68c7014083a4832887a3a4b46a688c6f