### PR TITLE
Add HumidiFi instruction decoder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,6 +560,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
+name = "humidifi"
+version = "0.1.0"
+dependencies = [
+ "base64 0.22.1",
+ "borsh 1.5.7",
+ "common",
+ "solana-program",
+ "substreams",
+ "substreams-solana",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2190,6 +2202,7 @@ dependencies = [
  "common",
  "dflow",
  "drift",
+ "humidifi",
  "jupiter",
  "meteora",
  "okx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ members = [
     "packages/pancakeswap",
     "packages/dflow",
     "packages/solfi",
-    "packages/saros"
+    "packages/saros",
+    "packages/humidifi"
 ]
 
 [dependencies]
@@ -39,6 +40,7 @@ dflow = { version = "0.1.0", path = "packages/dflow" }
 solfi = { version = "0.1.0", path = "packages/solfi" }
 okx = { version = "0.1.0", path = "packages/okx" }
 saros = { version = "0.1.0", path = "packages/saros" }
+humidifi = { version = "0.1.0", path = "packages/humidifi" }
 
 [workspace.dependencies]
 substreams = "0.6.2"

--- a/packages/humidifi/Cargo.toml
+++ b/packages/humidifi/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "humidifi"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+common = { path = "../common" }
+substreams = { workspace = true }
+substreams-solana = { workspace = true }
+solana-program = { workspace = true }
+borsh = { workspace = true }
+
+[dev-dependencies]
+base64 = { workspace = true }

--- a/packages/humidifi/README.md
+++ b/packages/humidifi/README.md
@@ -1,0 +1,5 @@
+# HumidiFi
+
+- https://solscan.io/account/9H6tua7jkLhdm3w8BvgpTn5LZNU7g4ZynDmCiNN3q6Rp
+  Program ID: `9H6tua7jkLhdm3w8BvgpTn5LZNU7g4ZynDmCiNN3q6Rp`
+

--- a/packages/humidifi/src/instructions.rs
+++ b/packages/humidifi/src/instructions.rs
@@ -1,0 +1,57 @@
+//! HumidiFi on-chain instructions.
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use common::ParseError;
+use solana_program::pubkey::Pubkey;
+
+// -----------------------------------------------------------------------------
+// Payload structs
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct MysteryInstruction {
+    pub unknown_pubkey: Pubkey,
+    pub field1: u64,
+    pub field2: u64,
+    pub field3: u64,
+    pub flag: u8,
+}
+
+// -----------------------------------------------------------------------------
+// Discriminators
+// -----------------------------------------------------------------------------
+pub const MYSTERY_INSTRUCTION: [u8; 8] = [95, 127, 87, 5, 236, 229, 87, 185];
+
+// -----------------------------------------------------------------------------
+// Instruction enumeration
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub enum HumidiFiInstruction {
+    Mystery(MysteryInstruction),
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for HumidiFiInstruction {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.len() < 8 {
+            return Err(ParseError::TooShort(data.len()));
+        }
+
+        let (disc, payload) = data.split_at(8);
+        let discriminator: [u8; 8] = disc.try_into().expect("slice len 8");
+
+        Ok(match discriminator {
+            MYSTERY_INSTRUCTION => Self::Mystery(MysteryInstruction::try_from_slice(payload)?),
+            other => return Err(ParseError::Unknown(other)),
+        })
+    }
+}
+
+/// Convenience wrapper that forwards to `TryFrom`.
+pub fn unpack(data: &[u8]) -> Result<HumidiFiInstruction, ParseError> {
+    HumidiFiInstruction::try_from(data)
+}

--- a/packages/humidifi/src/lib.rs
+++ b/packages/humidifi/src/lib.rs
@@ -1,0 +1,10 @@
+#[macro_use]
+extern crate common;
+use substreams_solana::b58;
+
+pub mod instructions;
+
+/// HumidiFi program
+///
+/// https://solscan.io/account/9H6tua7jkLhdm3w8BvgpTn5LZNU7g4ZynDmCiNN3q6Rp
+pub const PROGRAM_ID: [u8; 32] = b58!("9H6tua7jkLhdm3w8BvgpTn5LZNU7g4ZynDmCiNN3q6Rp");

--- a/packages/humidifi/tests/humidifi.rs
+++ b/packages/humidifi/tests/humidifi.rs
@@ -1,0 +1,20 @@
+#[cfg(test)]
+mod tests {
+    use humidifi::instructions;
+    use substreams::hex;
+
+    #[test]
+    fn decode_mystery_instruction() {
+        let bytes = hex!("5f7f5705ece557b9d98b7923eb12a946eac9f67609e09d6e6f2a54412ae39d6ee0f1190bb3e29d6e492f841e93e0dd6e8474c1b7338119d351f04825a25641503f");
+        match instructions::unpack(&bytes).expect("decode instruction") {
+            instructions::HumidiFiInstruction::Mystery(ix) => {
+                assert_eq!(ix.unknown_pubkey.to_string(), "FeCpdbVJaMCBD7vvK5umuMtmk9ajySgY9PP46XYVz8sP");
+                assert_eq!(ix.field1, 7_988_788_236_501_921_609);
+                assert_eq!(ix.field2, 15_211_331_275_546_784_900);
+                assert_eq!(ix.field3, 5_782_998_650_930_655_313);
+                assert_eq!(ix.flag, 63);
+            }
+            _ => panic!("expected Mystery"),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,3 +10,4 @@ pub use phoenix;
 pub use pumpfun;
 pub use raydium;
 pub use stabble;
+pub use humidifi;


### PR DESCRIPTION
## Summary
- add HumidiFi crate and program ID
- decode mystery instruction via Borsh
- test decoding against provided transaction

## Testing
- `cargo test -p humidifi`


------
https://chatgpt.com/codex/tasks/task_b_68c73f43560483289a0719d8a316fbef