### PR TITLE
feat: add saros swap instructions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,6 +1198,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "saros"
+version = "0.1.0"
+dependencies = [
+ "borsh 1.5.7",
+ "common",
+ "solana-program",
+ "substreams",
+ "substreams-solana",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2187,6 +2198,7 @@ dependencies = [
  "phoenix",
  "pumpfun",
  "raydium",
+ "saros",
  "solfi",
  "stabble",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,8 @@ members = [
     "packages/stabble",
     "packages/pancakeswap",
     "packages/dflow",
-    "packages/solfi"
+    "packages/solfi",
+    "packages/saros"
 ]
 
 [dependencies]
@@ -37,6 +38,7 @@ pancakeswap = { version = "0.1.0", path = "packages/pancakeswap" }
 dflow = { version = "0.1.0", path = "packages/dflow" }
 solfi = { version = "0.1.0", path = "packages/solfi" }
 okx = { version = "0.1.0", path = "packages/okx" }
+saros = { version = "0.1.0", path = "packages/saros" }
 
 [workspace.dependencies]
 substreams = "0.6.2"

--- a/packages/saros/Cargo.toml
+++ b/packages/saros/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "saros"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+common = { path = "../common" }
+substreams = { workspace = true }
+substreams-solana = { workspace = true }
+solana-program = { workspace = true }
+borsh = { workspace = true }

--- a/packages/saros/src/README.md
+++ b/packages/saros/src/README.md
@@ -1,0 +1,3 @@
+# Saros
+
+Implementation of Saros swap program instructions.

--- a/packages/saros/src/instructions.rs
+++ b/packages/saros/src/instructions.rs
@@ -1,0 +1,36 @@
+//! Saros swap program instructions.
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use common::ParseError;
+
+pub const SWAP: u8 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SarosInstruction {
+    Swap(SwapInstruction),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct SwapInstruction {
+    pub amount_in: u64,
+    pub minimum_amount_out: u64,
+}
+
+impl<'a> TryFrom<&'a [u8]> for SarosInstruction {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.is_empty() {
+            return Err(ParseError::TooShort(data.len()));
+        }
+        let (&disc, payload) = data.split_first().unwrap();
+        Ok(match disc {
+            SWAP => Self::Swap(SwapInstruction::try_from_slice(payload)?),
+            other => return Err(ParseError::Unknown([other, 0, 0, 0, 0, 0, 0, 0])),
+        })
+    }
+}
+
+pub fn unpack(data: &[u8]) -> Result<SarosInstruction, ParseError> {
+    SarosInstruction::try_from(data)
+}

--- a/packages/saros/src/lib.rs
+++ b/packages/saros/src/lib.rs
@@ -1,0 +1,9 @@
+extern crate common;
+use substreams_solana::b58;
+
+pub mod instructions;
+
+/// Saros swap program
+///
+/// https://solscan.io/account/SSwapUtytfBdBn1b9NUGG6foMVPtcWgpRU32HToDUZr
+pub const PROGRAM_ID: [u8; 32] = b58!("SSwapUtytfBdBn1b9NUGG6foMVPtcWgpRU32HToDUZr");

--- a/packages/saros/tests/saros.rs
+++ b/packages/saros/tests/saros.rs
@@ -1,0 +1,23 @@
+#[cfg(test)]
+mod tests {
+    use saros;
+    use substreams::hex;
+
+    #[test]
+    fn swap_instruction() {
+        // https://solscan.io/tx/5q8HEhbmxBmo73AFTDfynCCRtcTfCRBBV3CaBsRCsAKfYj5JLXJzaCGH59a5rn72onddJR1oVXmyx9AfU2BPdsTR
+        let bytes = hex!("017660741a000000000000000000000000");
+        match saros::instructions::unpack(&bytes).expect("decode instruction") {
+            saros::instructions::SarosInstruction::Swap(ix) => {
+                assert_eq!(
+                    ix,
+                    saros::instructions::SwapInstruction {
+                        amount_in: 443_834_486,
+                        minimum_amount_out: 0,
+                    }
+                );
+            }
+            _ => panic!("Expected Swap instruction"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Saros swap program module and program ID
- decode swap instruction with amount fields
- test Saros swap decoding

## Testing
- `cargo test -p saros`


------
https://chatgpt.com/codex/tasks/task_b_68c7061b8a688328af2183ee6fc8167b