### PR TITLE
Rename Anchor CPI logs to anchor_cpi_event

### DIFF
--- a/packages/meteora/src/daam/anchor_cpi_event.rs
+++ b/packages/meteora/src/daam/anchor_cpi_event.rs
@@ -1,4 +1,4 @@
-//! Meteora DAMM v2 events.
+//! Meteora DAMM v2 Anchor CPI events.
 
 use super::instructions::{
     AddLiquidityParameters, PoolFeeParameters, RemoveLiquidityParameters, SplitAmountInfo, SplitPositionInfo, SplitPositionParameters, SwapParameters,
@@ -42,7 +42,7 @@ const ANCHOR_DISC: [u8; 8] = [0xe4, 0x45, 0xa5, 0x2e, 0x51, 0xcb, 0x9a, 0x1d];
 // Event enumeration
 // -----------------------------------------------------------------------------
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum MeteoraDammEvent {
+pub enum MeteoraDammAnchorCpiEvent {
     EvtAddLiquidity(EvtAddLiquidity),
     EvtClaimPartnerFee(EvtClaimPartnerFee),
     EvtClaimPositionFee(EvtClaimPositionFee),
@@ -315,7 +315,7 @@ pub struct EvtWithdrawIneligibleReward {
 // -----------------------------------------------------------------------------
 // Borsh deserialisation helper
 // -----------------------------------------------------------------------------
-impl<'a> TryFrom<&'a [u8]> for MeteoraDammEvent {
+impl<'a> TryFrom<&'a [u8]> for MeteoraDammAnchorCpiEvent {
     type Error = ParseError;
 
     fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
@@ -360,6 +360,6 @@ impl<'a> TryFrom<&'a [u8]> for MeteoraDammEvent {
     }
 }
 
-pub fn unpack(data: &[u8]) -> Result<MeteoraDammEvent, ParseError> {
-    MeteoraDammEvent::try_from(data)
+pub fn unpack(data: &[u8]) -> Result<MeteoraDammAnchorCpiEvent, ParseError> {
+    MeteoraDammAnchorCpiEvent::try_from(data)
 }

--- a/packages/meteora/src/daam/mod.rs
+++ b/packages/meteora/src/daam/mod.rs
@@ -1,7 +1,7 @@
 use substreams_solana::b58;
 
 pub mod accounts;
-pub mod events;
+pub mod anchor_cpi_event;
 pub mod instructions;
 
 /// Meteora DAMM v2

--- a/packages/meteora/src/dllm/anchor_cpi_event.rs
+++ b/packages/meteora/src/dllm/anchor_cpi_event.rs
@@ -1,4 +1,4 @@
-//! Meteora DLMM on-chain events.
+//! Meteora DLMM Anchor CPI events.
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use common::ParseError;
@@ -38,7 +38,7 @@ const ANCHOR_DISC: [u8; 8] = [0xe4, 0x45, 0xa5, 0x2e, 0x51, 0xcb, 0x9a, 0x1d];
 // High-level event enum
 // -----------------------------------------------------------------------------
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum MeteoraDllmEvent {
+pub enum MeteoraDllmAnchorCpiEvent {
     Swap(SwapEvent),
     // AddLiquidity,
     // ClaimFee,
@@ -86,7 +86,7 @@ pub struct SwapEvent {
 // -----------------------------------------------------------------------------
 // Borsh deserialisation helper
 // -----------------------------------------------------------------------------
-impl<'a> TryFrom<&'a [u8]> for MeteoraDllmEvent {
+impl<'a> TryFrom<&'a [u8]> for MeteoraDllmAnchorCpiEvent {
     type Error = ParseError;
 
     fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
@@ -132,6 +132,6 @@ impl<'a> TryFrom<&'a [u8]> for MeteoraDllmEvent {
     }
 }
 
-pub fn unpack(data: &[u8]) -> Result<MeteoraDllmEvent, ParseError> {
-    MeteoraDllmEvent::try_from(data)
+pub fn unpack(data: &[u8]) -> Result<MeteoraDllmAnchorCpiEvent, ParseError> {
+    MeteoraDllmAnchorCpiEvent::try_from(data)
 }

--- a/packages/meteora/src/dllm/mod.rs
+++ b/packages/meteora/src/dllm/mod.rs
@@ -1,7 +1,7 @@
 use substreams_solana::b58;
 
 pub mod accounts;
-pub mod events;
+pub mod anchor_cpi_event;
 pub mod instructions;
 
 /// Meteora DLMM Program

--- a/packages/meteora/tests/meteora_daam.rs
+++ b/packages/meteora/tests/meteora_daam.rs
@@ -9,8 +9,8 @@ mod tests {
     fn unpack_daam_swap_event() {
         // https://solscan.io/tx/<unknown> contains this event payload
         let bytes = hex!("e445a52e51cb9a1d1b3c15d58aaabb9361eb363b6c0f73437a18891ec65e5a1f20fbbdd8870656657d3167e04d4830a5010000c2eb0b00000000ccc0a13a8c7f0000ee64bf1c6f8d0000e83e7db166ee49000000000000000000544b1d0000000000d4520700000000000000000000000000000000000000000000c2eb0b0000000053f2bb6800000000");
-        match daam::events::unpack(&bytes).expect("decode event") {
-            daam::events::MeteoraDammEvent::EvtSwap(event) => {
+        match daam::anchor_cpi_event::unpack(&bytes).expect("decode event") {
+            daam::anchor_cpi_event::MeteoraDammAnchorCpiEvent::EvtSwap(event) => {
                 assert_eq!(event.pool.to_string(), "7bEa1teiLKdRbEopnCWjDdcvAAAnaHuiRiPErUKhLybS", "pool",);
                 assert_eq!(event.trade_direction, 1, "trade_direction");
                 assert!(!event.has_referral, "has_referral");

--- a/packages/meteora/tests/meteora_dllm.rs
+++ b/packages/meteora/tests/meteora_dllm.rs
@@ -8,8 +8,8 @@ mod tests {
     fn unpack_dllm_swap_event() {
         // https://solscan.io/tx/<unknown? maybe but not necessary>. Maybe not.
         let bytes = hex!("e445a52e51cb9a1d516ce3becdd00ac471739c6f45944a0e56b3a0f9b2399f421b0a82b56c5b87acc78023b8ed27cc7cf74ba51f6820a847117a8fad48c80ae298e20bf37ff35e7ae8c7b85272b5010701feffff01feffff1f660a0000000000702c000000000000016037000000000000c40200000000000000623d010000000000000000000000000000000000000000");
-        match dllm::events::unpack(&bytes).expect("decode event") {
-            dllm::events::MeteoraDllmEvent::Swap(event) => {
+        match dllm::anchor_cpi_event::unpack(&bytes).expect("decode event") {
+            dllm::anchor_cpi_event::MeteoraDllmAnchorCpiEvent::Swap(event) => {
                 assert_eq!(event.lb_pair.to_string(), "8dsKNwMDMh1Vfr4YevzRY9oDS7N29fRHpPXcoDmUVSBd", "lb_pair");
                 assert_eq!(event.from.to_string(), "HeLbvj7KM5fkduCdiufTa5SmVtuuVjySPps7dnp2pDZG", "from");
                 assert_eq!(event.start_bin_id, -511, "start_bin_id");

--- a/packages/pumpfun/src/amm/anchor_cpi_event.rs
+++ b/packages/pumpfun/src/amm/anchor_cpi_event.rs
@@ -7,16 +7,16 @@ use solana_program::pubkey::Pubkey;
 // -------------------------------------------------------------------------
 // Discriminators
 // -------------------------------------------------------------------------
-const BUY_LOG: [u8; 8] = [103, 244, 82, 31, 44, 245, 119, 119]; // 67f4521f2cf57777
-const SELL_LOG: [u8; 8] = [62, 47, 55, 10, 165, 3, 220, 42]; // 3e2f370aa503dc2a
+const BUY_ANCHOR_CPI_EVENT: [u8; 8] = [103, 244, 82, 31, 44, 245, 119, 119]; // 67f4521f2cf57777
+const SELL_ANCHOR_CPI_EVENT: [u8; 8] = [62, 47, 55, 10, 165, 3, 220, 42]; // 3e2f370aa503dc2a
 
 // -------------------------------------------------------------------------
 // enumeration
 // -------------------------------------------------------------------------
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum PumpFunAmmLog {
-    BuyLog(BuyLog),
-    SellLog(SellLog),
+pub enum PumpFunAmmAnchorCpiEvent {
+    Buy(BuyAnchorCpiEvent),
+    Sell(SellAnchorCpiEvent),
     Unknown,
 }
 
@@ -28,7 +28,7 @@ pub enum PumpFunAmmLog {
 // Payload structs
 // -------------------------------------------------------------------------
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
-pub struct BuyLog {
+pub struct BuyAnchorCpiEvent {
     pub timestamp: i64,
     pub base_amount_out: u64,
     pub max_quote_amount_in: u64,
@@ -52,7 +52,7 @@ pub struct BuyLog {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
-pub struct SellLog {
+pub struct SellAnchorCpiEvent {
     pub timestamp: i64,
     pub base_amount_in: u64,
     pub min_quote_amount_out: u64,
@@ -78,7 +78,7 @@ pub struct SellLog {
 // -----------------------------------------------------------------------------
 // Borsh deserialisation helper
 // -----------------------------------------------------------------------------
-impl<'a> TryFrom<&'a [u8]> for PumpFunAmmLog {
+impl<'a> TryFrom<&'a [u8]> for PumpFunAmmAnchorCpiEvent {
     type Error = ParseError;
 
     fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
@@ -91,8 +91,8 @@ impl<'a> TryFrom<&'a [u8]> for PumpFunAmmLog {
         let payload = &data[8..]; // skip the discriminator
 
         Ok(match disc {
-            BUY_LOG => Self::BuyLog(BuyLog::try_from_slice(payload)?),
-            SELL_LOG => Self::SellLog(SellLog::try_from_slice(payload)?),
+            BUY_ANCHOR_CPI_EVENT => Self::Buy(BuyAnchorCpiEvent::try_from_slice(payload)?),
+            SELL_ANCHOR_CPI_EVENT => Self::Sell(SellAnchorCpiEvent::try_from_slice(payload)?),
             // If the discriminator does not match any known event, return Unknown
             other => return Err(ParseError::Unknown(other)),
         })
@@ -100,6 +100,6 @@ impl<'a> TryFrom<&'a [u8]> for PumpFunAmmLog {
 }
 
 /// Convenience wrapper that forwards to `TryFrom`.
-pub fn unpack(data: &[u8]) -> Result<PumpFunAmmLog, ParseError> {
-    PumpFunAmmLog::try_from(data)
+pub fn unpack(data: &[u8]) -> Result<PumpFunAmmAnchorCpiEvent, ParseError> {
+    PumpFunAmmAnchorCpiEvent::try_from(data)
 }

--- a/packages/pumpfun/src/amm/mod.rs
+++ b/packages/pumpfun/src/amm/mod.rs
@@ -1,8 +1,8 @@
 use substreams_solana::b58;
 pub mod accounts;
+pub mod anchor_cpi_event;
 pub mod events;
 pub mod instructions;
-pub mod logs;
 
 /// PumpFun AMM program
 ///

--- a/packages/raydium/src/launchpad/anchor_cpi_event.rs
+++ b/packages/raydium/src/launchpad/anchor_cpi_event.rs
@@ -1,4 +1,4 @@
-//! Raydium Launchpad events.
+//! Raydium Launchpad Anchor CPI events.
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use common::ParseError;
@@ -19,7 +19,7 @@ const ANCHOR_DISC: [u8; 8] = [0xe4, 0x45, 0xa5, 0x2e, 0x51, 0xcb, 0x9a, 0x1d];
 // Event enumeration
 // -----------------------------------------------------------------------------
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum RaydiumLaunchpadEvent {
+pub enum RaydiumLaunchpadAnchorCpiEvent {
     ClaimVestedEvent(ClaimVestedEvent),
     CreateVestingEvent(CreateVestingEvent),
     PoolCreateEvent(PoolCreateEvent),
@@ -171,7 +171,7 @@ pub enum PoolStatus {
 // -----------------------------------------------------------------------------
 // Borsh deserialisation helper
 // -----------------------------------------------------------------------------
-impl<'a> TryFrom<&'a [u8]> for RaydiumLaunchpadEvent {
+impl<'a> TryFrom<&'a [u8]> for RaydiumLaunchpadAnchorCpiEvent {
     type Error = ParseError;
 
     fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
@@ -205,6 +205,6 @@ impl<'a> TryFrom<&'a [u8]> for RaydiumLaunchpadEvent {
 }
 
 /// Convenience wrapper that forwards to `TryFrom`.
-pub fn unpack(data: &[u8]) -> Result<RaydiumLaunchpadEvent, ParseError> {
-    RaydiumLaunchpadEvent::try_from(data)
+pub fn unpack(data: &[u8]) -> Result<RaydiumLaunchpadAnchorCpiEvent, ParseError> {
+    RaydiumLaunchpadAnchorCpiEvent::try_from(data)
 }

--- a/packages/raydium/src/launchpad/mod.rs
+++ b/packages/raydium/src/launchpad/mod.rs
@@ -1,7 +1,7 @@
 use substreams_solana::b58;
 
 pub mod accounts;
-pub mod events;
+pub mod anchor_cpi_event;
 pub mod instructions;
 
 /// Raydium Launchpad program

--- a/packages/raydium/tests/raydium_launchpad.rs
+++ b/packages/raydium/tests/raydium_launchpad.rs
@@ -7,8 +7,8 @@ mod tests {
     #[test]
     fn unpack_launchpad_trade_event() {
         let bytes = hex!("e445a52e51cb9a1dbddb7fd34ee661eef5e31a347d6c0ffb5c1019f78d2c2244f6c99c6e873d3928bf94d281f65888bf0078c5fb51d10200de740e3ee9cf0300d7af30fc060000005ba7ef1db2a002006c872c7f0f000000577b4148b3a00200f2a5427f0f0000001c69160000000000fcd3512a01000000590e0000000000005f39000000000000de020000000000000000000000000000000001");
-        match launchpad::events::unpack(&bytes).expect("decode event") {
-            launchpad::events::RaydiumLaunchpadEvent::TradeEventV1(event) => {
+        match launchpad::anchor_cpi_event::unpack(&bytes).expect("decode event") {
+            launchpad::anchor_cpi_event::RaydiumLaunchpadAnchorCpiEvent::TradeEventV1(event) => {
                 assert_eq!(event.pool_state.to_string(), "HYqjiMv2jVE41qMoBDXAE5SEeNcyaEQMaEuVHCuisB4A", "pool_state");
                 assert_eq!(event.total_base_sell, 793_100_000_000_000, "total_base_sell");
                 assert_eq!(event.virtual_base, 1_073_025_605_596_382, "virtual_base");
@@ -23,8 +23,11 @@ mod tests {
                 assert_eq!(event.platform_fee, 14_687, "platform_fee");
                 assert_eq!(event.creator_fee, 734, "creator_fee");
                 assert_eq!(event.share_fee, 0, "share_fee");
-                assert!(matches!(event.trade_direction, launchpad::events::TradeDirection::Buy), "trade_direction");
-                assert!(matches!(event.pool_status, launchpad::events::PoolStatus::Fund), "pool_status");
+                assert!(
+                    matches!(event.trade_direction, launchpad::anchor_cpi_event::TradeDirection::Buy),
+                    "trade_direction"
+                );
+                assert!(matches!(event.pool_status, launchpad::anchor_cpi_event::PoolStatus::Fund), "pool_status");
                 assert!(event.exact_in, "exact_in");
             }
             _ => panic!("Expected TradeEventV1"),
@@ -34,8 +37,8 @@ mod tests {
     #[test]
     fn unpack_launchpad_trade_event_2() {
         let bytes = hex!("e445a52e51cb9a1dbddb7fd34ee661ee98f7bd21e067c6d32836f1fedec18b74080417ae1639b740c2ae2cf1ed4d166b0078c5fb51d10200de740e3ee9cf0300d7af30fc06000000bd19242496bc0200960933c61100000035f94e2496bc0200710d33c611000000e80300000000000078df2a000000000003000000000000000a0000000000000000000000000000000000");
-        match launchpad::events::unpack(&bytes).expect("decode event") {
-            launchpad::events::RaydiumLaunchpadEvent::TradeEventV2(event) => {
+        match launchpad::anchor_cpi_event::unpack(&bytes).expect("decode event") {
+            launchpad::anchor_cpi_event::RaydiumLaunchpadAnchorCpiEvent::TradeEventV2(event) => {
                 assert_eq!(event.pool_state.to_string(), "BJ859ZCoKvCrq6Fv9aJGChHy9UnG7o2ZhLVpsYw8wyPp", "pool_state");
                 assert_eq!(event.total_base_sell, 793_100_000_000_000, "total_base_sell");
                 assert_eq!(event.virtual_base, 1_073_025_605_596_382, "virtual_base");
@@ -49,8 +52,11 @@ mod tests {
                 assert_eq!(event.protocol_fee, 3, "protocol_fee");
                 assert_eq!(event.platform_fee, 10, "platform_fee");
                 assert_eq!(event.share_fee, 0, "share_fee");
-                assert!(matches!(event.trade_direction, launchpad::events::TradeDirection::Buy), "trade_direction");
-                assert!(matches!(event.pool_status, launchpad::events::PoolStatus::Fund), "pool_status");
+                assert!(
+                    matches!(event.trade_direction, launchpad::anchor_cpi_event::TradeDirection::Buy),
+                    "trade_direction"
+                );
+                assert!(matches!(event.pool_status, launchpad::anchor_cpi_event::PoolStatus::Fund), "pool_status");
             }
             _ => panic!("Expected TradeEventV2"),
         }


### PR DESCRIPTION
## Summary
- rename PumpFun AMM CPI log helpers to `anchor_cpi_event`
- rename Meteora DAAM & DLMM event helpers to `anchor_cpi_event`
- rename Raydium Launchpad event helper to `anchor_cpi_event`

## Testing
- `cargo test -p pumpfun`
- `cargo test -p meteora -p raydium`


------
https://chatgpt.com/codex/tasks/task_b_68c818ffee5083288f4b9055dd938f85