### PR TITLE
Add Tessera V swap instruction decoder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2201,6 +2201,7 @@ dependencies = [
  "saros",
  "solfi",
  "stabble",
+ "tesserav",
 ]
 
 [[package]]
@@ -2251,6 +2252,17 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "tesserav"
+version = "0.1.0"
+dependencies = [
+ "borsh 1.5.7",
+ "common",
+ "solana-program",
+ "substreams",
+ "substreams-solana",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ members = [
     "packages/pancakeswap",
     "packages/dflow",
     "packages/solfi",
-    "packages/saros"
+    "packages/saros",
+    "packages/tesserav"
 ]
 
 [dependencies]
@@ -39,6 +40,7 @@ dflow = { version = "0.1.0", path = "packages/dflow" }
 solfi = { version = "0.1.0", path = "packages/solfi" }
 okx = { version = "0.1.0", path = "packages/okx" }
 saros = { version = "0.1.0", path = "packages/saros" }
+tesserav = { version = "0.1.0", path = "packages/tesserav" }
 
 [workspace.dependencies]
 substreams = "0.6.2"

--- a/packages/tesserav/Cargo.toml
+++ b/packages/tesserav/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "tesserav"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+common = { path = "../common" }
+substreams = { workspace = true }
+substreams-solana = { workspace = true }
+solana-program = { workspace = true }
+borsh = { workspace = true }

--- a/packages/tesserav/README.md
+++ b/packages/tesserav/README.md
@@ -1,0 +1,4 @@
+# Tessera V
+
+- https://solscan.io/account/TessVdML9pBGgG9yGks7o4HewRaXVAMuoVj4x83GLQH
+  Program ID: `TessVdML9pBGgG9yGks7o4HewRaXVAMuoVj4x83GLQH`

--- a/packages/tesserav/src/instructions.rs
+++ b/packages/tesserav/src/instructions.rs
@@ -1,0 +1,51 @@
+//! Tessera V on-chain instructions.
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use common::ParseError;
+
+// -----------------------------------------------------------------------------
+// Discriminators
+// -----------------------------------------------------------------------------
+pub const SWAP: u8 = 16;
+
+// -----------------------------------------------------------------------------
+// Instruction enumeration
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TesseraVInstruction {
+    Swap(SwapInstruction),
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Payload structs
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct SwapInstruction {
+    pub is_a_to_b: bool,
+    pub amount_in: u64,
+    pub min_amount_out: u64,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for TesseraVInstruction {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.is_empty() {
+            return Err(ParseError::TooShort(data.len()));
+        }
+        let (disc, payload) = data.split_at(1);
+        match disc[0] {
+            SWAP => Ok(Self::Swap(SwapInstruction::try_from_slice(payload)?)),
+            other => Err(ParseError::Unknown([other, 0, 0, 0, 0, 0, 0, 0])),
+        }
+    }
+}
+
+/// Convenience wrapper that forwards to `TryFrom`.
+pub fn unpack(data: &[u8]) -> Result<TesseraVInstruction, ParseError> {
+    TesseraVInstruction::try_from(data)
+}

--- a/packages/tesserav/src/lib.rs
+++ b/packages/tesserav/src/lib.rs
@@ -1,0 +1,3 @@
+extern crate common;
+
+pub mod instructions;

--- a/packages/tesserav/tests/tesserav.rs
+++ b/packages/tesserav/tests/tesserav.rs
@@ -1,0 +1,19 @@
+#[cfg(test)]
+mod tests {
+    use substreams::hex;
+    use tesserav;
+
+    #[test]
+    fn unpack_swap_instruction() {
+        // https://solscan.io/tx/5EnwvjH197dogrBjyiVmCHniUPoYRQksTwUTczLL568ukQQY5wK2JX3iDwMJ3yEyQgEB3MLJYF6D79FAM2fkbDZM
+        let bytes = hex!("1000ec930d00000000000000000000000000");
+        match tesserav::instructions::unpack(&bytes).expect("decode instruction") {
+            tesserav::instructions::TesseraVInstruction::Swap(ix) => {
+                assert!(!ix.is_a_to_b);
+                assert_eq!(ix.amount_in, 889_836);
+                assert_eq!(ix.min_amount_out, 0);
+            }
+            _ => panic!("Expected a Swap instruction"),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,3 +10,4 @@ pub use phoenix;
 pub use pumpfun;
 pub use raydium;
 pub use stabble;
+pub use tesserav;


### PR DESCRIPTION
## Summary
- add Tessera V crate with swap instruction decoding
- decode swap instruction into fields is_a_to_b, amount_in, min_amount_out
- test swap parsing against on-chain transaction

## Testing
- `cargo test -p tesserav`


------
https://chatgpt.com/codex/tasks/task_b_68c740081bf08328a9617db509d36602