### PR TITLE
Add Heaven DEX instruction and log parsers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,6 +542,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
+name = "heaven"
+version = "0.1.0"
+dependencies = [
+ "base64 0.22.1",
+ "borsh 1.5.7",
+ "common",
+ "solana-program",
+ "substreams",
+ "substreams-solana",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2190,6 +2202,7 @@ dependencies = [
  "common",
  "dflow",
  "drift",
+ "heaven",
  "jupiter",
  "meteora",
  "okx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ members = [
     "packages/pancakeswap",
     "packages/dflow",
     "packages/solfi",
-    "packages/saros"
+    "packages/saros",
+    "packages/heaven"
 ]
 
 [dependencies]
@@ -39,6 +40,7 @@ dflow = { version = "0.1.0", path = "packages/dflow" }
 solfi = { version = "0.1.0", path = "packages/solfi" }
 okx = { version = "0.1.0", path = "packages/okx" }
 saros = { version = "0.1.0", path = "packages/saros" }
+heaven = { version = "0.1.0", path = "packages/heaven" }
 
 [workspace.dependencies]
 substreams = "0.6.2"

--- a/packages/heaven/Cargo.toml
+++ b/packages/heaven/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "heaven"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+common = { path = "../common" }
+substreams = { workspace = true }
+substreams-solana = { workspace = true }
+solana-program = { workspace = true }
+borsh = { workspace = true }
+base64 = { workspace = true }

--- a/packages/heaven/README.md
+++ b/packages/heaven/README.md
@@ -1,0 +1,3 @@
+# Heaven
+
+Heaven DEX instruction and log definitions for Substreams.

--- a/packages/heaven/src/instructions.rs
+++ b/packages/heaven/src/instructions.rs
@@ -1,0 +1,54 @@
+//! Heaven DEX on-chain instructions.
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use common::ParseError;
+
+// -----------------------------------------------------------------------------
+// Discriminators
+// -----------------------------------------------------------------------------
+const SELL: [u8; 8] = [51, 230, 133, 164, 1, 127, 131, 173]; // 33e685a4017f83ad
+
+// -----------------------------------------------------------------------------
+// Instruction enumeration
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub enum HeavenInstruction {
+    Sell(SellInstruction),
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Payload structs
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct SellInstruction {
+    pub amount_in: u64,
+    pub minimum_amount_out: u64,
+    pub encoded_user_defined_event_data: String,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for HeavenInstruction {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.len() < 8 {
+            return Err(ParseError::TooShort(data.len()));
+        }
+
+        let (disc, payload) = data.split_at(8);
+        let discriminator: [u8; 8] = disc.try_into().expect("slice len 8");
+
+        Ok(match discriminator {
+            SELL => Self::Sell(SellInstruction::try_from_slice(payload)?),
+            other => return Err(ParseError::Unknown(other)),
+        })
+    }
+}
+
+/// Convenience wrapper that forwards to `TryFrom`.
+pub fn unpack(data: &[u8]) -> Result<HeavenInstruction, ParseError> {
+    HeavenInstruction::try_from(data)
+}

--- a/packages/heaven/src/lib.rs
+++ b/packages/heaven/src/lib.rs
@@ -1,0 +1,10 @@
+extern crate common;
+use substreams_solana::b58;
+
+pub mod instructions;
+pub mod logs;
+
+/// Heaven DEX program
+///
+/// https://solscan.io/account/HEAVENoP2qxoeuF8Dj2oT1GHEnu49U5mJYkdeC8BAX2o
+pub const PROGRAM_ID: [u8; 32] = b58!("HEAVENoP2qxoeuF8Dj2oT1GHEnu49U5mJYkdeC8BAX2o");

--- a/packages/heaven/src/logs.rs
+++ b/packages/heaven/src/logs.rs
@@ -1,0 +1,55 @@
+//! Heaven DEX on-chain logs.
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use common::ParseError;
+use solana_program::pubkey::Pubkey;
+
+// -----------------------------------------------------------------------------
+// Discriminators
+// -----------------------------------------------------------------------------
+const SELL_LOG: [u8; 8] = [189, 219, 127, 211, 78, 230, 97, 238]; // bddb7fd34ee661ee
+
+// -----------------------------------------------------------------------------
+// Log enumeration
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HeavenLog {
+    Sell(SellLog),
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Payload structs
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct SellLog {
+    pub user: Pubkey,
+    pub mint: Pubkey,
+    pub amount: u64,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for HeavenLog {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.len() < 8 {
+            return Err(ParseError::TooShort(data.len()));
+        }
+
+        let (disc, payload) = data.split_at(8);
+        let discriminator: [u8; 8] = disc.try_into().expect("slice len 8");
+
+        Ok(match discriminator {
+            SELL_LOG => Self::Sell(SellLog::try_from_slice(payload)?),
+            other => return Err(ParseError::Unknown(other)),
+        })
+    }
+}
+
+/// Convenience wrapper that forwards to `TryFrom`.
+pub fn unpack(data: &[u8]) -> Result<HeavenLog, ParseError> {
+    HeavenLog::try_from(data)
+}

--- a/packages/heaven/tests/heaven.rs
+++ b/packages/heaven/tests/heaven.rs
@@ -1,0 +1,37 @@
+#[cfg(test)]
+mod tests {
+    use base64::Engine;
+    use heaven;
+    use substreams::hex;
+
+    #[test]
+    fn unpack_sell_instruction() {
+        // https://solscan.io/tx/32yEf5etU6dMSe2MMe9davZ4zHNi94HEYVJYL6ew9PzCcA2PK4KBhSD9DGbDAeds5CsvFyFRPF4QHhpgXbtURi2y
+        let bytes = hex!("33e685a4017f83ad948526a45c050000000000000000000000000000");
+
+        match heaven::instructions::unpack(&bytes).expect("decode instruction") {
+            heaven::instructions::HeavenInstruction::Sell(ix) => {
+                assert_eq!(ix.amount_in, 5_895_449_118_100);
+                assert_eq!(ix.minimum_amount_out, 0);
+                assert_eq!(ix.encoded_user_defined_event_data, "");
+            }
+            _ => panic!("expected Sell instruction"),
+        }
+    }
+
+    #[test]
+    fn unpack_sell_log() {
+        // https://solscan.io/tx/32yEf5etU6dMSe2MMe9davZ4zHNi94HEYVJYL6ew9PzCcA2PK4KBhSD9DGbDAeds5CsvFyFRPF4QHhpgXbtURi2y
+        let base64 = "vdt/007mYe5nk11q92ZpANtuuawSAQAAEuZMwgMAAAChqjUAAAAAAF/utLFpKG5AlIUmpFwFAAAAAAAAAAAAAAAAAAAAAAAA1MT5DQAAAAA=";
+        let bytes = base64::engine::general_purpose::STANDARD.decode(base64).expect("decode base64");
+
+        match heaven::logs::unpack(&bytes).expect("decode log") {
+            heaven::logs::HeavenLog::Sell(log) => {
+                assert_eq!(log.user.to_string(), "7yKKk4eCqVvSrMpiBMB8HzmeQQeivkxj1W2yJLq7to9Z");
+                assert_eq!(log.mint.to_string(), "7TUqwzuPcoWmiWLkEdTP4z1ndGMom2myLW3zuJ2w4sKm");
+                assert_eq!(log.amount, 234_472_660);
+            }
+            _ => panic!("expected Sell log"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Heaven DEX crate with program id `HEAVENoP2qxoeuF8Dj2oT1GHEnu49U5mJYkdeC8BAX2o`
- implement Sell instruction decoder supporting custom user data
- add Sell log parser capturing user, mint and amount fields
- cover Heaven Sell decoding with tests

## Testing
- `cargo test -p heaven`


------
https://chatgpt.com/codex/tasks/task_b_68c741dd4b4083288e9a98d011dbb55d