### PR TITLE
[codex] Decode OKX v2 swap events

### DIFF
--- a/src/okx/v2/events.rs
+++ b/src/okx/v2/events.rs
@@ -1,0 +1,54 @@
+//! OKX Dex v2 on-chain events.
+
+use crate::{common::ParseError, okx::v2::instructions::Dex};
+use borsh::{BorshDeserialize, BorshSerialize};
+
+// -----------------------------------------------------------------------------
+// Discriminators
+// -----------------------------------------------------------------------------
+pub const SWAP_EVENT: [u8; 8] = [64, 198, 205, 232, 38, 8, 113, 226];
+
+// -----------------------------------------------------------------------------
+// Event enumeration
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OkxV2Event {
+    Swap(SwapEvent),
+    Unknown,
+}
+
+// -----------------------------------------------------------------------------
+// Payload structs
+// -----------------------------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct SwapEvent {
+    pub dex: Dex,
+    pub amount_in: u64,
+    pub amount_out: u64,
+}
+
+// -----------------------------------------------------------------------------
+// Borsh deserialisation helper
+// -----------------------------------------------------------------------------
+impl<'a> TryFrom<&'a [u8]> for OkxV2Event {
+    type Error = ParseError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        if data.len() < 8 {
+            return Err(ParseError::TooShort(data.len()));
+        }
+
+        let (disc, payload) = data.split_at(8);
+        let discriminator: [u8; 8] = disc.try_into().expect("slice len 8");
+
+        Ok(match discriminator {
+            SWAP_EVENT => Self::Swap(SwapEvent::try_from_slice(payload)?),
+            _ => Self::Unknown,
+        })
+    }
+}
+
+/// Convenience wrapper that forwards to `TryFrom`.
+pub fn unpack(data: &[u8]) -> Result<OkxV2Event, ParseError> {
+    OkxV2Event::try_from(data)
+}

--- a/src/okx/v2/idl.json
+++ b/src/okx/v2/idl.json
@@ -1,4765 +1,2404 @@
 {
-    "address": "6m2CDdhRgxpH4WjvdzxAYbGxwdGUz5MziiL5jek2kBma",
-    "metadata": {
-        "name": "dex_solana",
-        "version": "0.1.0",
-        "spec": "0.1.0",
-        "description": "Created with Anchor"
-    },
-    "instructions": [
+    "constants": [
         {
-            "name": "add_resolver",
-            "discriminator": [
-                213,
-                83,
-                253,
+            "docs": [],
+            "name": "SEED_SA",
+            "type": "bytes",
+            "value": [
+                111,
                 107,
-                89,
-                173,
-                25,
-                250
-            ],
-            "accounts": [
-                {
-                    "name": "admin",
-                    "signer": true,
-                    "relations": [
-                        "global_config"
-                    ]
-                },
-                {
-                    "name": "global_config",
-                    "writable": true,
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    103,
-                                    108,
-                                    111,
-                                    98,
-                                    97,
-                                    108,
-                                    95,
-                                    99,
-                                    111,
-                                    110,
-                                    102,
-                                    105,
-                                    103
-                                ]
-                            }
-                        ]
-                    }
-                }
-            ],
-            "args": [
-                {
-                    "name": "resolver",
-                    "type": "pubkey"
-                }
-            ]
-        },
-        {
-            "name": "cancel_order",
-            "discriminator": [
-                95,
-                129,
-                237,
-                240,
-                8,
-                49,
-                223,
-                132
-            ],
-            "accounts": [
-                {
-                    "name": "payer",
-                    "docs": [
-                        "The payer of the transaction"
-                    ],
-                    "writable": true,
-                    "signer": true
-                },
-                {
-                    "name": "maker",
-                    "writable": true
-                },
-                {
-                    "name": "global_config",
-                    "docs": [
-                        "The global config account"
-                    ],
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    103,
-                                    108,
-                                    111,
-                                    98,
-                                    97,
-                                    108,
-                                    95,
-                                    99,
-                                    111,
-                                    110,
-                                    102,
-                                    105,
-                                    103
-                                ]
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "order_pda",
-                    "docs": [
-                        "The order PDA account"
-                    ],
-                    "writable": true,
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    111,
-                                    114,
-                                    100,
-                                    101,
-                                    114,
-                                    95,
-                                    118,
-                                    49
-                                ]
-                            },
-                            {
-                                "kind": "arg",
-                                "path": "order_id"
-                            },
-                            {
-                                "kind": "account",
-                                "path": "maker"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "escrow_token_account",
-                    "docs": [
-                        "The escrow token account for the order"
-                    ],
-                    "writable": true,
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    101,
-                                    115,
-                                    99,
-                                    114,
-                                    111,
-                                    119,
-                                    95,
-                                    116,
-                                    111,
-                                    107,
-                                    101,
-                                    110
-                                ]
-                            },
-                            {
-                                "kind": "account",
-                                "path": "order_pda"
-                            },
-                            {
-                                "kind": "account",
-                                "path": "input_token_mint"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "input_token_account",
-                    "docs": [
-                        "The user token account for input token"
-                    ],
-                    "writable": true
-                },
-                {
-                    "name": "input_token_mint",
-                    "docs": [
-                        "The mint of input token"
-                    ],
-                    "writable": true
-                },
-                {
-                    "name": "input_token_program",
-                    "docs": [
-                        "SPL program for input token transfers"
-                    ]
-                },
-                {
-                    "name": "instructions_sysvar",
-                    "address": "Sysvar1nstructions1111111111111111111111111"
-                },
-                {
-                    "name": "event_authority",
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    95,
-                                    95,
-                                    101,
-                                    118,
-                                    101,
-                                    110,
-                                    116,
-                                    95,
-                                    97,
-                                    117,
-                                    116,
-                                    104,
-                                    111,
-                                    114,
-                                    105,
-                                    116,
-                                    121
-                                ]
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "program"
-                }
-            ],
-            "args": [
-                {
-                    "name": "order_id",
-                    "type": "u64"
-                },
-                {
-                    "name": "tips",
-                    "type": "u64"
-                }
-            ]
-        },
-        {
-            "name": "claim",
-            "discriminator": [
-                62,
-                198,
-                214,
-                193,
-                213,
-                159,
-                108,
-                210
-            ],
-            "accounts": [
-                {
-                    "name": "signer",
-                    "writable": true,
-                    "signer": true,
-                    "address": "CjoV5B96reuCfPh2rRK11G1QptG97jZdyZArTn3EN1Mj"
-                },
-                {
-                    "name": "receiver",
-                    "writable": true
-                },
-                {
-                    "name": "source_token_account",
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "destination_token_account",
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "sa_authority",
-                    "writable": true,
-                    "address": "HV1KXxWFaSeriyFvXyx48FqG9BoFbfinB8njCJonqP7K"
-                },
-                {
-                    "name": "token_mint",
-                    "optional": true
-                },
-                {
-                    "name": "token_program",
-                    "optional": true
-                },
-                {
-                    "name": "system_program",
-                    "address": "11111111111111111111111111111111"
-                },
-                {
-                    "name": "associated_token_program",
-                    "optional": true,
-                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
-                }
-            ],
-            "args": []
-        },
-        {
-            "name": "commission_fill_order",
-            "discriminator": [
-                93,
-                237,
-                144,
-                37,
-                39,
-                166,
-                152,
-                242
-            ],
-            "accounts": [
-                {
-                    "name": "payer",
-                    "docs": [
-                        "The payer of the transaction"
-                    ],
-                    "writable": true,
-                    "signer": true
-                },
-                {
-                    "name": "maker",
-                    "writable": true
-                },
-                {
-                    "name": "global_config",
-                    "docs": [
-                        "The global config account"
-                    ],
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    103,
-                                    108,
-                                    111,
-                                    98,
-                                    97,
-                                    108,
-                                    95,
-                                    99,
-                                    111,
-                                    110,
-                                    102,
-                                    105,
-                                    103
-                                ]
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "sa_authority",
-                    "optional": true,
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    111,
-                                    107,
-                                    120,
-                                    95,
-                                    115,
-                                    97
-                                ]
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "input_token_sa",
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "output_token_sa",
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "order_pda",
-                    "docs": [
-                        "The order PDA account"
-                    ],
-                    "writable": true,
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    111,
-                                    114,
-                                    100,
-                                    101,
-                                    114,
-                                    95,
-                                    118,
-                                    49
-                                ]
-                            },
-                            {
-                                "kind": "arg",
-                                "path": "order_id"
-                            },
-                            {
-                                "kind": "account",
-                                "path": "maker"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "escrow_token_account",
-                    "docs": [
-                        "The escrow token account for the order"
-                    ],
-                    "writable": true,
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    101,
-                                    115,
-                                    99,
-                                    114,
-                                    111,
-                                    119,
-                                    95,
-                                    116,
-                                    111,
-                                    107,
-                                    101,
-                                    110
-                                ]
-                            },
-                            {
-                                "kind": "account",
-                                "path": "order_pda"
-                            },
-                            {
-                                "kind": "account",
-                                "path": "input_token_mint"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "temp_input_token_account",
-                    "docs": [
-                        "Temp input token account"
-                    ],
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "output_token_account",
-                    "docs": [
-                        "The user token account for output token"
-                    ],
-                    "writable": true
-                },
-                {
-                    "name": "input_token_mint",
-                    "docs": [
-                        "The mint of input token"
-                    ],
-                    "writable": true
-                },
-                {
-                    "name": "output_token_mint",
-                    "docs": [
-                        "The mint of output token"
-                    ]
-                },
-                {
-                    "name": "input_token_program"
-                },
-                {
-                    "name": "output_token_program"
-                },
-                {
-                    "name": "associated_token_program",
-                    "optional": true,
-                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
-                },
-                {
-                    "name": "system_program",
-                    "optional": true,
-                    "address": "11111111111111111111111111111111"
-                },
-                {
-                    "name": "instructions_sysvar",
-                    "address": "Sysvar1nstructions1111111111111111111111111"
-                },
-                {
-                    "name": "commission_token_account",
-                    "writable": true
-                },
-                {
-                    "name": "event_authority",
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    95,
-                                    95,
-                                    101,
-                                    118,
-                                    101,
-                                    110,
-                                    116,
-                                    95,
-                                    97,
-                                    117,
-                                    116,
-                                    104,
-                                    111,
-                                    114,
-                                    105,
-                                    116,
-                                    121
-                                ]
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "program"
-                }
-            ],
-            "args": [
-                {
-                    "name": "order_id",
-                    "type": "u64"
-                },
-                {
-                    "name": "tips",
-                    "type": "u64"
-                },
-                {
-                    "name": "args",
-                    "type": {
-                        "defined": {
-                            "name": "SwapArgs"
-                        }
-                    }
-                },
-                {
-                    "name": "commission_info",
-                    "type": "u32"
-                }
-            ]
-        },
-        {
-            "name": "commission_sol_from_swap",
-            "discriminator": [
-                129,
-                59,
-                69,
-                10,
-                132,
-                76,
-                35,
-                20
-            ],
-            "accounts": [
-                {
-                    "name": "payer",
-                    "writable": true,
-                    "signer": true
-                },
-                {
-                    "name": "source_token_account",
-                    "writable": true
-                },
-                {
-                    "name": "destination_token_account",
-                    "writable": true
-                },
-                {
-                    "name": "source_mint"
-                },
-                {
-                    "name": "destination_mint",
-                    "writable": true
-                },
-                {
-                    "name": "bridge_program",
-                    "address": "okxBd18urPbBi2vsExxUDArzQNcju2DugV9Mt46BxYE"
-                },
-                {
-                    "name": "associated_token_program",
-                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
-                },
-                {
-                    "name": "token_program",
-                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
-                },
-                {
-                    "name": "token_2022_program",
-                    "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
-                },
-                {
-                    "name": "system_program",
-                    "address": "11111111111111111111111111111111"
-                },
-                {
-                    "name": "commission_account",
-                    "writable": true
-                }
-            ],
-            "args": [
-                {
-                    "name": "args",
-                    "type": {
-                        "defined": {
-                            "name": "SwapArgs"
-                        }
-                    }
-                },
-                {
-                    "name": "commission_rate",
-                    "type": "u16"
-                },
-                {
-                    "name": "bridge_to_args",
-                    "type": {
-                        "defined": {
-                            "name": "BridgeToArgs"
-                        }
-                    }
-                },
-                {
-                    "name": "offset",
-                    "type": "u8"
-                },
-                {
-                    "name": "len",
-                    "type": "u8"
-                }
-            ]
-        },
-        {
-            "name": "commission_sol_proxy_swap",
-            "discriminator": [
-                30,
-                33,
-                208,
-                91,
-                31,
-                157,
-                37,
-                18
-            ],
-            "accounts": [
-                {
-                    "name": "payer",
-                    "writable": true,
-                    "signer": true
-                },
-                {
-                    "name": "source_token_account",
-                    "writable": true
-                },
-                {
-                    "name": "destination_token_account",
-                    "writable": true
-                },
-                {
-                    "name": "source_mint"
-                },
-                {
-                    "name": "destination_mint"
-                },
-                {
-                    "name": "commission_account",
-                    "writable": true
-                },
-                {
-                    "name": "sa_authority",
-                    "optional": true,
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    111,
-                                    107,
-                                    120,
-                                    95,
-                                    115,
-                                    97
-                                ]
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "source_token_sa",
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "destination_token_sa",
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "source_token_program",
-                    "optional": true
-                },
-                {
-                    "name": "destination_token_program",
-                    "optional": true
-                },
-                {
-                    "name": "associated_token_program",
-                    "optional": true,
-                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
-                },
-                {
-                    "name": "system_program",
-                    "optional": true,
-                    "address": "11111111111111111111111111111111"
-                }
-            ],
-            "args": [
-                {
-                    "name": "data",
-                    "type": {
-                        "defined": {
-                            "name": "SwapArgs"
-                        }
-                    }
-                },
-                {
-                    "name": "commission_rate",
-                    "type": "u16"
-                },
-                {
-                    "name": "commission_direction",
-                    "type": "bool"
-                },
-                {
-                    "name": "order_id",
-                    "type": "u64"
-                }
-            ]
-        },
-        {
-            "name": "commission_sol_swap",
-            "discriminator": [
-                81,
-                128,
-                134,
-                73,
-                114,
-                73,
-                45,
-                94
-            ],
-            "accounts": [
-                {
-                    "name": "payer",
-                    "signer": true
-                },
-                {
-                    "name": "source_token_account",
-                    "writable": true
-                },
-                {
-                    "name": "destination_token_account",
-                    "writable": true
-                },
-                {
-                    "name": "source_mint"
-                },
-                {
-                    "name": "destination_mint"
-                },
-                {
-                    "name": "commission_account",
-                    "writable": true
-                },
-                {
-                    "name": "system_program",
-                    "address": "11111111111111111111111111111111"
-                }
-            ],
-            "args": [
-                {
-                    "name": "data",
-                    "type": {
-                        "defined": {
-                            "name": "CommissionSwapArgs"
-                        }
-                    }
-                },
-                {
-                    "name": "order_id",
-                    "type": "u64"
-                }
-            ]
-        },
-        {
-            "name": "commission_spl_from_swap",
-            "discriminator": [
-                5,
-                77,
-                144,
-                50,
-                222,
-                228,
-                233,
-                171
-            ],
-            "accounts": [
-                {
-                    "name": "payer",
-                    "writable": true,
-                    "signer": true
-                },
-                {
-                    "name": "source_token_account",
-                    "writable": true
-                },
-                {
-                    "name": "destination_token_account",
-                    "writable": true
-                },
-                {
-                    "name": "source_mint"
-                },
-                {
-                    "name": "destination_mint",
-                    "writable": true
-                },
-                {
-                    "name": "bridge_program",
-                    "address": "okxBd18urPbBi2vsExxUDArzQNcju2DugV9Mt46BxYE"
-                },
-                {
-                    "name": "associated_token_program",
-                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
-                },
-                {
-                    "name": "token_program",
-                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
-                },
-                {
-                    "name": "token_2022_program",
-                    "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
-                },
-                {
-                    "name": "system_program",
-                    "address": "11111111111111111111111111111111"
-                },
-                {
-                    "name": "commission_token_account",
-                    "writable": true
-                }
-            ],
-            "args": [
-                {
-                    "name": "args",
-                    "type": {
-                        "defined": {
-                            "name": "SwapArgs"
-                        }
-                    }
-                },
-                {
-                    "name": "commission_rate",
-                    "type": "u16"
-                },
-                {
-                    "name": "bridge_to_args",
-                    "type": {
-                        "defined": {
-                            "name": "BridgeToArgs"
-                        }
-                    }
-                },
-                {
-                    "name": "offset",
-                    "type": "u8"
-                },
-                {
-                    "name": "len",
-                    "type": "u8"
-                }
-            ]
-        },
-        {
-            "name": "commission_spl_proxy_swap",
-            "discriminator": [
-                96,
-                67,
-                12,
-                151,
-                129,
-                164,
-                18,
-                71
-            ],
-            "accounts": [
-                {
-                    "name": "payer",
-                    "writable": true,
-                    "signer": true
-                },
-                {
-                    "name": "source_token_account",
-                    "writable": true
-                },
-                {
-                    "name": "destination_token_account",
-                    "writable": true
-                },
-                {
-                    "name": "source_mint"
-                },
-                {
-                    "name": "destination_mint"
-                },
-                {
-                    "name": "commission_token_account",
-                    "writable": true
-                },
-                {
-                    "name": "sa_authority",
-                    "optional": true,
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    111,
-                                    107,
-                                    120,
-                                    95,
-                                    115,
-                                    97
-                                ]
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "source_token_sa",
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "destination_token_sa",
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "source_token_program",
-                    "optional": true
-                },
-                {
-                    "name": "destination_token_program",
-                    "optional": true
-                },
-                {
-                    "name": "associated_token_program",
-                    "optional": true,
-                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
-                },
-                {
-                    "name": "system_program",
-                    "optional": true,
-                    "address": "11111111111111111111111111111111"
-                }
-            ],
-            "args": [
-                {
-                    "name": "data",
-                    "type": {
-                        "defined": {
-                            "name": "SwapArgs"
-                        }
-                    }
-                },
-                {
-                    "name": "commission_rate",
-                    "type": "u16"
-                },
-                {
-                    "name": "commission_direction",
-                    "type": "bool"
-                },
-                {
-                    "name": "order_id",
-                    "type": "u64"
-                }
-            ]
-        },
-        {
-            "name": "commission_spl_swap",
-            "discriminator": [
-                235,
-                71,
-                211,
-                196,
-                114,
-                199,
-                143,
-                92
-            ],
-            "accounts": [
-                {
-                    "name": "payer",
-                    "signer": true
-                },
-                {
-                    "name": "source_token_account",
-                    "writable": true
-                },
-                {
-                    "name": "destination_token_account",
-                    "writable": true
-                },
-                {
-                    "name": "source_mint"
-                },
-                {
-                    "name": "destination_mint"
-                },
-                {
-                    "name": "commission_token_account",
-                    "writable": true
-                },
-                {
-                    "name": "token_program"
-                }
-            ],
-            "args": [
-                {
-                    "name": "data",
-                    "type": {
-                        "defined": {
-                            "name": "CommissionSwapArgs"
-                        }
-                    }
-                },
-                {
-                    "name": "order_id",
-                    "type": "u64"
-                }
-            ]
-        },
-        {
-            "name": "commission_wrap_unwrap",
-            "discriminator": [
-                12,
-                73,
-                156,
-                71,
-                233,
-                172,
-                189,
-                197
-            ],
-            "accounts": [
-                {
-                    "name": "payer",
-                    "writable": true,
-                    "signer": true
-                },
-                {
-                    "name": "payer_wsol_account",
-                    "writable": true
-                },
-                {
-                    "name": "wsol_mint",
-                    "address": "So11111111111111111111111111111111111111112"
-                },
-                {
-                    "name": "temp_wsol_account",
-                    "writable": true,
-                    "optional": true,
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    116,
-                                    101,
-                                    109,
-                                    112,
-                                    95,
-                                    119,
-                                    115,
-                                    111,
-                                    108
-                                ]
-                            },
-                            {
-                                "kind": "account",
-                                "path": "payer"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "commission_sol_account",
-                    "writable": true
-                },
-                {
-                    "name": "commission_wsol_account",
-                    "writable": true
-                },
-                {
-                    "name": "system_program",
-                    "address": "11111111111111111111111111111111"
-                },
-                {
-                    "name": "token_program"
-                }
-            ],
-            "args": [
-                {
-                    "name": "data",
-                    "type": {
-                        "defined": {
-                            "name": "CommissionWrapUnwrapArgs"
-                        }
-                    }
-                },
-                {
-                    "name": "order_id",
-                    "type": "u64"
-                }
-            ]
-        },
-        {
-            "name": "fill_order_by_resolver",
-            "discriminator": [
-                176,
-                206,
-                126,
-                248,
-                50,
-                215,
-                39,
-                44
-            ],
-            "accounts": [
-                {
-                    "name": "payer",
-                    "docs": [
-                        "The payer of the transaction"
-                    ],
-                    "writable": true,
-                    "signer": true
-                },
-                {
-                    "name": "maker",
-                    "writable": true
-                },
-                {
-                    "name": "global_config",
-                    "docs": [
-                        "The global config account"
-                    ],
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    103,
-                                    108,
-                                    111,
-                                    98,
-                                    97,
-                                    108,
-                                    95,
-                                    99,
-                                    111,
-                                    110,
-                                    102,
-                                    105,
-                                    103
-                                ]
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "sa_authority",
-                    "optional": true,
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    111,
-                                    107,
-                                    120,
-                                    95,
-                                    115,
-                                    97
-                                ]
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "input_token_sa",
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "output_token_sa",
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "order_pda",
-                    "docs": [
-                        "The order PDA account"
-                    ],
-                    "writable": true,
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    111,
-                                    114,
-                                    100,
-                                    101,
-                                    114,
-                                    95,
-                                    118,
-                                    49
-                                ]
-                            },
-                            {
-                                "kind": "arg",
-                                "path": "order_id"
-                            },
-                            {
-                                "kind": "account",
-                                "path": "maker"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "escrow_token_account",
-                    "docs": [
-                        "The escrow token account for the order"
-                    ],
-                    "writable": true,
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    101,
-                                    115,
-                                    99,
-                                    114,
-                                    111,
-                                    119,
-                                    95,
-                                    116,
-                                    111,
-                                    107,
-                                    101,
-                                    110
-                                ]
-                            },
-                            {
-                                "kind": "account",
-                                "path": "order_pda"
-                            },
-                            {
-                                "kind": "account",
-                                "path": "input_token_mint"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "temp_input_token_account",
-                    "docs": [
-                        "Temp input token account"
-                    ],
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "output_token_account",
-                    "docs": [
-                        "The user token account for output token"
-                    ],
-                    "writable": true
-                },
-                {
-                    "name": "input_token_mint",
-                    "docs": [
-                        "The mint of input token"
-                    ],
-                    "writable": true
-                },
-                {
-                    "name": "output_token_mint",
-                    "docs": [
-                        "The mint of output token"
-                    ]
-                },
-                {
-                    "name": "input_token_program"
-                },
-                {
-                    "name": "output_token_program"
-                },
-                {
-                    "name": "associated_token_program",
-                    "optional": true,
-                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
-                },
-                {
-                    "name": "system_program",
-                    "optional": true,
-                    "address": "11111111111111111111111111111111"
-                },
-                {
-                    "name": "instructions_sysvar",
-                    "address": "Sysvar1nstructions1111111111111111111111111"
-                },
-                {
-                    "name": "event_authority",
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    95,
-                                    95,
-                                    101,
-                                    118,
-                                    101,
-                                    110,
-                                    116,
-                                    95,
-                                    97,
-                                    117,
-                                    116,
-                                    104,
-                                    111,
-                                    114,
-                                    105,
-                                    116,
-                                    121
-                                ]
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "program"
-                }
-            ],
-            "args": [
-                {
-                    "name": "order_id",
-                    "type": "u64"
-                },
-                {
-                    "name": "tips",
-                    "type": "u64"
-                },
-                {
-                    "name": "args",
-                    "type": {
-                        "defined": {
-                            "name": "SwapArgs"
-                        }
-                    }
-                }
-            ]
-        },
-        {
-            "name": "from_swap_log",
-            "discriminator": [
-                133,
-                186,
-                15,
-                105,
-                31,
-                76,
-                31,
-                112
-            ],
-            "accounts": [
-                {
-                    "name": "payer",
-                    "writable": true,
-                    "signer": true
-                },
-                {
-                    "name": "source_token_account",
-                    "writable": true
-                },
-                {
-                    "name": "destination_token_account",
-                    "writable": true
-                },
-                {
-                    "name": "source_mint"
-                },
-                {
-                    "name": "destination_mint",
-                    "writable": true
-                },
-                {
-                    "name": "bridge_program",
-                    "address": "okxBd18urPbBi2vsExxUDArzQNcju2DugV9Mt46BxYE"
-                },
-                {
-                    "name": "associated_token_program",
-                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
-                },
-                {
-                    "name": "token_program",
-                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
-                },
-                {
-                    "name": "token_2022_program",
-                    "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
-                },
-                {
-                    "name": "system_program",
-                    "address": "11111111111111111111111111111111"
-                }
-            ],
-            "args": [
-                {
-                    "name": "args",
-                    "type": {
-                        "defined": {
-                            "name": "SwapArgs"
-                        }
-                    }
-                },
-                {
-                    "name": "bridge_to_args",
-                    "type": {
-                        "defined": {
-                            "name": "BridgeToArgs"
-                        }
-                    }
-                },
-                {
-                    "name": "offset",
-                    "type": "u8"
-                },
-                {
-                    "name": "len",
-                    "type": "u8"
-                }
-            ]
-        },
-        {
-            "name": "init_global_config",
-            "discriminator": [
-                140,
-                136,
-                214,
-                48,
-                87,
-                0,
                 120,
-                255
-            ],
-            "accounts": [
-                {
-                    "name": "admin",
-                    "docs": [
-                        "Address to be set as protocol owner."
-                    ],
-                    "writable": true,
-                    "signer": true
-                },
-                {
-                    "name": "global_config",
-                    "docs": [
-                        "Initialize config state account to store protocol owner address and fee rates."
-                    ],
-                    "writable": true,
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    103,
-                                    108,
-                                    111,
-                                    98,
-                                    97,
-                                    108,
-                                    95,
-                                    99,
-                                    111,
-                                    110,
-                                    102,
-                                    105,
-                                    103
-                                ]
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "program",
-                    "address": "6m2CDdhRgxpH4WjvdzxAYbGxwdGUz5MziiL5jek2kBma"
-                },
-                {
-                    "name": "program_data"
-                },
-                {
-                    "name": "system_program",
-                    "address": "11111111111111111111111111111111"
-                }
-            ],
-            "args": [
-                {
-                    "name": "trade_fee",
-                    "type": "u64"
-                }
-            ]
-        },
-        {
-            "name": "pause",
-            "discriminator": [
-                211,
-                22,
-                221,
-                251,
-                74,
-                121,
-                193,
-                47
-            ],
-            "accounts": [
-                {
-                    "name": "admin",
-                    "signer": true,
-                    "relations": [
-                        "global_config"
-                    ]
-                },
-                {
-                    "name": "global_config",
-                    "writable": true,
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    103,
-                                    108,
-                                    111,
-                                    98,
-                                    97,
-                                    108,
-                                    95,
-                                    99,
-                                    111,
-                                    110,
-                                    102,
-                                    105,
-                                    103
-                                ]
-                            }
-                        ]
-                    }
-                }
-            ],
-            "args": []
-        },
-        {
-            "name": "place_order",
-            "discriminator": [
-                51,
-                194,
-                155,
-                175,
-                109,
-                130,
-                96,
-                106
-            ],
-            "accounts": [
-                {
-                    "name": "maker",
-                    "docs": [
-                        "The maker of the order"
-                    ],
-                    "writable": true,
-                    "signer": true
-                },
-                {
-                    "name": "global_config",
-                    "docs": [
-                        "The global config account"
-                    ],
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    103,
-                                    108,
-                                    111,
-                                    98,
-                                    97,
-                                    108,
-                                    95,
-                                    99,
-                                    111,
-                                    110,
-                                    102,
-                                    105,
-                                    103
-                                ]
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "order_pda",
-                    "docs": [
-                        "The order PDA account"
-                    ],
-                    "writable": true,
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    111,
-                                    114,
-                                    100,
-                                    101,
-                                    114,
-                                    95,
-                                    118,
-                                    49
-                                ]
-                            },
-                            {
-                                "kind": "arg",
-                                "path": "order_id"
-                            },
-                            {
-                                "kind": "account",
-                                "path": "maker"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "escrow_token_account",
-                    "docs": [
-                        "The escrow token account for the order"
-                    ],
-                    "writable": true,
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    101,
-                                    115,
-                                    99,
-                                    114,
-                                    111,
-                                    119,
-                                    95,
-                                    116,
-                                    111,
-                                    107,
-                                    101,
-                                    110
-                                ]
-                            },
-                            {
-                                "kind": "account",
-                                "path": "order_pda"
-                            },
-                            {
-                                "kind": "account",
-                                "path": "input_token_mint"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "input_token_account",
-                    "docs": [
-                        "The user token account for input token"
-                    ],
-                    "writable": true
-                },
-                {
-                    "name": "input_token_mint",
-                    "docs": [
-                        "The mint of input token"
-                    ]
-                },
-                {
-                    "name": "output_token_mint",
-                    "docs": [
-                        "The mint of output token"
-                    ]
-                },
-                {
-                    "name": "input_token_program"
-                },
-                {
-                    "name": "output_token_program"
-                },
-                {
-                    "name": "system_program",
-                    "address": "11111111111111111111111111111111"
-                },
-                {
-                    "name": "event_authority",
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    95,
-                                    95,
-                                    101,
-                                    118,
-                                    101,
-                                    110,
-                                    116,
-                                    95,
-                                    97,
-                                    117,
-                                    116,
-                                    104,
-                                    111,
-                                    114,
-                                    105,
-                                    116,
-                                    121
-                                ]
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "program"
-                }
-            ],
-            "args": [
-                {
-                    "name": "order_id",
-                    "type": "u64"
-                },
-                {
-                    "name": "making_amount",
-                    "type": "u64"
-                },
-                {
-                    "name": "expect_taking_amount",
-                    "type": "u64"
-                },
-                {
-                    "name": "min_return_amount",
-                    "type": "u64"
-                },
-                {
-                    "name": "deadline",
-                    "type": "u64"
-                },
-                {
-                    "name": "trade_fee",
-                    "type": "u64"
-                }
-            ]
-        },
-        {
-            "name": "platform_fee_sol_proxy_swap_v2",
-            "discriminator": [
-                69,
-                200,
-                254,
-                247,
-                40,
-                52,
-                118,
-                202
-            ],
-            "accounts": [
-                {
-                    "name": "payer",
-                    "writable": true,
-                    "signer": true
-                },
-                {
-                    "name": "source_token_account",
-                    "writable": true
-                },
-                {
-                    "name": "destination_token_account",
-                    "writable": true
-                },
-                {
-                    "name": "source_mint"
-                },
-                {
-                    "name": "destination_mint"
-                },
-                {
-                    "name": "commission_account",
-                    "writable": true
-                },
-                {
-                    "name": "sa_authority",
-                    "optional": true,
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    111,
-                                    107,
-                                    120,
-                                    95,
-                                    115,
-                                    97
-                                ]
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "source_token_sa",
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "destination_token_sa",
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "source_token_program",
-                    "optional": true
-                },
-                {
-                    "name": "destination_token_program",
-                    "optional": true
-                },
-                {
-                    "name": "associated_token_program",
-                    "optional": true,
-                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
-                },
-                {
-                    "name": "system_program",
-                    "optional": true,
-                    "address": "11111111111111111111111111111111"
-                }
-            ],
-            "args": [
-                {
-                    "name": "args",
-                    "type": {
-                        "defined": {
-                            "name": "SwapArgs"
-                        }
-                    }
-                },
-                {
-                    "name": "commission_info",
-                    "type": "u32"
-                },
-                {
-                    "name": "platform_fee_rate",
-                    "type": "u32"
-                },
-                {
-                    "name": "trim_rate",
-                    "type": "u8"
-                },
-                {
-                    "name": "order_id",
-                    "type": "u64"
-                }
-            ]
-        },
-        {
-            "name": "platform_fee_sol_wrap_unwrap_v2",
-            "discriminator": [
-                196,
-                172,
-                152,
-                92,
-                60,
-                186,
-                64,
-                227
-            ],
-            "accounts": [
-                {
-                    "name": "payer",
-                    "writable": true,
-                    "signer": true
-                },
-                {
-                    "name": "payer_wsol_account",
-                    "writable": true
-                },
-                {
-                    "name": "wsol_mint",
-                    "address": "So11111111111111111111111111111111111111112"
-                },
-                {
-                    "name": "temp_wsol_account",
-                    "writable": true,
-                    "optional": true,
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    116,
-                                    101,
-                                    109,
-                                    112,
-                                    95,
-                                    119,
-                                    115,
-                                    111,
-                                    108
-                                ]
-                            },
-                            {
-                                "kind": "account",
-                                "path": "payer"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "commission_sol_account",
-                    "writable": true
-                },
-                {
-                    "name": "commission_wsol_account",
-                    "writable": true
-                },
-                {
-                    "name": "source_token_sa",
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "destination_token_sa",
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "system_program",
-                    "address": "11111111111111111111111111111111"
-                },
-                {
-                    "name": "token_program"
-                }
-            ],
-            "args": [
-                {
-                    "name": "args",
-                    "type": {
-                        "defined": {
-                            "name": "PlatformFeeWrapUnwrapArgsV2"
-                        }
-                    }
-                },
-                {
-                    "name": "order_id",
-                    "type": "u64"
-                }
-            ]
-        },
-        {
-            "name": "platform_fee_spl_proxy_swap_v2",
-            "discriminator": [
-                69,
-                164,
-                210,
-                89,
-                146,
-                214,
-                173,
-                67
-            ],
-            "accounts": [
-                {
-                    "name": "payer",
-                    "writable": true,
-                    "signer": true
-                },
-                {
-                    "name": "source_token_account",
-                    "writable": true
-                },
-                {
-                    "name": "destination_token_account",
-                    "writable": true
-                },
-                {
-                    "name": "source_mint"
-                },
-                {
-                    "name": "destination_mint"
-                },
-                {
-                    "name": "commission_token_account",
-                    "writable": true
-                },
-                {
-                    "name": "sa_authority",
-                    "optional": true,
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    111,
-                                    107,
-                                    120,
-                                    95,
-                                    115,
-                                    97
-                                ]
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "source_token_sa",
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "destination_token_sa",
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "source_token_program",
-                    "optional": true
-                },
-                {
-                    "name": "destination_token_program",
-                    "optional": true
-                },
-                {
-                    "name": "associated_token_program",
-                    "optional": true,
-                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
-                },
-                {
-                    "name": "system_program",
-                    "optional": true,
-                    "address": "11111111111111111111111111111111"
-                }
-            ],
-            "args": [
-                {
-                    "name": "args",
-                    "type": {
-                        "defined": {
-                            "name": "SwapArgs"
-                        }
-                    }
-                },
-                {
-                    "name": "commission_info",
-                    "type": "u32"
-                },
-                {
-                    "name": "platform_fee_rate",
-                    "type": "u32"
-                },
-                {
-                    "name": "trim_rate",
-                    "type": "u8"
-                },
-                {
-                    "name": "order_id",
-                    "type": "u64"
-                }
-            ]
-        },
-        {
-            "name": "proxy_swap",
-            "discriminator": [
-                19,
-                44,
-                130,
-                148,
-                72,
-                56,
-                44,
-                238
-            ],
-            "accounts": [
-                {
-                    "name": "payer",
-                    "writable": true,
-                    "signer": true
-                },
-                {
-                    "name": "source_token_account",
-                    "writable": true
-                },
-                {
-                    "name": "destination_token_account",
-                    "writable": true
-                },
-                {
-                    "name": "source_mint"
-                },
-                {
-                    "name": "destination_mint"
-                },
-                {
-                    "name": "sa_authority",
-                    "optional": true,
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    111,
-                                    107,
-                                    120,
-                                    95,
-                                    115,
-                                    97
-                                ]
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "source_token_sa",
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "destination_token_sa",
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "source_token_program",
-                    "optional": true
-                },
-                {
-                    "name": "destination_token_program",
-                    "optional": true
-                },
-                {
-                    "name": "associated_token_program",
-                    "optional": true,
-                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
-                },
-                {
-                    "name": "system_program",
-                    "optional": true,
-                    "address": "11111111111111111111111111111111"
-                }
-            ],
-            "args": [
-                {
-                    "name": "data",
-                    "type": {
-                        "defined": {
-                            "name": "SwapArgs"
-                        }
-                    }
-                },
-                {
-                    "name": "order_id",
-                    "type": "u64"
-                }
-            ]
-        },
-        {
-            "name": "remove_resolver",
-            "discriminator": [
-                87,
-                90,
-                193,
-                60,
-                246,
-                119,
-                62,
-                88
-            ],
-            "accounts": [
-                {
-                    "name": "admin",
-                    "signer": true,
-                    "relations": [
-                        "global_config"
-                    ]
-                },
-                {
-                    "name": "global_config",
-                    "writable": true,
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    103,
-                                    108,
-                                    111,
-                                    98,
-                                    97,
-                                    108,
-                                    95,
-                                    99,
-                                    111,
-                                    110,
-                                    102,
-                                    105,
-                                    103
-                                ]
-                            }
-                        ]
-                    }
-                }
-            ],
-            "args": [
-                {
-                    "name": "resolver",
-                    "type": "pubkey"
-                }
-            ]
-        },
-        {
-            "name": "set_admin",
-            "discriminator": [
-                251,
-                163,
-                0,
-                52,
-                91,
-                194,
-                187,
-                92
-            ],
-            "accounts": [
-                {
-                    "name": "admin",
-                    "signer": true,
-                    "relations": [
-                        "global_config"
-                    ]
-                },
-                {
-                    "name": "global_config",
-                    "writable": true,
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    103,
-                                    108,
-                                    111,
-                                    98,
-                                    97,
-                                    108,
-                                    95,
-                                    99,
-                                    111,
-                                    110,
-                                    102,
-                                    105,
-                                    103
-                                ]
-                            }
-                        ]
-                    }
-                }
-            ],
-            "args": [
-                {
-                    "name": "admin",
-                    "type": "pubkey"
-                }
-            ]
-        },
-        {
-            "name": "set_fee_multiplier",
-            "discriminator": [
-                9,
-                25,
-                249,
-                189,
-                130,
-                0,
-                250,
-                159
-            ],
-            "accounts": [
-                {
-                    "name": "admin",
-                    "signer": true,
-                    "relations": [
-                        "global_config"
-                    ]
-                },
-                {
-                    "name": "global_config",
-                    "writable": true,
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    103,
-                                    108,
-                                    111,
-                                    98,
-                                    97,
-                                    108,
-                                    95,
-                                    99,
-                                    111,
-                                    110,
-                                    102,
-                                    105,
-                                    103
-                                ]
-                            }
-                        ]
-                    }
-                }
-            ],
-            "args": [
-                {
-                    "name": "fee_multiplier",
-                    "type": "u8"
-                }
-            ]
-        },
-        {
-            "name": "set_trade_fee",
-            "discriminator": [
-                209,
-                92,
-                87,
-                185,
-                19,
-                29,
-                112,
-                91
-            ],
-            "accounts": [
-                {
-                    "name": "admin",
-                    "signer": true,
-                    "relations": [
-                        "global_config"
-                    ]
-                },
-                {
-                    "name": "global_config",
-                    "writable": true,
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    103,
-                                    108,
-                                    111,
-                                    98,
-                                    97,
-                                    108,
-                                    95,
-                                    99,
-                                    111,
-                                    110,
-                                    102,
-                                    105,
-                                    103
-                                ]
-                            }
-                        ]
-                    }
-                }
-            ],
-            "args": [
-                {
-                    "name": "trade_fee",
-                    "type": "u64"
-                }
-            ]
-        },
-        {
-            "name": "swap",
-            "discriminator": [
-                248,
-                198,
-                158,
-                145,
-                225,
-                117,
-                135,
-                200
-            ],
-            "accounts": [
-                {
-                    "name": "payer",
-                    "signer": true
-                },
-                {
-                    "name": "source_token_account",
-                    "writable": true
-                },
-                {
-                    "name": "destination_token_account",
-                    "writable": true
-                },
-                {
-                    "name": "source_mint"
-                },
-                {
-                    "name": "destination_mint"
-                }
-            ],
-            "args": [
-                {
-                    "name": "data",
-                    "type": {
-                        "defined": {
-                            "name": "SwapArgs"
-                        }
-                    }
-                },
-                {
-                    "name": "order_id",
-                    "type": "u64"
-                }
-            ]
-        },
-        {
-            "name": "swap_tob_v3",
-            "discriminator": [
-                14,
-                191,
-                44,
-                246,
-                142,
-                225,
-                224,
-                157
-            ],
-            "accounts": [
-                {
-                    "name": "payer",
-                    "writable": true,
-                    "signer": true
-                },
-                {
-                    "name": "source_token_account",
-                    "writable": true
-                },
-                {
-                    "name": "destination_token_account",
-                    "writable": true
-                },
-                {
-                    "name": "source_mint"
-                },
-                {
-                    "name": "destination_mint"
-                },
-                {
-                    "name": "commission_account",
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "platform_fee_account",
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "sa_authority",
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "source_token_sa",
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "destination_token_sa",
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "source_token_program",
-                    "optional": true
-                },
-                {
-                    "name": "destination_token_program",
-                    "optional": true
-                },
-                {
-                    "name": "associated_token_program",
-                    "optional": true,
-                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
-                },
-                {
-                    "name": "system_program",
-                    "optional": true,
-                    "address": "11111111111111111111111111111111"
-                }
-            ],
-            "args": [
-                {
-                    "name": "args",
-                    "type": {
-                        "defined": {
-                            "name": "SwapArgs"
-                        }
-                    }
-                },
-                {
-                    "name": "commission_info",
-                    "type": "u32"
-                },
-                {
-                    "name": "trim_rate",
-                    "type": "u8"
-                },
-                {
-                    "name": "platform_fee_rate",
-                    "type": "u16"
-                },
-                {
-                    "name": "order_id",
-                    "type": "u64"
-                }
-            ]
-        },
-        {
-            "name": "swap_tob_v3_with_receiver",
-            "docs": [
-                "Swap ToB with optional specified receiver",
-                "- For normal token swaps: sol_receiver should be None",
-                "- For swap to SOL with custom receiver: sol_receiver should be Some and acc_close_flag must be true"
-            ],
-            "discriminator": [
-                63,
-                114,
-                246,
-                131,
-                51,
-                2,
-                247,
-                29
-            ],
-            "accounts": [
-                {
-                    "name": "payer",
-                    "writable": true,
-                    "signer": true
-                },
-                {
-                    "name": "source_token_account",
-                    "writable": true
-                },
-                {
-                    "name": "destination_token_account",
-                    "writable": true
-                },
-                {
-                    "name": "source_mint"
-                },
-                {
-                    "name": "destination_mint"
-                },
-                {
-                    "name": "commission_account",
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "platform_fee_account",
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "sa_authority",
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "source_token_sa",
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "destination_token_sa",
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "source_token_program",
-                    "optional": true
-                },
-                {
-                    "name": "destination_token_program",
-                    "optional": true
-                },
-                {
-                    "name": "associated_token_program",
-                    "optional": true,
-                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
-                },
-                {
-                    "name": "system_program",
-                    "optional": true,
-                    "address": "11111111111111111111111111111111"
-                },
-                {
-                    "name": "sol_receiver",
-                    "docs": [
-                        "Optional SOL receiver account",
-                        "- None: normal swap or SOL stays with payer",
-                        "- Some: SOL receiver when converting wSOL -> SOL"
-                    ],
-                    "writable": true,
-                    "optional": true
-                }
-            ],
-            "args": [
-                {
-                    "name": "args",
-                    "type": {
-                        "defined": {
-                            "name": "SwapArgs"
-                        }
-                    }
-                },
-                {
-                    "name": "commission_info",
-                    "type": "u32"
-                },
-                {
-                    "name": "trim_rate",
-                    "type": "u8"
-                },
-                {
-                    "name": "platform_fee_rate",
-                    "type": "u16"
-                },
-                {
-                    "name": "order_id",
-                    "type": "u64"
-                }
-            ]
-        },
-        {
-            "name": "swap_v3",
-            "discriminator": [
-                240,
-                224,
-                38,
-                33,
-                176,
-                31,
-                241,
-                175
-            ],
-            "accounts": [
-                {
-                    "name": "payer",
-                    "writable": true,
-                    "signer": true
-                },
-                {
-                    "name": "source_token_account",
-                    "writable": true
-                },
-                {
-                    "name": "destination_token_account",
-                    "writable": true
-                },
-                {
-                    "name": "source_mint"
-                },
-                {
-                    "name": "destination_mint"
-                },
-                {
-                    "name": "commission_account",
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "platform_fee_account",
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "sa_authority",
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "source_token_sa",
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "destination_token_sa",
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "source_token_program",
-                    "optional": true
-                },
-                {
-                    "name": "destination_token_program",
-                    "optional": true
-                },
-                {
-                    "name": "associated_token_program",
-                    "optional": true,
-                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
-                },
-                {
-                    "name": "system_program",
-                    "optional": true,
-                    "address": "11111111111111111111111111111111"
-                }
-            ],
-            "args": [
-                {
-                    "name": "args",
-                    "type": {
-                        "defined": {
-                            "name": "SwapArgs"
-                        }
-                    }
-                },
-                {
-                    "name": "commission_info",
-                    "type": "u32"
-                },
-                {
-                    "name": "platform_fee_rate",
-                    "type": "u16"
-                },
-                {
-                    "name": "order_id",
-                    "type": "u64"
-                }
-            ]
-        },
-        {
-            "name": "unpause",
-            "discriminator": [
-                169,
-                144,
-                4,
-                38,
-                10,
-                141,
-                188,
-                255
-            ],
-            "accounts": [
-                {
-                    "name": "admin",
-                    "signer": true,
-                    "relations": [
-                        "global_config"
-                    ]
-                },
-                {
-                    "name": "global_config",
-                    "writable": true,
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    103,
-                                    108,
-                                    111,
-                                    98,
-                                    97,
-                                    108,
-                                    95,
-                                    99,
-                                    111,
-                                    110,
-                                    102,
-                                    105,
-                                    103
-                                ]
-                            }
-                        ]
-                    }
-                }
-            ],
-            "args": []
-        },
-        {
-            "name": "update_order",
-            "discriminator": [
-                54,
-                8,
-                208,
-                207,
-                34,
-                134,
-                239,
-                168
-            ],
-            "accounts": [
-                {
-                    "name": "maker",
-                    "writable": true,
-                    "signer": true
-                },
-                {
-                    "name": "global_config",
-                    "docs": [
-                        "The global config account"
-                    ],
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    103,
-                                    108,
-                                    111,
-                                    98,
-                                    97,
-                                    108,
-                                    95,
-                                    99,
-                                    111,
-                                    110,
-                                    102,
-                                    105,
-                                    103
-                                ]
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "order_pda",
-                    "docs": [
-                        "The order PDA account"
-                    ],
-                    "writable": true,
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    111,
-                                    114,
-                                    100,
-                                    101,
-                                    114,
-                                    95,
-                                    118,
-                                    49
-                                ]
-                            },
-                            {
-                                "kind": "arg",
-                                "path": "order_id"
-                            },
-                            {
-                                "kind": "account",
-                                "path": "maker"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "system_program",
-                    "docs": [
-                        "System program"
-                    ],
-                    "address": "11111111111111111111111111111111"
-                },
-                {
-                    "name": "event_authority",
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    95,
-                                    95,
-                                    101,
-                                    118,
-                                    101,
-                                    110,
-                                    116,
-                                    95,
-                                    97,
-                                    117,
-                                    116,
-                                    104,
-                                    111,
-                                    114,
-                                    105,
-                                    116,
-                                    121
-                                ]
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "program"
-                }
-            ],
-            "args": [
-                {
-                    "name": "order_id",
-                    "type": "u64"
-                },
-                {
-                    "name": "expect_taking_amount",
-                    "type": "u64"
-                },
-                {
-                    "name": "min_return_amount",
-                    "type": "u64"
-                },
-                {
-                    "name": "deadline",
-                    "type": "u64"
-                },
-                {
-                    "name": "increase_fee",
-                    "type": "u64"
-                }
-            ]
-        },
-        {
-            "name": "wrap_unwrap_v3",
-            "discriminator": [
-                180,
-                178,
-                191,
-                54,
-                70,
-                8,
-                13,
-                224
-            ],
-            "accounts": [
-                {
-                    "name": "payer",
-                    "writable": true,
-                    "signer": true
-                },
-                {
-                    "name": "payer_wsol_account",
-                    "writable": true
-                },
-                {
-                    "name": "wsol_mint",
-                    "address": "So11111111111111111111111111111111111111112"
-                },
-                {
-                    "name": "temp_wsol_account",
-                    "writable": true,
-                    "optional": true,
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    116,
-                                    101,
-                                    109,
-                                    112,
-                                    95,
-                                    119,
-                                    115,
-                                    111,
-                                    108
-                                ]
-                            },
-                            {
-                                "kind": "account",
-                                "path": "payer"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "commission_account",
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "platform_fee_account",
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "authority_pda",
-                    "docs": [
-                        "Used for signing fee transfers from authority_pda (SOL) or wsol_sa (WSOL)"
-                    ],
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "wsol_sa",
-                    "docs": [
-                        "This is the authority_pda's associated token account for WSOL"
-                    ],
-                    "writable": true,
-                    "optional": true
-                },
-                {
-                    "name": "token_program"
-                },
-                {
-                    "name": "system_program",
-                    "address": "11111111111111111111111111111111"
-                }
-            ],
-            "args": [
-                {
-                    "name": "args",
-                    "type": {
-                        "defined": {
-                            "name": "PlatformFeeWrapUnwrapArgs"
-                        }
-                    }
-                }
-            ]
-        }
-    ],
-    "accounts": [
-        {
-            "name": "GlobalConfig",
-            "discriminator": [
-                149,
-                8,
-                156,
-                202,
-                160,
-                252,
-                176,
-                217
-            ]
-        },
-        {
-            "name": "OrderV1",
-            "discriminator": [
-                253,
-                98,
                 95,
-                208,
-                51,
-                199,
-                159,
-                88
-            ]
-        }
-    ],
-    "events": [
-        {
-            "name": "AddResolverEvent",
-            "discriminator": [
-                173,
-                137,
-                29,
-                251,
-                195,
-                58,
                 115,
-                71
-            ]
-        },
-        {
-            "name": "CancelOrderEvent",
-            "discriminator": [
-                174,
-                66,
-                141,
-                17,
-                4,
-                224,
-                162,
-                77
-            ]
-        },
-        {
-            "name": "FillOrderEvent",
-            "discriminator": [
-                37,
-                51,
-                197,
-                130,
-                53,
-                15,
-                99,
-                18
-            ]
-        },
-        {
-            "name": "InitGlobalConfigEvent",
-            "discriminator": [
-                195,
-                252,
-                133,
-                149,
-                47,
-                126,
-                107,
-                231
-            ]
-        },
-        {
-            "name": "PauseTradingEvent",
-            "discriminator": [
-                85,
-                23,
-                87,
-                137,
-                206,
-                65,
-                208,
-                58
-            ]
-        },
-        {
-            "name": "PlaceOrderEvent",
-            "discriminator": [
-                65,
-                191,
-                25,
-                91,
-                27,
-                252,
-                192,
-                40
-            ]
-        },
-        {
-            "name": "RefundEvent",
-            "discriminator": [
-                176,
-                159,
-                218,
-                59,
-                94,
-                213,
-                129,
-                218
-            ]
-        },
-        {
-            "name": "RemoveResolverEvent",
-            "discriminator": [
-                57,
-                138,
-                125,
-                122,
-                100,
-                83,
-                156,
-                37
-            ]
-        },
-        {
-            "name": "SetAdminEvent",
-            "discriminator": [
-                240,
-                117,
-                204,
-                254,
-                89,
-                150,
-                132,
-                94
-            ]
-        },
-        {
-            "name": "SetFeeMultiplierEvent",
-            "discriminator": [
-                197,
-                91,
-                90,
-                165,
-                244,
-                201,
-                13,
-                154
-            ]
-        },
-        {
-            "name": "SetTradeFeeEvent",
-            "discriminator": [
-                8,
-                97,
-                163,
-                68,
-                79,
-                99,
-                134,
-                229
-            ]
-        },
-        {
-            "name": "SwapEvent",
-            "discriminator": [
-                64,
-                198,
-                205,
-                232,
-                38,
-                8,
-                113,
-                226
-            ]
-        },
-        {
-            "name": "UpdateOrderEvent",
-            "discriminator": [
-                55,
-                24,
-                47,
-                240,
-                105,
-                245,
-                30,
-                135
+                97
             ]
         }
     ],
     "errors": [
         {
-            "code": 6000,
-            "name": "TooManyHops",
-            "msg": "Too many hops"
+            "code": "6000",
+            "message": "Too many hops",
+            "name": "TooManyHops"
         },
         {
-            "code": 6001,
-            "name": "MinReturnNotReached",
-            "msg": "Min return not reached"
+            "code": "6001",
+            "message": "Min return not reached",
+            "name": "MinReturnNotReached"
         },
         {
-            "code": 6002,
-            "name": "AmountInMustBeGreaterThanZero",
-            "msg": "amount_in must be greater than 0"
+            "code": "6002",
+            "message": "amount_in must be greater than 0",
+            "name": "AmountInMustBeGreaterThanZero"
         },
         {
-            "code": 6003,
-            "name": "MinReturnMustBeGreaterThanZero",
-            "msg": "min_return must be greater than 0"
+            "code": "6003",
+            "message": "invalid expect amount out",
+            "name": "InvalidExpectAmountOut"
         },
         {
-            "code": 6004,
-            "name": "InvalidExpectAmountOut",
-            "msg": "invalid expect amount out"
+            "code": "6004",
+            "message": "amounts and routes must have the same length",
+            "name": "AmountsAndRoutesMustHaveTheSameLength"
         },
         {
-            "code": 6005,
-            "name": "AmountsAndRoutesMustHaveTheSameLength",
-            "msg": "amounts and routes must have the same length"
+            "code": "6005",
+            "message": "total_amounts must be equal to amount_in",
+            "name": "TotalAmountsMustBeEqualToAmountIn"
         },
         {
-            "code": 6006,
-            "name": "TotalAmountsMustBeEqualToAmountIn",
-            "msg": "total_amounts must be equal to amount_in"
+            "code": "6006",
+            "message": "dexes and weights must have the same length",
+            "name": "DexesAndWeightsMustHaveTheSameLength"
         },
         {
-            "code": 6007,
-            "name": "DexesAndWeightsMustHaveTheSameLength",
-            "msg": "dexes and weights must have the same length"
+            "code": "6007",
+            "message": "weights must sum to 100",
+            "name": "WeightsMustSumTo100"
         },
         {
-            "code": 6008,
-            "name": "WeightsMustSumTo100",
-            "msg": "weights must sum to 100"
+            "code": "6008",
+            "message": "Invalid source token account",
+            "name": "InvalidSourceTokenAccount"
         },
         {
-            "code": 6009,
-            "name": "InvalidSourceTokenAccount",
-            "msg": "Invalid source token account"
+            "code": "6009",
+            "message": "Invalid destination token account",
+            "name": "InvalidDestinationTokenAccount"
         },
         {
-            "code": 6010,
-            "name": "InvalidDestinationTokenAccount",
-            "msg": "Invalid destination token account"
+            "code": "6010",
+            "message": "Invalid token account",
+            "name": "InvalidTokenAccount"
         },
         {
-            "code": 6011,
-            "name": "InvalidTokenAccount",
-            "msg": "Invalid token account"
+            "code": "6011",
+            "message": "Invalid commission rate",
+            "name": "InvalidCommissionRate"
         },
         {
-            "code": 6012,
-            "name": "InvalidCommissionRate",
-            "msg": "Invalid commission rate"
+            "code": "6012",
+            "message": "Invalid trim rate",
+            "name": "InvalidTrimRate"
         },
         {
-            "code": 6013,
-            "name": "InvalidTrimRate",
-            "msg": "Invalid trim rate"
+            "code": "6013",
+            "message": "Invalid charge rate",
+            "name": "InvalidChargeRate"
         },
         {
-            "code": 6014,
-            "name": "InvalidCommissionTokenAccount",
-            "msg": "Invalid commission token account"
+            "code": "6014",
+            "message": "Invalid commission token account",
+            "name": "InvalidCommissionTokenAccount"
         },
         {
-            "code": 6015,
-            "name": "InvalidCommissionTemporaryTokenAccount",
-            "msg": "Invalid commission temporary token account"
+            "code": "6015",
+            "message": "Invalid commission temporary token account",
+            "name": "InvalidCommissionTemporaryTokenAccount"
         },
         {
-            "code": 6016,
-            "name": "InvalidAccountsLength",
-            "msg": "Invalid accounts length"
+            "code": "6016",
+            "message": "Invalid accounts length",
+            "name": "InvalidAccountsLength"
         },
         {
-            "code": 6017,
-            "name": "InvalidHopAccounts",
-            "msg": "Invalid hop accounts"
+            "code": "6017",
+            "message": "Invalid hop accounts",
+            "name": "InvalidHopAccounts"
         },
         {
-            "code": 6018,
-            "name": "InvalidHopFromAccount",
-            "msg": "Invalid hop from account"
+            "code": "6018",
+            "message": "Invalid hop from account",
+            "name": "InvalidHopFromAccount"
         },
         {
-            "code": 6019,
-            "name": "SwapAuthorityIsNotSigner",
-            "msg": "Swap authority is not signer"
+            "code": "6019",
+            "message": "Swap authority is not signer",
+            "name": "SwapAuthorityIsNotSigner"
         },
         {
-            "code": 6020,
-            "name": "InvalidAuthorityPda",
-            "msg": "Invalid authority pda"
+            "code": "6020",
+            "message": "Invalid authority pda",
+            "name": "InvalidAuthorityPda"
         },
         {
-            "code": 6021,
-            "name": "InvalidSwapAuthority",
-            "msg": "Invalid swap authority"
+            "code": "6021",
+            "message": "Invalid swap authority",
+            "name": "InvalidSwapAuthority"
         },
         {
-            "code": 6022,
-            "name": "InvalidProgramId",
-            "msg": "Invalid program id"
+            "code": "6022",
+            "message": "Invalid program id",
+            "name": "InvalidProgramId"
         },
         {
-            "code": 6023,
-            "name": "InvalidPool",
-            "msg": "Invalid pool"
+            "code": "6023",
+            "message": "Invalid pool",
+            "name": "InvalidPool"
         },
         {
-            "code": 6024,
-            "name": "InvalidTokenMint",
-            "msg": "Invalid token mint"
+            "code": "6024",
+            "message": "Invalid token mint",
+            "name": "InvalidTokenMint"
         },
         {
-            "code": 6025,
-            "name": "CalculationError",
-            "msg": "Calculation error"
+            "code": "6025",
+            "message": "Calculation error",
+            "name": "CalculationError"
         },
         {
-            "code": 6026,
-            "name": "InvalidSanctumLstStateListData",
-            "msg": "Invalid sanctum lst state list data"
+            "code": "6026",
+            "message": "Invalid sanctum lst state list data",
+            "name": "InvalidSanctumLstStateListData"
         },
         {
-            "code": 6027,
-            "name": "InvalidSanctumLstStateListIndex",
-            "msg": "Invalid sanctum lst state list index"
+            "code": "6027",
+            "message": "Invalid sanctum lst state list index",
+            "name": "InvalidSanctumLstStateListIndex"
         },
         {
-            "code": 6028,
-            "name": "InvalidSanctumSwapAccounts",
-            "msg": "Invalid sanctum swap accounts"
+            "code": "6028",
+            "message": "Invalid sanctum swap accounts",
+            "name": "InvalidSanctumSwapAccounts"
         },
         {
-            "code": 6029,
-            "name": "InvalidSwapAuthorityAccounts",
-            "msg": "Invalid swap authority account"
+            "code": "6029",
+            "message": "Invalid swap authority account",
+            "name": "InvalidSwapAuthorityAccounts"
         },
         {
-            "code": 6030,
-            "name": "InvalidBridgeSeed",
-            "msg": "Bridge Seed Error"
+            "code": "6030",
+            "message": "Bridge Seed Error",
+            "name": "InvalidBridgeSeed"
         },
         {
-            "code": 6031,
-            "name": "InvalidBundleInput",
-            "msg": "Invalid accounts and instruction length"
+            "code": "6031",
+            "message": "Invalid accounts and instruction length",
+            "name": "InvalidBundleInput"
         },
         {
-            "code": 6032,
-            "name": "MissingSaAccount",
-            "msg": "SA is required"
+            "code": "6032",
+            "message": "SA is required",
+            "name": "MissingSaAccount"
         },
         {
-            "code": 6033,
-            "name": "InvalidPlatformFeeRate",
-            "msg": "Invalid platform fee rate"
+            "code": "6033",
+            "message": "Invalid platform fee rate",
+            "name": "InvalidPlatformFeeRate"
         },
         {
-            "code": 6034,
-            "name": "AmountOutMustBeGreaterThanZero",
-            "msg": "Amount out must be greater than 0"
+            "code": "6034",
+            "message": "Amount out must be greater than 0",
+            "name": "AmountOutMustBeGreaterThanZero"
         },
         {
-            "code": 6035,
-            "name": "InvalidDampingTerm",
-            "msg": "Invalid DampingTerm"
+            "code": "6035",
+            "message": "Invalid DampingTerm",
+            "name": "InvalidDampingTerm"
         },
         {
-            "code": 6036,
-            "name": "InvalidMint",
-            "msg": "Invalid mint"
+            "code": "6036",
+            "message": "Invalid mint",
+            "name": "InvalidMint"
         },
         {
-            "code": 6037,
-            "name": "InvalidPlatformFeeAmount",
-            "msg": "Invalid platform fee amount"
+            "code": "6037",
+            "message": "Invalid platform fee amount",
+            "name": "InvalidPlatformFeeAmount"
         },
         {
-            "code": 6038,
-            "name": "InvalidFeeTokenAccount",
-            "msg": "Invalid fee token account"
+            "code": "6038",
+            "message": "Invalid fee token account",
+            "name": "InvalidFeeTokenAccount"
         },
         {
-            "code": 6039,
-            "name": "InvalidSaAuthority",
-            "msg": "Invalid sa authority"
+            "code": "6039",
+            "message": "Invalid sa authority",
+            "name": "InvalidSaAuthority"
         },
         {
-            "code": 6040,
-            "name": "CommissionAccountIsNone",
-            "msg": "Commission account is none"
+            "code": "6040",
+            "message": "Commission account is none",
+            "name": "CommissionAccountIsNone"
         },
         {
-            "code": 6041,
-            "name": "PlatformFeeAccountIsNone",
-            "msg": "Platform fee account is none"
+            "code": "6041",
+            "message": "Platform fee account is none",
+            "name": "PlatformFeeAccountIsNone"
         },
         {
-            "code": 6042,
-            "name": "TrimAccountIsNone",
-            "msg": "Trim account is none"
+            "code": "6042",
+            "message": "Trim account is none",
+            "name": "TrimAccountIsNone"
         },
         {
-            "code": 6043,
-            "name": "InvalidFeeAccount",
-            "msg": "Invalid fee account"
+            "code": "6043",
+            "message": "Charge account is none",
+            "name": "ChargeAccountIsNone"
         },
         {
-            "code": 6044,
-            "name": "InvalidSourceTokenSa",
-            "msg": "Invalid source token sa"
+            "code": "6044",
+            "message": "Invalid fee account",
+            "name": "InvalidFeeAccount"
         },
         {
-            "code": 6045,
-            "name": "SaAuthorityIsNone",
-            "msg": "Sa authority is none"
+            "code": "6045",
+            "message": "Invalid source token sa",
+            "name": "InvalidSourceTokenSa"
         },
         {
-            "code": 6046,
-            "name": "SourceTokenSaIsNone",
-            "msg": "Source token sa is none"
+            "code": "6046",
+            "message": "Sa authority is none",
+            "name": "SaAuthorityIsNone"
         },
         {
-            "code": 6047,
-            "name": "SourceTokenProgramIsNone",
-            "msg": "Source token program is none"
+            "code": "6047",
+            "message": "Source token sa is none",
+            "name": "SourceTokenSaIsNone"
         },
         {
-            "code": 6048,
-            "name": "DestinationTokenSaIsNone",
-            "msg": "Destination token sa is none"
+            "code": "6048",
+            "message": "Source token program is none",
+            "name": "SourceTokenProgramIsNone"
         },
         {
-            "code": 6049,
-            "name": "DestinationTokenProgramIsNone",
-            "msg": "Destination token program is none"
+            "code": "6049",
+            "message": "Destination token sa is none",
+            "name": "DestinationTokenSaIsNone"
         },
         {
-            "code": 6050,
-            "name": "ResultMustBeGreaterThanZero",
-            "msg": "Calculation result must be greater than zero"
+            "code": "6050",
+            "message": "Destination token program is none",
+            "name": "DestinationTokenProgramIsNone"
         },
         {
-            "code": 6051,
-            "name": "InvalidAccountData",
-            "msg": "Invalid account data"
+            "code": "6051",
+            "message": "Calculation result must be greater than zero",
+            "name": "ResultMustBeGreaterThanZero"
         },
         {
-            "code": 6052,
-            "name": "InvalidRfqParameters",
-            "msg": "Invalid RFQ parameters"
+            "code": "6052",
+            "message": "Invalid account data",
+            "name": "InvalidAccountData"
         },
         {
-            "code": 6053,
-            "name": "TobAuthorityPdaRequired",
-            "msg": "TOB mode requires authority PDA"
+            "code": "6053",
+            "message": "Invalid RFQ parameters",
+            "name": "InvalidRfqParameters"
         },
         {
-            "code": 6054,
-            "name": "TobWsolSaRequired",
-            "msg": "TOB mode with WSOL fees requires wsol_sa account"
+            "code": "6054",
+            "message": "TOB mode requires authority PDA",
+            "name": "TobAuthorityPdaRequired"
         },
         {
-            "code": 6055,
-            "name": "InvalidWsolSa",
-            "msg": "Invalid WSOL SA account"
+            "code": "6055",
+            "message": "TOB mode with WSOL fees requires wsol_sa account",
+            "name": "TobWsolSaRequired"
         },
         {
-            "code": 6056,
-            "name": "InvalidTrimAccount",
-            "msg": "Invalid trim account"
+            "code": "6056",
+            "message": "Invalid WSOL SA account",
+            "name": "InvalidWsolSa"
         },
         {
-            "code": 6057,
-            "name": "InvalidCommissionAccount",
-            "msg": "Invalid commission account"
+            "code": "6057",
+            "message": "Invalid trim account",
+            "name": "InvalidTrimAccount"
         },
         {
-            "code": 6058,
-            "name": "InvalidPlatformFeeAccount",
-            "msg": "Invalid platform fee account"
+            "code": "6058",
+            "message": "Invalid charge account",
+            "name": "InvalidChargeAccount"
         },
         {
-            "code": 6059,
-            "name": "InvalidActualAmountIn",
-            "msg": "Invalid actual amount in"
+            "code": "6059",
+            "message": "Invalid commission account",
+            "name": "InvalidCommissionAccount"
         },
         {
-            "code": 6060,
-            "name": "UnexpectedSaTokenAccount",
-            "msg": "Unexpected SA token account in CPI"
+            "code": "6060",
+            "message": "Invalid platform fee account",
+            "name": "InvalidPlatformFeeAccount"
         },
         {
-            "code": 6061,
-            "name": "InvalidSourceTokenSaMint",
-            "msg": "Invalid source token sa mint"
+            "code": "6061",
+            "message": "Invalid actual amount in",
+            "name": "InvalidActualAmountIn"
         },
         {
-            "code": 6062,
-            "name": "InvalidDestinationTokenSaMint",
-            "msg": "Invalid destination token sa mint"
+            "code": "6062",
+            "message": "Unexpected SA token account in CPI",
+            "name": "UnexpectedSaTokenAccount"
         },
         {
-            "code": 6063,
-            "name": "AdapterAbort",
-            "msg": "Adapter abort"
+            "code": "6063",
+            "message": "Invalid source token sa mint",
+            "name": "InvalidSourceTokenSaMint"
         },
         {
-            "code": 6064,
-            "name": "InsufficientFunds",
-            "msg": "Insufficient funds"
+            "code": "6064",
+            "message": "Invalid destination token sa mint",
+            "name": "InvalidDestinationTokenSaMint"
         },
         {
-            "code": 6065,
-            "name": "InvalidDiffLamports",
-            "msg": "Invalid diff lamports"
+            "code": "6065",
+            "message": "Adapter abort",
+            "name": "AdapterAbort"
         },
         {
-            "code": 6066,
-            "name": "InvalidTokenProgram",
-            "msg": "Invalid token program"
+            "code": "6066",
+            "message": "Insufficient funds",
+            "name": "InsufficientFunds"
         },
         {
-            "code": 6067,
-            "name": "InvalidSigner",
-            "msg": "Invalid signer"
+            "code": "6067",
+            "message": "Invalid diff lamports",
+            "name": "InvalidDiffLamports"
         },
         {
-            "code": 6068,
-            "name": "InvalidAssociatedTokenProgram",
-            "msg": "Invalid associated token program"
+            "code": "6068",
+            "message": "Invalid token program",
+            "name": "InvalidTokenProgram"
         },
         {
-            "code": 6069,
-            "name": "SolReceiverMustBeSystemAccount",
-            "msg": "SOL receiver must be a system account"
+            "code": "6069",
+            "message": "Invalid signer",
+            "name": "InvalidSigner"
         },
         {
-            "code": 6070,
-            "name": "InsufficientBalance",
-            "msg": "Insufficient balance for transfer"
+            "code": "6070",
+            "message": "Invalid associated token program",
+            "name": "InvalidAssociatedTokenProgram"
         },
         {
-            "code": 6071,
-            "name": "SolReceiverRequiresAccCloseFlag",
-            "msg": "SOL receiver requires acc_close_flag to be true"
+            "code": "6071",
+            "message": "SOL receiver must be a system account",
+            "name": "SolReceiverMustBeSystemAccount"
         },
         {
-            "code": 6072,
-            "name": "DestinationMustBeWsolForSolReceiver",
-            "msg": "Destination must be wSOL when sol_receiver is specified"
+            "code": "6072",
+            "message": "Insufficient balance for transfer",
+            "name": "InsufficientBalance"
+        },
+        {
+            "code": "6073",
+            "message": "SOL receiver requires acc_close_flag to be true",
+            "name": "SolReceiverRequiresAccCloseFlag"
+        },
+        {
+            "code": "6074",
+            "message": "Destination must be wSOL when sol_receiver is specified",
+            "name": "DestinationMustBeWsolForSolReceiver"
+        },
+        {
+            "code": "6075",
+            "message": "Invalid Goonfi parameters",
+            "name": "InvalidGoonfiParameters"
+        },
+        {
+            "code": "6076",
+            "message": "Invalid trim amount",
+            "name": "InvalidTrimAmount"
+        },
+        {
+            "code": "6077",
+            "message": "Receiver must be a token account for wrap operation",
+            "name": "ReceiverMustBeTokenAccount"
+        },
+        {
+            "code": "6078",
+            "message": "Receiver must be a WSOL token account for wrap operation",
+            "name": "ReceiverMustBeWsolAccount"
+        },
+        {
+            "code": "6079",
+            "message": "Token program is none",
+            "name": "TokenProgramIsNone"
+        },
+        {
+            "code": "6080",
+            "message": "Associated token program is none",
+            "name": "AssociatedTokenProgramIsNone"
+        },
+        {
+            "code": "6081",
+            "message": "System program is none",
+            "name": "SystemProgramIsNone"
+        }
+    ],
+    "events": [
+        {
+            "docs": [],
+            "fieldType": {
+                "fields": [
+                    {
+                        "docs": [],
+                        "name": "dex",
+                        "type": "Dex"
+                    },
+                    {
+                        "docs": [],
+                        "name": "amountIn",
+                        "type": "u64"
+                    },
+                    {
+                        "docs": [],
+                        "name": "amountOut",
+                        "type": "u64"
+                    }
+                ],
+                "kind": "struct"
+            },
+            "name": "SwapEvent"
+        },
+        {
+            "docs": [],
+            "fieldType": {
+                "fields": [
+                    {
+                        "docs": [],
+                        "name": "orderId",
+                        "type": "u64"
+                    },
+                    {
+                        "docs": [],
+                        "name": "sourceMint",
+                        "type": "pubkey"
+                    },
+                    {
+                        "docs": [],
+                        "name": "destinationMint",
+                        "type": "pubkey"
+                    },
+                    {
+                        "docs": [],
+                        "name": "sourceTokenAccountOwner",
+                        "type": "pubkey"
+                    },
+                    {
+                        "docs": [],
+                        "name": "destinationTokenAccountOwner",
+                        "type": "pubkey"
+                    },
+                    {
+                        "docs": [],
+                        "name": "amountIn",
+                        "type": "u64"
+                    },
+                    {
+                        "docs": [],
+                        "name": "sourceTokenChange",
+                        "type": "u64"
+                    },
+                    {
+                        "docs": [],
+                        "name": "destinationTokenChange",
+                        "type": "u64"
+                    },
+                    {
+                        "docs": [],
+                        "name": "commissionDirection",
+                        "type": "bool"
+                    },
+                    {
+                        "docs": [],
+                        "name": "commissionRate",
+                        "type": "u32"
+                    },
+                    {
+                        "docs": [],
+                        "name": "commissionAmount",
+                        "type": "u64"
+                    },
+                    {
+                        "docs": [],
+                        "name": "commissionAccount",
+                        "type": "pubkey"
+                    },
+                    {
+                        "docs": [],
+                        "name": "platformFeeRate",
+                        "type": "u16"
+                    },
+                    {
+                        "docs": [],
+                        "name": "platformFeeAmount",
+                        "type": "u64"
+                    },
+                    {
+                        "docs": [],
+                        "name": "platformFeeAccount",
+                        "type": "pubkey"
+                    },
+                    {
+                        "docs": [],
+                        "name": "trimRate",
+                        "type": "u8"
+                    },
+                    {
+                        "docs": [],
+                        "name": "trimAmount",
+                        "type": "u64"
+                    },
+                    {
+                        "docs": [],
+                        "name": "trimAccount",
+                        "type": "pubkey"
+                    }
+                ],
+                "kind": "struct"
+            },
+            "name": "SwapWithFeesCpiEvent"
+        }
+    ],
+    "instructions": [
+        {
+            "accounts": [
+                {
+                    "docs": [],
+                    "name": "signer",
+                    "optional": false,
+                    "pda": false,
+                    "signer": true,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "receiver",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "sourceTokenAccount",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "destinationTokenAccount",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "saAuthority",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "tokenMint",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "tokenProgram",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "systemProgram",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "associatedTokenProgram",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                }
+            ],
+            "args": [],
+            "docs": [],
+            "name": "claim"
+        },
+        {
+            "accounts": [
+                {
+                    "docs": [],
+                    "name": "signer",
+                    "optional": false,
+                    "pda": false,
+                    "signer": true,
+                    "writable": false
+                },
+                {
+                    "docs": [
+                        "PumpFun transfers claimed SOL directly to this account (account[0] in the CPI)."
+                    ],
+                    "name": "saAuthority",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [
+                        "Holds native SOL accumulated as cashback; emptied by PumpFun during claim."
+                    ],
+                    "name": "userVolumeAccumulator",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [
+                        "after PumpFun deposits it there."
+                    ],
+                    "name": "receiver",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "eventAuthority",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "systemProgram",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "pumpfunProgram",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                }
+            ],
+            "args": [],
+            "docs": [],
+            "name": "claimCashbackPumpfun"
+        },
+        {
+            "accounts": [
+                {
+                    "docs": [],
+                    "name": "signer",
+                    "optional": false,
+                    "pda": false,
+                    "signer": true,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "saAuthority",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "userVolumeAccumulator",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "wsolMint",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "splTokenProgram",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "uvaWsolAta",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [
+                        "PumpSwap requires account[5] to be a token account owned by authority_pda",
+                        "(same owner as user_volume_accumulator). WSOL is deposited here by PumpSwap,",
+                        "then forwarded to receiver_wsol_ata via a second SPL transfer."
+                    ],
+                    "name": "saWsolAta",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "receiverWsolAta",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "systemProgram",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "eventAuthority",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "pumpswapProgram",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                }
+            ],
+            "args": [],
+            "docs": [],
+            "name": "claimCashbackPumpswap"
+        },
+        {
+            "accounts": [
+                {
+                    "docs": [],
+                    "name": "payer",
+                    "optional": false,
+                    "pda": false,
+                    "signer": true,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "owner",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "tokenAccount",
+                    "optional": false,
+                    "pda": true,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "tokenMint",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "tokenProgram",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "systemProgram",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                }
+            ],
+            "args": [
+                {
+                    "docs": [],
+                    "name": "bump",
+                    "rawType": "u8",
+                    "type": "u8"
+                }
+            ],
+            "docs": [],
+            "name": "createTokenAccount"
+        },
+        {
+            "accounts": [
+                {
+                    "docs": [],
+                    "name": "payer",
+                    "optional": false,
+                    "pda": false,
+                    "signer": true,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "owner",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "tokenAccount",
+                    "optional": false,
+                    "pda": true,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "tokenMint",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "tokenProgram",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "systemProgram",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                }
+            ],
+            "args": [
+                {
+                    "docs": [],
+                    "name": "bump",
+                    "rawType": "u8",
+                    "type": "u8"
+                },
+                {
+                    "docs": [],
+                    "name": "seed",
+                    "rawType": "u32",
+                    "type": "u32"
+                }
+            ],
+            "docs": [],
+            "name": "createTokenAccountWithSeed"
+        },
+        {
+            "accounts": [
+                {
+                    "docs": [],
+                    "name": "payer",
+                    "optional": false,
+                    "pda": false,
+                    "signer": true,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "sourceTokenAccount",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "destinationTokenAccount",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "sourceMint",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "destinationMint",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "saAuthority",
+                    "optional": true,
+                    "pda": true,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "sourceTokenSa",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "destinationTokenSa",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "sourceTokenProgram",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "destinationTokenProgram",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "associatedTokenProgram",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "systemProgram",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                }
+            ],
+            "args": [
+                {
+                    "docs": [],
+                    "name": "data",
+                    "rawType": {
+                        "defined": {
+                            "name": "SwapArgs"
+                        }
+                    },
+                    "type": "SwapArgs"
+                },
+                {
+                    "docs": [],
+                    "name": "orderId",
+                    "rawType": "u64",
+                    "type": "u64"
+                }
+            ],
+            "docs": [],
+            "name": "proxySwap"
+        },
+        {
+            "accounts": [
+                {
+                    "docs": [],
+                    "name": "payer",
+                    "optional": false,
+                    "pda": false,
+                    "signer": true,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "sourceTokenAccount",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "destinationTokenAccount",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "sourceMint",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "destinationMint",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                }
+            ],
+            "args": [
+                {
+                    "docs": [],
+                    "name": "data",
+                    "rawType": {
+                        "defined": {
+                            "name": "SwapArgs"
+                        }
+                    },
+                    "type": "SwapArgs"
+                },
+                {
+                    "docs": [],
+                    "name": "orderId",
+                    "rawType": "u64",
+                    "type": "u64"
+                }
+            ],
+            "docs": [],
+            "name": "swap"
+        },
+        {
+            "accounts": [
+                {
+                    "docs": [],
+                    "name": "payer",
+                    "optional": false,
+                    "pda": false,
+                    "signer": true,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "sourceTokenAccount",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "destinationTokenAccount",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "sourceMint",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "destinationMint",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "commissionAccount",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "platformFeeAccount",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "saAuthority",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "sourceTokenSa",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "destinationTokenSa",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "sourceTokenProgram",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "destinationTokenProgram",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "associatedTokenProgram",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "systemProgram",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                }
+            ],
+            "args": [
+                {
+                    "docs": [],
+                    "name": "args",
+                    "rawType": {
+                        "defined": {
+                            "name": "SwapArgs"
+                        }
+                    },
+                    "type": "SwapArgs"
+                },
+                {
+                    "docs": [],
+                    "name": "commissionInfo",
+                    "rawType": "u32",
+                    "type": "u32"
+                },
+                {
+                    "docs": [],
+                    "name": "trimRate",
+                    "rawType": "u8",
+                    "type": "u8"
+                },
+                {
+                    "docs": [],
+                    "name": "platformFeeRate",
+                    "rawType": "u16",
+                    "type": "u16"
+                },
+                {
+                    "docs": [],
+                    "name": "orderId",
+                    "rawType": "u64",
+                    "type": "u64"
+                }
+            ],
+            "docs": [],
+            "name": "swapTobV3"
+        },
+        {
+            "accounts": [
+                {
+                    "docs": [],
+                    "name": "payer",
+                    "optional": false,
+                    "pda": false,
+                    "signer": true,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "sourceTokenAccount",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "destinationTokenAccount",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "sourceMint",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "destinationMint",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "commissionAccount",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "platformFeeAccount",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "saAuthority",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "sourceTokenSa",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "destinationTokenSa",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "sourceTokenProgram",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "destinationTokenProgram",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "associatedTokenProgram",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "systemProgram",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                }
+            ],
+            "args": [
+                {
+                    "docs": [],
+                    "name": "args",
+                    "rawType": {
+                        "defined": {
+                            "name": "SwapArgs"
+                        }
+                    },
+                    "type": "SwapArgs"
+                },
+                {
+                    "docs": [],
+                    "name": "commissionInfo",
+                    "rawType": "u32",
+                    "type": "u32"
+                },
+                {
+                    "docs": [],
+                    "name": "trimRate",
+                    "rawType": "u8",
+                    "type": "u8"
+                },
+                {
+                    "docs": [],
+                    "name": "chargeRate",
+                    "rawType": "u16",
+                    "type": "u16"
+                },
+                {
+                    "docs": [],
+                    "name": "platformFeeRate",
+                    "rawType": "u16",
+                    "type": "u16"
+                },
+                {
+                    "docs": [],
+                    "name": "orderId",
+                    "rawType": "u64",
+                    "type": "u64"
+                }
+            ],
+            "docs": [],
+            "name": "swapTobV3Enhanced"
+        },
+        {
+            "accounts": [
+                {
+                    "docs": [],
+                    "name": "payer",
+                    "optional": false,
+                    "pda": false,
+                    "signer": true,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "sourceTokenAccount",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "destinationTokenAccount",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "sourceMint",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "destinationMint",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "commissionAccount",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "platformFeeAccount",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "saAuthority",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "sourceTokenSa",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "destinationTokenSa",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "sourceTokenProgram",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "destinationTokenProgram",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "associatedTokenProgram",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "systemProgram",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [
+                        "Optional SOL receiver account",
+                        "- None: normal swap or SOL stays with payer",
+                        "- Some: SOL receiver when converting wSOL -> SOL"
+                    ],
+                    "name": "solReceiver",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "docs": [],
+                    "name": "args",
+                    "rawType": {
+                        "defined": {
+                            "name": "SwapArgs"
+                        }
+                    },
+                    "type": "SwapArgs"
+                },
+                {
+                    "docs": [],
+                    "name": "commissionInfo",
+                    "rawType": "u32",
+                    "type": "u32"
+                },
+                {
+                    "docs": [],
+                    "name": "trimRate",
+                    "rawType": "u8",
+                    "type": "u8"
+                },
+                {
+                    "docs": [],
+                    "name": "platformFeeRate",
+                    "rawType": "u16",
+                    "type": "u16"
+                },
+                {
+                    "docs": [],
+                    "name": "orderId",
+                    "rawType": "u64",
+                    "type": "u64"
+                }
+            ],
+            "docs": [
+                "Swap ToB with optional specified receiver",
+                "- For normal token swaps: sol_receiver should be None",
+                "- For swap to SOL with custom receiver: sol_receiver should be Some and acc_close_flag must be true"
+            ],
+            "name": "swapTobV3WithReceiver"
+        },
+        {
+            "accounts": [
+                {
+                    "docs": [],
+                    "name": "payer",
+                    "optional": false,
+                    "pda": false,
+                    "signer": true,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "sourceTokenAccount",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "destinationTokenAccount",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "sourceMint",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "destinationMint",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "commissionAccount",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "platformFeeAccount",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "saAuthority",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "sourceTokenSa",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "destinationTokenSa",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "sourceTokenProgram",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "destinationTokenProgram",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "associatedTokenProgram",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "systemProgram",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                }
+            ],
+            "args": [
+                {
+                    "docs": [],
+                    "name": "args",
+                    "rawType": {
+                        "defined": {
+                            "name": "SwapArgs"
+                        }
+                    },
+                    "type": "SwapArgs"
+                },
+                {
+                    "docs": [],
+                    "name": "commissionInfo",
+                    "rawType": "u32",
+                    "type": "u32"
+                },
+                {
+                    "docs": [],
+                    "name": "platformFeeRate",
+                    "rawType": "u16",
+                    "type": "u16"
+                },
+                {
+                    "docs": [],
+                    "name": "orderId",
+                    "rawType": "u64",
+                    "type": "u64"
+                }
+            ],
+            "docs": [],
+            "name": "swapV3"
+        },
+        {
+            "accounts": [
+                {
+                    "docs": [],
+                    "name": "payer",
+                    "optional": false,
+                    "pda": false,
+                    "signer": true,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "sourceTokenAccount",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "destinationTokenAccount",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "sourceMint",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "destinationMint",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "commissionAccount",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "platformFeeAccount",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "saAuthority",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "sourceTokenSa",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "destinationTokenSa",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "sourceTokenProgram",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "destinationTokenProgram",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "associatedTokenProgram",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "systemProgram",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "eventAuthority",
+                    "optional": false,
+                    "pda": true,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "program",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                }
+            ],
+            "args": [
+                {
+                    "docs": [],
+                    "name": "args",
+                    "rawType": {
+                        "defined": {
+                            "name": "SwapArgs"
+                        }
+                    },
+                    "type": "SwapArgs"
+                },
+                {
+                    "docs": [],
+                    "name": "commissionInfo",
+                    "rawType": "u32",
+                    "type": "u32"
+                },
+                {
+                    "docs": [],
+                    "name": "platformFeeRate",
+                    "rawType": "u16",
+                    "type": "u16"
+                },
+                {
+                    "docs": [],
+                    "name": "orderId",
+                    "rawType": "u64",
+                    "type": "u64"
+                }
+            ],
+            "docs": [],
+            "name": "swapV3WithCpiEvent"
+        },
+        {
+            "accounts": [
+                {
+                    "docs": [],
+                    "name": "payer",
+                    "optional": false,
+                    "pda": false,
+                    "signer": true,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "payerWsolAccount",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "wsolMint",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "tempWsolAccount",
+                    "optional": true,
+                    "pda": true,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "commissionAccount",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "platformFeeAccount",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [
+                        "Used for signing fee transfers from authority_pda (SOL) or wsol_sa (WSOL)"
+                    ],
+                    "name": "authorityPda",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [
+                        "This is the authority_pda's associated token account for WSOL"
+                    ],
+                    "name": "wsolSa",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "tokenProgram",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "systemProgram",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                }
+            ],
+            "args": [
+                {
+                    "docs": [],
+                    "name": "args",
+                    "rawType": {
+                        "defined": {
+                            "name": "PlatformFeeWrapUnwrapArgs"
+                        }
+                    },
+                    "type": "PlatformFeeWrapUnwrapArgs"
+                }
+            ],
+            "docs": [],
+            "name": "wrapUnwrapV3"
+        },
+        {
+            "accounts": [
+                {
+                    "docs": [],
+                    "name": "payer",
+                    "optional": false,
+                    "pda": false,
+                    "signer": true,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "payerWsolAccount",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "wsolMint",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "tempWsolAccount",
+                    "optional": true,
+                    "pda": true,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "commissionAccount",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "platformFeeAccount",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [
+                        "Used for signing fee transfers from authority_pda (SOL) or wsol_sa (WSOL)"
+                    ],
+                    "name": "authorityPda",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [
+                        "This is the authority_pda's associated token account for WSOL"
+                    ],
+                    "name": "wsolSa",
+                    "optional": true,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                },
+                {
+                    "docs": [],
+                    "name": "tokenProgram",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [],
+                    "name": "systemProgram",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": false
+                },
+                {
+                    "docs": [
+                        "- Wrap: WSOL token account (ATA) to receive WSOL",
+                        "- Unwrap: System account (EOA) to receive SOL"
+                    ],
+                    "name": "receiver",
+                    "optional": false,
+                    "pda": false,
+                    "signer": false,
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "docs": [],
+                    "name": "args",
+                    "rawType": {
+                        "defined": {
+                            "name": "PlatformFeeWrapUnwrapArgs"
+                        }
+                    },
+                    "type": "PlatformFeeWrapUnwrapArgs"
+                }
+            ],
+            "docs": [
+                "Wrap/Unwrap with optional specified receiver",
+                "- Wrap (SOL -> WSOL): receiver is WSOL token account (ATA)",
+                "- Unwrap (WSOL -> SOL): receiver is system account (EOA)",
+                "Transfer amount:",
+                "- From fee: amount_in",
+                "- To fee: amount_in - fees"
+            ],
+            "name": "wrapUnwrapV3WithReceiver"
+        }
+    ],
+    "pdas": [
+        {
+            "docs": [],
+            "name": "tokenAccount",
+            "seeds": [
+                {
+                    "kind": "type",
+                    "name": "token_mint",
+                    "type": "pubkey"
+                },
+                {
+                    "kind": "type",
+                    "name": "owner",
+                    "type": "pubkey"
+                },
+                {
+                    "kind": "type",
+                    "name": "seed",
+                    "type": "arg: u32"
+                }
+            ]
+        },
+        {
+            "docs": [],
+            "name": "saAuthority",
+            "seeds": [
+                {
+                    "kind": "type",
+                    "name": "6f6b785f7361",
+                    "type": "seed"
+                }
+            ]
+        },
+        {
+            "docs": [],
+            "name": "eventAuthority",
+            "seeds": [
+                {
+                    "kind": "type",
+                    "name": "5f5f6576656e745f617574686f72697479",
+                    "type": "seed"
+                }
+            ]
+        },
+        {
+            "docs": [],
+            "name": "tempWsolAccount",
+            "seeds": [
+                {
+                    "kind": "type",
+                    "name": "74656d705f77736f6c",
+                    "type": "seed"
+                },
+                {
+                    "kind": "type",
+                    "name": "payer",
+                    "type": "pubkey"
+                }
+            ]
         }
     ],
     "types": [
         {
-            "name": "AdaptorID",
-            "type": {
+            "docs": [],
+            "fieldType": {
                 "kind": "enum",
                 "variants": [
-                    {
-                        "name": "Bridge0"
-                    },
-                    {
-                        "name": "Bridge1"
-                    },
-                    {
-                        "name": "Bridge2"
-                    },
-                    {
-                        "name": "Bridge3"
-                    },
-                    {
-                        "name": "Bridge4"
-                    },
-                    {
-                        "name": "Bridge5"
-                    },
-                    {
-                        "name": "Bridge6"
-                    },
-                    {
-                        "name": "Bridge7"
-                    },
-                    {
-                        "name": "Bridge8"
-                    },
-                    {
-                        "name": "Bridge9"
-                    },
-                    {
-                        "name": "Bridge10"
-                    },
-                    {
-                        "name": "Bridge11"
-                    },
-                    {
-                        "name": "Bridge12"
-                    },
-                    {
-                        "name": "Bridge13"
-                    },
-                    {
-                        "name": "Bridge14"
-                    },
-                    {
-                        "name": "Bridge15"
-                    },
-                    {
-                        "name": "Bridge16"
-                    },
-                    {
-                        "name": "Bridge17"
-                    },
-                    {
-                        "name": "Cctp"
-                    },
-                    {
-                        "name": "Bridge19"
-                    },
-                    {
-                        "name": "Bridge20"
-                    },
-                    {
-                        "name": "Wormhole"
-                    },
-                    {
-                        "name": "Meson"
-                    },
-                    {
-                        "name": "Bridge23"
-                    },
-                    {
-                        "name": "Bridge24"
-                    },
-                    {
-                        "name": "Bridge25"
-                    },
-                    {
-                        "name": "Bridge26"
-                    },
-                    {
-                        "name": "Bridge27"
-                    },
-                    {
-                        "name": "Bridge28"
-                    },
-                    {
-                        "name": "Bridge29"
-                    },
-                    {
-                        "name": "Bridge30"
-                    },
-                    {
-                        "name": "Bridge31"
-                    },
-                    {
-                        "name": "Bridge32"
-                    },
-                    {
-                        "name": "Bridge33"
-                    },
-                    {
-                        "name": "Debridgedln"
-                    },
-                    {
-                        "name": "Bridge35"
-                    },
-                    {
-                        "name": "Bridge36"
-                    },
-                    {
-                        "name": "Bridge37"
-                    },
-                    {
-                        "name": "Bridge38"
-                    },
-                    {
-                        "name": "Bridge39"
-                    },
-                    {
-                        "name": "Bridge40"
-                    },
-                    {
-                        "name": "Allbridge"
-                    },
-                    {
-                        "name": "Bridge42"
-                    },
-                    {
-                        "name": "Bridge43"
-                    },
-                    {
-                        "name": "Bridge44"
-                    },
-                    {
-                        "name": "Bridge45"
-                    },
-                    {
-                        "name": "Bridge46"
-                    },
-                    {
-                        "name": "MayanSwift"
-                    },
-                    {
-                        "name": "Bridge48"
-                    },
-                    {
-                        "name": "Bridge49"
-                    }
+                    "SplTokenSwap",
+                    "StableSwap",
+                    "Whirlpool",
+                    "MeteoraDynamicpool",
+                    "RaydiumSwap",
+                    "RaydiumStableSwap",
+                    "RaydiumClmmSwap",
+                    "AldrinExchangeV1",
+                    "AldrinExchangeV2",
+                    "LifinityV1",
+                    "LifinityV2",
+                    "RaydiumClmmSwapV2",
+                    "FluxBeam",
+                    "MeteoraDlmm",
+                    "RaydiumCpmmSwap",
+                    "OpenBookV2",
+                    "WhirlpoolV2",
+                    "Phoenix",
+                    "ObricV2",
+                    "SanctumAddLiq",
+                    "SanctumRemoveLiq",
+                    "SanctumNonWsolSwap",
+                    "SanctumWsolSwap",
+                    "PumpfunBuy",
+                    "PumpfunSell",
+                    "StabbleSwap",
+                    "SanctumRouter",
+                    "MeteoraVaultDeposit",
+                    "MeteoraVaultWithdraw",
+                    "Saros",
+                    "MeteoraLst",
+                    "Solfi",
+                    "QualiaSwap",
+                    "Zerofi",
+                    "PumpfunammBuy",
+                    "PumpfunammSell",
+                    "Virtuals",
+                    "VertigoBuy",
+                    "VertigoSell",
+                    "PerpetualsAddLiq",
+                    "PerpetualsRemoveLiq",
+                    "PerpetualsSwap",
+                    "RaydiumLaunchpad",
+                    "LetsBonkFun",
+                    "Woofi",
+                    "MeteoraDbc",
+                    "MeteoraDlmmSwap2",
+                    "MeteoraDAMMV2",
+                    "Gavel",
+                    "BoopfunBuy",
+                    "BoopfunSell",
+                    "MeteoraDbc2",
+                    "GooseFX",
+                    "Dooar",
+                    "Numeraire",
+                    "SaberDecimalWrapperDeposit",
+                    "SaberDecimalWrapperWithdraw",
+                    "SarosDlmm",
+                    "OneDexSwap",
+                    "Manifest",
+                    "ByrealClmm",
+                    "PancakeSwapV3Swap",
+                    "PancakeSwapV3SwapV2",
+                    "Tessera",
+                    "SolRfq {\"rfqId\":\"u64\",\"expectedMakerAmount\":\"u64\",\"expectedTakerAmount\":\"u64\",\"makerSendAmount\":\"u64\",\"takerSendAmount\":\"u64\",\"expiry\":\"u64\",\"makerUseNativeSol\":\"bool\",\"takerUseNativeSol\":\"bool\"}",
+                    "PumpfunBuy2",
+                    "PumpfunammBuy2",
+                    "Humidifi",
+                    "HeavenBuy",
+                    "HeavenSell",
+                    "SolfiV2",
+                    "PumpfunBuy3",
+                    "PumpfunSell3",
+                    "PumpfunammBuy3",
+                    "PumpfunammSell3",
+                    "Goonfi",
+                    "MoonitBuy",
+                    "MoonitSell",
+                    "RaydiumSwapV2",
+                    "Whalestreet",
+                    "SugarMoneyBuy {\"bondingCurveBump\":\"u8\",\"bondingCurveSolAssociatedAccountBump\":\"u8\"}",
+                    "SugarMoneySell {\"bondingCurveBump\":\"u8\",\"bondingCurveSolAssociatedAccountBump\":\"u8\"}",
+                    "MeteoraDAMMV2Swap2",
+                    "AlphaQ",
+                    "FutarchyAmm",
+                    "PumpfunSell2",
+                    "HumidifiSwap2 {\"swapId\":\"u64\"}",
+                    "Scorch {\"id\":\"u128\"}",
+                    "JupiterLendDeposit",
+                    "JupiterLendRedeem",
+                    "TaurusFi",
+                    "BisonFi",
+                    "GoonfiV2",
+                    "Quantum",
+                    "BoopfunBuy2",
+                    "BoopfunSell2",
+                    "ByrealClmm2",
+                    "Dooar2",
+                    "HeavenBuy2",
+                    "HeavenSell2",
+                    "MoonitBuy2",
+                    "MoonitSell2",
+                    "SaberDecimalWrapperDeposit2",
+                    "SaberDecimalWrapperWithdraw2",
+                    "ByrealPropAmm",
+                    "SanctumPrefundSwapViaStake {\"swapId\":\"u64\"}",
+                    "AbyssAmm",
+                    "Aquifer",
+                    "WhalestreetV2 {\"authAmountIn\":\"u64\",\"auth\":\"u64\"}",
+                    "SolfiV2WithSig {\"unixTimestamp\":\"u64\",\"msgAmountIn\":\"u64\",\"expectAmountOut\":\"u64\",\"slippage\":\"u16\",\"userRequestSlot\":\"u64\",\"signature\":\"array(u8, 64)\",\"recoveryId\":\"u8\"}"
                 ]
-            }
-        },
-        {
-            "name": "AddResolverEvent",
-            "type": {
-                "kind": "struct",
-                "fields": [
-                    {
-                        "name": "resolver",
-                        "type": "pubkey"
-                    }
-                ]
-            }
-        },
-        {
-            "name": "BridgeToArgs",
-            "type": {
-                "kind": "struct",
-                "fields": [
-                    {
-                        "name": "adaptor_id",
-                        "type": {
-                            "defined": {
-                                "name": "AdaptorID"
-                            }
-                        }
-                    },
-                    {
-                        "name": "to",
-                        "type": "bytes"
-                    },
-                    {
-                        "name": "order_id",
-                        "type": "u64"
-                    },
-                    {
-                        "name": "to_chain_id",
-                        "type": "u64"
-                    },
-                    {
-                        "name": "amount",
-                        "type": "u64"
-                    },
-                    {
-                        "name": "swap_type",
-                        "type": {
-                            "defined": {
-                                "name": "SwapType"
-                            }
-                        }
-                    },
-                    {
-                        "name": "data",
-                        "type": "bytes"
-                    },
-                    {
-                        "name": "ext_data",
-                        "type": "bytes"
-                    }
-                ]
-            }
-        },
-        {
-            "name": "CancelOrderEvent",
-            "type": {
-                "kind": "struct",
-                "fields": [
-                    {
-                        "name": "order_id",
-                        "type": "u64"
-                    },
-                    {
-                        "name": "payer",
-                        "type": "pubkey"
-                    },
-                    {
-                        "name": "maker",
-                        "type": "pubkey"
-                    },
-                    {
-                        "name": "update_ts",
-                        "type": "u64"
-                    }
-                ]
-            }
-        },
-        {
-            "name": "CommissionSwapArgs",
-            "type": {
-                "kind": "struct",
-                "fields": [
-                    {
-                        "name": "amount_in",
-                        "type": "u64"
-                    },
-                    {
-                        "name": "expect_amount_out",
-                        "type": "u64"
-                    },
-                    {
-                        "name": "min_return",
-                        "type": "u64"
-                    },
-                    {
-                        "name": "amounts",
-                        "type": {
-                            "vec": "u64"
-                        }
-                    },
-                    {
-                        "name": "routes",
-                        "type": {
-                            "vec": {
-                                "vec": {
-                                    "defined": {
-                                        "name": "Route"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "name": "commission_rate",
-                        "type": "u16"
-                    },
-                    {
-                        "name": "commission_direction",
-                        "type": "bool"
-                    }
-                ]
-            }
-        },
-        {
-            "name": "CommissionWrapUnwrapArgs",
-            "type": {
-                "kind": "struct",
-                "fields": [
-                    {
-                        "name": "amount_in",
-                        "type": "u64"
-                    },
-                    {
-                        "name": "wrap_direction",
-                        "type": "bool"
-                    },
-                    {
-                        "name": "commission_rate",
-                        "type": "u16"
-                    },
-                    {
-                        "name": "commission_direction",
-                        "type": "bool"
-                    }
-                ]
-            }
-        },
-        {
-            "name": "Dex",
-            "type": {
-                "kind": "enum",
-                "variants": [
-                    {
-                        "name": "SplTokenSwap"
-                    },
-                    {
-                        "name": "StableSwap"
-                    },
-                    {
-                        "name": "Whirlpool"
-                    },
-                    {
-                        "name": "MeteoraDynamicpool"
-                    },
-                    {
-                        "name": "RaydiumSwap"
-                    },
-                    {
-                        "name": "RaydiumStableSwap"
-                    },
-                    {
-                        "name": "RaydiumClmmSwap"
-                    },
-                    {
-                        "name": "AldrinExchangeV1"
-                    },
-                    {
-                        "name": "AldrinExchangeV2"
-                    },
-                    {
-                        "name": "LifinityV1"
-                    },
-                    {
-                        "name": "LifinityV2"
-                    },
-                    {
-                        "name": "RaydiumClmmSwapV2"
-                    },
-                    {
-                        "name": "FluxBeam"
-                    },
-                    {
-                        "name": "MeteoraDlmm"
-                    },
-                    {
-                        "name": "RaydiumCpmmSwap"
-                    },
-                    {
-                        "name": "OpenBookV2"
-                    },
-                    {
-                        "name": "WhirlpoolV2"
-                    },
-                    {
-                        "name": "Phoenix"
-                    },
-                    {
-                        "name": "ObricV2"
-                    },
-                    {
-                        "name": "SanctumAddLiq"
-                    },
-                    {
-                        "name": "SanctumRemoveLiq"
-                    },
-                    {
-                        "name": "SanctumNonWsolSwap"
-                    },
-                    {
-                        "name": "SanctumWsolSwap"
-                    },
-                    {
-                        "name": "PumpfunBuy"
-                    },
-                    {
-                        "name": "PumpfunSell"
-                    },
-                    {
-                        "name": "StabbleSwap"
-                    },
-                    {
-                        "name": "SanctumRouter"
-                    },
-                    {
-                        "name": "MeteoraVaultDeposit"
-                    },
-                    {
-                        "name": "MeteoraVaultWithdraw"
-                    },
-                    {
-                        "name": "Saros"
-                    },
-                    {
-                        "name": "MeteoraLst"
-                    },
-                    {
-                        "name": "Solfi"
-                    },
-                    {
-                        "name": "QualiaSwap"
-                    },
-                    {
-                        "name": "Zerofi"
-                    },
-                    {
-                        "name": "PumpfunammBuy"
-                    },
-                    {
-                        "name": "PumpfunammSell"
-                    },
-                    {
-                        "name": "Virtuals"
-                    },
-                    {
-                        "name": "VertigoBuy"
-                    },
-                    {
-                        "name": "VertigoSell"
-                    },
-                    {
-                        "name": "PerpetualsAddLiq"
-                    },
-                    {
-                        "name": "PerpetualsRemoveLiq"
-                    },
-                    {
-                        "name": "PerpetualsSwap"
-                    },
-                    {
-                        "name": "RaydiumLaunchpad"
-                    },
-                    {
-                        "name": "LetsBonkFun"
-                    },
-                    {
-                        "name": "Woofi"
-                    },
-                    {
-                        "name": "MeteoraDbc"
-                    },
-                    {
-                        "name": "MeteoraDlmmSwap2"
-                    },
-                    {
-                        "name": "MeteoraDAMMV2"
-                    },
-                    {
-                        "name": "Gavel"
-                    },
-                    {
-                        "name": "BoopfunBuy"
-                    },
-                    {
-                        "name": "BoopfunSell"
-                    },
-                    {
-                        "name": "MeteoraDbc2"
-                    },
-                    {
-                        "name": "GooseFX"
-                    },
-                    {
-                        "name": "Dooar"
-                    },
-                    {
-                        "name": "Numeraire"
-                    },
-                    {
-                        "name": "SaberDecimalWrapperDeposit"
-                    },
-                    {
-                        "name": "SaberDecimalWrapperWithdraw"
-                    },
-                    {
-                        "name": "SarosDlmm"
-                    },
-                    {
-                        "name": "OneDexSwap"
-                    },
-                    {
-                        "name": "Manifest"
-                    },
-                    {
-                        "name": "ByrealClmm"
-                    },
-                    {
-                        "name": "PancakeSwapV3Swap"
-                    },
-                    {
-                        "name": "PancakeSwapV3SwapV2"
-                    },
-                    {
-                        "name": "Tessera"
-                    },
-                    {
-                        "name": "SolRfq"
-                    },
-                    {
-                        "name": "PumpfunBuy2"
-                    },
-                    {
-                        "name": "PumpfunammBuy2"
-                    },
-                    {
-                        "name": "Humidifi"
-                    },
-                    {
-                        "name": "HeavenBuy"
-                    },
-                    {
-                        "name": "HeavenSell"
-                    },
-                    {
-                        "name": "SolfiV2"
-                    },
-                    {
-                        "name": "PumpfunBuy3"
-                    },
-                    {
-                        "name": "PumpfunSell3"
-                    },
-                    {
-                        "name": "PumpfunammBuy3"
-                    },
-                    {
-                        "name": "PumpfunammSell3"
-                    }
-                ]
-            }
-        },
-        {
-            "name": "FillOrderEvent",
-            "type": {
-                "kind": "struct",
-                "fields": [
-                    {
-                        "name": "order_id",
-                        "type": "u64"
-                    },
-                    {
-                        "name": "payer",
-                        "type": "pubkey"
-                    },
-                    {
-                        "name": "maker",
-                        "type": "pubkey"
-                    },
-                    {
-                        "name": "input_token_mint",
-                        "type": "pubkey"
-                    },
-                    {
-                        "name": "output_token_mint",
-                        "type": "pubkey"
-                    },
-                    {
-                        "name": "making_amount",
-                        "type": "u64"
-                    },
-                    {
-                        "name": "taking_amount",
-                        "type": "u64"
-                    },
-                    {
-                        "name": "update_ts",
-                        "type": "u64"
-                    }
-                ]
-            }
-        },
-        {
-            "name": "GlobalConfig",
-            "serialization": "bytemuckunsafe",
-            "repr": {
-                "kind": "rust",
-                "packed": true
             },
-            "type": {
-                "kind": "struct",
-                "fields": [
-                    {
-                        "name": "bump",
-                        "docs": [
-                            "Bump to identify PDA."
-                        ],
-                        "type": "u8"
-                    },
-                    {
-                        "name": "admin",
-                        "docs": [
-                            "The admin of the program."
-                        ],
-                        "type": "pubkey"
-                    },
-                    {
-                        "name": "resolvers",
-                        "docs": [
-                            "Only the resolver can trigger order filled."
-                        ],
-                        "type": {
-                            "array": [
-                                "pubkey",
-                                5
-                            ]
-                        }
-                    },
-                    {
-                        "name": "trade_fee",
-                        "docs": [
-                            "Prepaid trade fee, the remaining amount will be refunded to the user"
-                        ],
-                        "type": "u64"
-                    },
-                    {
-                        "name": "paused",
-                        "docs": [
-                            "Indicate whether to pause trading."
-                        ],
-                        "type": "bool"
-                    },
-                    {
-                        "name": "fee_multiplier",
-                        "docs": [
-                            "Fee multiplier for the trade fee"
-                        ],
-                        "type": "u8"
-                    },
-                    {
-                        "name": "padding",
-                        "docs": [
-                            "padding for upgrade"
-                        ],
-                        "type": {
-                            "array": [
-                                "u8",
-                                127
-                            ]
-                        }
-                    }
-                ]
-            }
+            "name": "Dex"
         },
         {
-            "name": "InitGlobalConfigEvent",
-            "type": {
-                "kind": "struct",
+            "docs": [],
+            "fieldType": {
                 "fields": [
                     {
-                        "name": "admin",
-                        "type": "pubkey"
-                    },
-                    {
-                        "name": "trade_fee",
-                        "type": "u64"
-                    }
-                ]
-            }
-        },
-        {
-            "name": "OrderV1",
-            "type": {
-                "kind": "struct",
-                "fields": [
-                    {
-                        "name": "bump",
-                        "docs": [
-                            "Bump to identify PDA."
-                        ],
-                        "type": "u8"
-                    },
-                    {
-                        "name": "order_id",
-                        "docs": [
-                            "The order id."
-                        ],
+                        "docs": [],
+                        "name": "orderId",
                         "type": "u64"
                     },
                     {
-                        "name": "maker",
-                        "docs": [
-                            "The maker of the order."
-                        ],
-                        "type": "pubkey"
-                    },
-                    {
-                        "name": "making_amount",
-                        "docs": [
-                            "The makeing amount of the order."
-                        ],
+                        "docs": [],
+                        "name": "amountIn",
                         "type": "u64"
                     },
                     {
-                        "name": "expect_taking_amount",
-                        "docs": [
-                            "The expect taking amount of the order."
-                        ],
-                        "type": "u64"
-                    },
-                    {
-                        "name": "min_return_amount",
-                        "docs": [
-                            "The min return amount of the order."
-                        ],
-                        "type": "u64"
-                    },
-                    {
-                        "name": "escrow_token_account",
-                        "docs": [
-                            "The escrow token account of the order."
-                        ],
-                        "type": "pubkey"
-                    },
-                    {
-                        "name": "input_token_mint",
-                        "docs": [
-                            "Input token mint."
-                        ],
-                        "type": "pubkey"
-                    },
-                    {
-                        "name": "output_token_mint",
-                        "docs": [
-                            "Output token mint."
-                        ],
-                        "type": "pubkey"
-                    },
-                    {
-                        "name": "input_token_program",
-                        "docs": [
-                            "Input token program."
-                        ],
-                        "type": "pubkey"
-                    },
-                    {
-                        "name": "output_token_program",
-                        "docs": [
-                            "Output token program."
-                        ],
-                        "type": "pubkey"
-                    },
-                    {
-                        "name": "create_ts",
-                        "docs": [
-                            "The create timestamp of the order."
-                        ],
-                        "type": "u64"
-                    },
-                    {
-                        "name": "deadline",
-                        "docs": [
-                            "The deadline of the order."
-                        ],
-                        "type": "u64"
-                    },
-                    {
-                        "name": "padding",
-                        "docs": [
-                            "padding"
-                        ],
-                        "type": {
-                            "array": [
-                                "u8",
-                                128
-                            ]
-                        }
-                    }
-                ]
-            }
-        },
-        {
-            "name": "PauseTradingEvent",
-            "type": {
-                "kind": "struct",
-                "fields": [
-                    {
-                        "name": "paused",
-                        "type": "bool"
-                    }
-                ]
-            }
-        },
-        {
-            "name": "PlaceOrderEvent",
-            "type": {
-                "kind": "struct",
-                "fields": [
-                    {
-                        "name": "order_id",
-                        "type": "u64"
-                    },
-                    {
-                        "name": "maker",
-                        "type": "pubkey"
-                    },
-                    {
-                        "name": "input_token_mint",
-                        "type": "pubkey"
-                    },
-                    {
-                        "name": "output_token_mint",
-                        "type": "pubkey"
-                    },
-                    {
-                        "name": "making_amount",
-                        "type": "u64"
-                    },
-                    {
-                        "name": "expect_taking_amount",
-                        "type": "u64"
-                    },
-                    {
-                        "name": "min_return_amount",
-                        "type": "u64"
-                    },
-                    {
-                        "name": "create_ts",
-                        "type": "u64"
-                    },
-                    {
-                        "name": "deadline",
-                        "type": "u64"
-                    },
-                    {
-                        "name": "trade_fee",
-                        "type": "u64"
-                    }
-                ]
-            }
-        },
-        {
-            "name": "PlatformFeeWrapUnwrapArgs",
-            "type": {
-                "kind": "struct",
-                "fields": [
-                    {
-                        "name": "order_id",
-                        "type": "u64"
-                    },
-                    {
-                        "name": "amount_in",
-                        "type": "u64"
-                    },
-                    {
-                        "name": "commission_info",
+                        "docs": [],
+                        "name": "commissionInfo",
                         "type": "u32"
                     },
                     {
-                        "name": "platform_fee_rate",
+                        "docs": [],
+                        "name": "platformFeeRate",
                         "type": "u16"
                     },
                     {
+                        "docs": [],
                         "name": "tob",
                         "type": "bool"
                     }
-                ]
-            }
+                ],
+                "kind": "struct"
+            },
+            "name": "PlatformFeeWrapUnwrapArgs"
         },
         {
-            "name": "PlatformFeeWrapUnwrapArgsV2",
-            "type": {
-                "kind": "struct",
+            "docs": [],
+            "fieldType": {
                 "fields": [
                     {
-                        "name": "amount_in",
-                        "type": "u64"
-                    },
-                    {
-                        "name": "commission_info",
-                        "type": "u32"
-                    },
-                    {
-                        "name": "platform_fee_rate",
-                        "type": "u32"
-                    }
-                ]
-            }
-        },
-        {
-            "name": "RefundEvent",
-            "type": {
-                "kind": "struct",
-                "fields": [
-                    {
-                        "name": "order_id",
-                        "type": "u64"
-                    },
-                    {
-                        "name": "maker",
-                        "type": "pubkey"
-                    },
-                    {
-                        "name": "input_token_mint",
-                        "type": "pubkey"
-                    },
-                    {
-                        "name": "amount",
-                        "type": "u64"
-                    }
-                ]
-            }
-        },
-        {
-            "name": "RemoveResolverEvent",
-            "type": {
-                "kind": "struct",
-                "fields": [
-                    {
-                        "name": "resolver",
-                        "type": "pubkey"
-                    }
-                ]
-            }
-        },
-        {
-            "name": "Route",
-            "type": {
-                "kind": "struct",
-                "fields": [
-                    {
+                        "docs": [],
                         "name": "dexes",
-                        "type": {
-                            "vec": {
-                                "defined": {
-                                    "name": "Dex"
-                                }
-                            }
-                        }
+                        "type": "vec(Dex)"
                     },
                     {
+                        "docs": [],
                         "name": "weights",
                         "type": "bytes"
                     }
-                ]
-            }
+                ],
+                "kind": "struct"
+            },
+            "name": "Route"
         },
         {
-            "name": "SetAdminEvent",
-            "type": {
-                "kind": "struct",
+            "docs": [],
+            "fieldType": {
                 "fields": [
                     {
-                        "name": "admin",
-                        "type": "pubkey"
-                    }
-                ]
-            }
-        },
-        {
-            "name": "SetFeeMultiplierEvent",
-            "type": {
-                "kind": "struct",
-                "fields": [
-                    {
-                        "name": "fee_multiplier",
-                        "type": "u8"
-                    }
-                ]
-            }
-        },
-        {
-            "name": "SetTradeFeeEvent",
-            "type": {
-                "kind": "struct",
-                "fields": [
-                    {
-                        "name": "trade_fee",
-                        "type": "u64"
-                    }
-                ]
-            }
-        },
-        {
-            "name": "SwapArgs",
-            "type": {
-                "kind": "struct",
-                "fields": [
-                    {
-                        "name": "amount_in",
+                        "docs": [],
+                        "name": "amountIn",
                         "type": "u64"
                     },
                     {
-                        "name": "expect_amount_out",
+                        "docs": [],
+                        "name": "expectAmountOut",
                         "type": "u64"
                     },
                     {
-                        "name": "min_return",
+                        "docs": [],
+                        "name": "minReturn",
                         "type": "u64"
                     },
                     {
+                        "docs": [],
                         "name": "amounts",
-                        "type": {
-                            "vec": "u64"
-                        }
+                        "type": "vec(u64)"
                     },
                     {
+                        "docs": [],
                         "name": "routes",
-                        "type": {
-                            "vec": {
-                                "vec": {
-                                    "defined": {
-                                        "name": "Route"
-                                    }
-                                }
-                            }
-                        }
+                        "type": "vec(vec(Route))"
                     }
-                ]
-            }
-        },
-        {
-            "name": "SwapEvent",
-            "type": {
-                "kind": "struct",
-                "fields": [
-                    {
-                        "name": "dex",
-                        "type": {
-                            "defined": {
-                                "name": "Dex"
-                            }
-                        }
-                    },
-                    {
-                        "name": "amount_in",
-                        "type": "u64"
-                    },
-                    {
-                        "name": "amount_out",
-                        "type": "u64"
-                    }
-                ]
-            }
-        },
-        {
-            "name": "SwapType",
-            "type": {
-                "kind": "enum",
-                "variants": [
-                    {
-                        "name": "BRIDGE"
-                    },
-                    {
-                        "name": "SWAPANDBRIDGE"
-                    }
-                ]
-            }
-        },
-        {
-            "name": "UpdateOrderEvent",
-            "type": {
-                "kind": "struct",
-                "fields": [
-                    {
-                        "name": "order_id",
-                        "type": "u64"
-                    },
-                    {
-                        "name": "maker",
-                        "type": "pubkey"
-                    },
-                    {
-                        "name": "expect_taking_amount",
-                        "type": "u64"
-                    },
-                    {
-                        "name": "min_return_amount",
-                        "type": "u64"
-                    },
-                    {
-                        "name": "deadline",
-                        "type": "u64"
-                    },
-                    {
-                        "name": "update_ts",
-                        "type": "u64"
-                    },
-                    {
-                        "name": "increase_fee",
-                        "type": "u64"
-                    }
-                ]
-            }
-        }
-    ],
-    "constants": [
-        {
-            "name": "SEED_SA",
-            "type": "bytes",
-            "value": "[111, 107, 120, 95, 115, 97]"
+                ],
+                "kind": "struct"
+            },
+            "name": "SwapArgs"
         }
     ]
 }

--- a/src/okx/v2/instructions.rs
+++ b/src/okx/v2/instructions.rs
@@ -2,6 +2,7 @@
 
 use crate::common::ParseError;
 use borsh::{BorshDeserialize, BorshSerialize};
+use std::str::FromStr;
 
 // -----------------------------------------------------------------------------
 // Custom types
@@ -19,6 +20,70 @@ pub struct SwapArgs {
 pub struct Route {
     pub dexes: Vec<Dex>,
     pub weights: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct SolRfqArgs {
+    pub rfq_id: u64,
+    pub expected_maker_amount: u64,
+    pub expected_taker_amount: u64,
+    pub maker_send_amount: u64,
+    pub taker_send_amount: u64,
+    pub expiry: u64,
+    pub maker_use_native_sol: bool,
+    pub taker_use_native_sol: bool,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct SugarMoneyArgs {
+    pub bonding_curve_bump: u8,
+    pub bonding_curve_sol_associated_account_bump: u8,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct HumidifiSwap2Args {
+    pub swap_id: u64,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct ScorchArgs {
+    pub id: u128,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct SanctumPrefundSwapViaStakeArgs {
+    pub swap_id: u64,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct WhalestreetV2Args {
+    pub auth_amount_in: u64,
+    pub auth: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct SolfiV2WithSigArgs {
+    pub unix_timestamp: u64,
+    pub msg_amount_in: u64,
+    pub expect_amount_out: u64,
+    pub slippage: u16,
+    pub user_request_slot: u64,
+    pub signature: [u8; 64],
+    pub recovery_id: u8,
+}
+
+impl Default for SolfiV2WithSigArgs {
+    fn default() -> Self {
+        Self {
+            unix_timestamp: 0,
+            msg_amount_in: 0,
+            expect_amount_out: 0,
+            slippage: 0,
+            user_request_slot: 0,
+            signature: [0; 64],
+            recovery_id: 0,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
@@ -87,7 +152,7 @@ pub enum Dex {
     PancakeSwapV3Swap,
     PancakeSwapV3SwapV2,
     Tessera,
-    SolRfq,
+    SolRfq(SolRfqArgs),
     PumpfunBuy2,
     PumpfunammBuy2,
     Humidifi,
@@ -98,6 +163,276 @@ pub enum Dex {
     PumpfunSell3,
     PumpfunammBuy3,
     PumpfunammSell3,
+    Goonfi,
+    MoonitBuy,
+    MoonitSell,
+    RaydiumSwapV2,
+    Whalestreet,
+    SugarMoneyBuy(SugarMoneyArgs),
+    SugarMoneySell(SugarMoneyArgs),
+    MeteoraDAMMV2Swap2,
+    AlphaQ,
+    FutarchyAmm,
+    PumpfunSell2,
+    HumidifiSwap2(HumidifiSwap2Args),
+    Scorch(ScorchArgs),
+    JupiterLendDeposit,
+    JupiterLendRedeem,
+    TaurusFi,
+    BisonFi,
+    GoonfiV2,
+    Quantum,
+    BoopfunBuy2,
+    BoopfunSell2,
+    ByrealClmm2,
+    Dooar2,
+    HeavenBuy2,
+    HeavenSell2,
+    MoonitBuy2,
+    MoonitSell2,
+    SaberDecimalWrapperDeposit2,
+    SaberDecimalWrapperWithdraw2,
+    ByrealPropAmm,
+    SanctumPrefundSwapViaStake(SanctumPrefundSwapViaStakeArgs),
+    AbyssAmm,
+    Aquifer,
+    WhalestreetV2(WhalestreetV2Args),
+    SolfiV2WithSig(SolfiV2WithSigArgs),
+}
+
+pub const DEX_VARIANT_NAMES: &[&str] = &[
+    "SplTokenSwap",
+    "StableSwap",
+    "Whirlpool",
+    "MeteoraDynamicpool",
+    "RaydiumSwap",
+    "RaydiumStableSwap",
+    "RaydiumClmmSwap",
+    "AldrinExchangeV1",
+    "AldrinExchangeV2",
+    "LifinityV1",
+    "LifinityV2",
+    "RaydiumClmmSwapV2",
+    "FluxBeam",
+    "MeteoraDlmm",
+    "RaydiumCpmmSwap",
+    "OpenBookV2",
+    "WhirlpoolV2",
+    "Phoenix",
+    "ObricV2",
+    "SanctumAddLiq",
+    "SanctumRemoveLiq",
+    "SanctumNonWsolSwap",
+    "SanctumWsolSwap",
+    "PumpfunBuy",
+    "PumpfunSell",
+    "StabbleSwap",
+    "SanctumRouter",
+    "MeteoraVaultDeposit",
+    "MeteoraVaultWithdraw",
+    "Saros",
+    "MeteoraLst",
+    "Solfi",
+    "QualiaSwap",
+    "Zerofi",
+    "PumpfunammBuy",
+    "PumpfunammSell",
+    "Virtuals",
+    "VertigoBuy",
+    "VertigoSell",
+    "PerpetualsAddLiq",
+    "PerpetualsRemoveLiq",
+    "PerpetualsSwap",
+    "RaydiumLaunchpad",
+    "LetsBonkFun",
+    "Woofi",
+    "MeteoraDbc",
+    "MeteoraDlmmSwap2",
+    "MeteoraDAMMV2",
+    "Gavel",
+    "BoopfunBuy",
+    "BoopfunSell",
+    "MeteoraDbc2",
+    "GooseFX",
+    "Dooar",
+    "Numeraire",
+    "SaberDecimalWrapperDeposit",
+    "SaberDecimalWrapperWithdraw",
+    "SarosDlmm",
+    "OneDexSwap",
+    "Manifest",
+    "ByrealClmm",
+    "PancakeSwapV3Swap",
+    "PancakeSwapV3SwapV2",
+    "Tessera",
+    "SolRfq",
+    "PumpfunBuy2",
+    "PumpfunammBuy2",
+    "Humidifi",
+    "HeavenBuy",
+    "HeavenSell",
+    "SolfiV2",
+    "PumpfunBuy3",
+    "PumpfunSell3",
+    "PumpfunammBuy3",
+    "PumpfunammSell3",
+    "Goonfi",
+    "MoonitBuy",
+    "MoonitSell",
+    "RaydiumSwapV2",
+    "Whalestreet",
+    "SugarMoneyBuy",
+    "SugarMoneySell",
+    "MeteoraDAMMV2Swap2",
+    "AlphaQ",
+    "FutarchyAmm",
+    "PumpfunSell2",
+    "HumidifiSwap2",
+    "Scorch",
+    "JupiterLendDeposit",
+    "JupiterLendRedeem",
+    "TaurusFi",
+    "BisonFi",
+    "GoonfiV2",
+    "Quantum",
+    "BoopfunBuy2",
+    "BoopfunSell2",
+    "ByrealClmm2",
+    "Dooar2",
+    "HeavenBuy2",
+    "HeavenSell2",
+    "MoonitBuy2",
+    "MoonitSell2",
+    "SaberDecimalWrapperDeposit2",
+    "SaberDecimalWrapperWithdraw2",
+    "ByrealPropAmm",
+    "SanctumPrefundSwapViaStake",
+    "AbyssAmm",
+    "Aquifer",
+    "WhalestreetV2",
+    "SolfiV2WithSig",
+];
+
+impl FromStr for Dex {
+    type Err = ParseError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let variant = value.split_once(" {").map(|(name, _)| name).unwrap_or(value);
+        Ok(match variant {
+            "SplTokenSwap" => Self::SplTokenSwap,
+            "StableSwap" => Self::StableSwap,
+            "Whirlpool" => Self::Whirlpool,
+            "MeteoraDynamicpool" => Self::MeteoraDynamicpool,
+            "RaydiumSwap" => Self::RaydiumSwap,
+            "RaydiumStableSwap" => Self::RaydiumStableSwap,
+            "RaydiumClmmSwap" => Self::RaydiumClmmSwap,
+            "AldrinExchangeV1" => Self::AldrinExchangeV1,
+            "AldrinExchangeV2" => Self::AldrinExchangeV2,
+            "LifinityV1" => Self::LifinityV1,
+            "LifinityV2" => Self::LifinityV2,
+            "RaydiumClmmSwapV2" => Self::RaydiumClmmSwapV2,
+            "FluxBeam" => Self::FluxBeam,
+            "MeteoraDlmm" => Self::MeteoraDlmm,
+            "RaydiumCpmmSwap" => Self::RaydiumCpmmSwap,
+            "OpenBookV2" => Self::OpenBookV2,
+            "WhirlpoolV2" => Self::WhirlpoolV2,
+            "Phoenix" => Self::Phoenix,
+            "ObricV2" => Self::ObricV2,
+            "SanctumAddLiq" => Self::SanctumAddLiq,
+            "SanctumRemoveLiq" => Self::SanctumRemoveLiq,
+            "SanctumNonWsolSwap" => Self::SanctumNonWsolSwap,
+            "SanctumWsolSwap" => Self::SanctumWsolSwap,
+            "PumpfunBuy" => Self::PumpfunBuy,
+            "PumpfunSell" => Self::PumpfunSell,
+            "StabbleSwap" => Self::StabbleSwap,
+            "SanctumRouter" => Self::SanctumRouter,
+            "MeteoraVaultDeposit" => Self::MeteoraVaultDeposit,
+            "MeteoraVaultWithdraw" => Self::MeteoraVaultWithdraw,
+            "Saros" => Self::Saros,
+            "MeteoraLst" => Self::MeteoraLst,
+            "Solfi" => Self::Solfi,
+            "QualiaSwap" => Self::QualiaSwap,
+            "Zerofi" => Self::Zerofi,
+            "PumpfunammBuy" => Self::PumpfunammBuy,
+            "PumpfunammSell" => Self::PumpfunammSell,
+            "Virtuals" => Self::Virtuals,
+            "VertigoBuy" => Self::VertigoBuy,
+            "VertigoSell" => Self::VertigoSell,
+            "PerpetualsAddLiq" => Self::PerpetualsAddLiq,
+            "PerpetualsRemoveLiq" => Self::PerpetualsRemoveLiq,
+            "PerpetualsSwap" => Self::PerpetualsSwap,
+            "RaydiumLaunchpad" => Self::RaydiumLaunchpad,
+            "LetsBonkFun" => Self::LetsBonkFun,
+            "Woofi" => Self::Woofi,
+            "MeteoraDbc" => Self::MeteoraDbc,
+            "MeteoraDlmmSwap2" => Self::MeteoraDlmmSwap2,
+            "MeteoraDAMMV2" => Self::MeteoraDAMMV2,
+            "Gavel" => Self::Gavel,
+            "BoopfunBuy" => Self::BoopfunBuy,
+            "BoopfunSell" => Self::BoopfunSell,
+            "MeteoraDbc2" => Self::MeteoraDbc2,
+            "GooseFX" => Self::GooseFX,
+            "Dooar" => Self::Dooar,
+            "Numeraire" => Self::Numeraire,
+            "SaberDecimalWrapperDeposit" => Self::SaberDecimalWrapperDeposit,
+            "SaberDecimalWrapperWithdraw" => Self::SaberDecimalWrapperWithdraw,
+            "SarosDlmm" => Self::SarosDlmm,
+            "OneDexSwap" => Self::OneDexSwap,
+            "Manifest" => Self::Manifest,
+            "ByrealClmm" => Self::ByrealClmm,
+            "PancakeSwapV3Swap" => Self::PancakeSwapV3Swap,
+            "PancakeSwapV3SwapV2" => Self::PancakeSwapV3SwapV2,
+            "Tessera" => Self::Tessera,
+            "SolRfq" => Self::SolRfq(SolRfqArgs::default()),
+            "PumpfunBuy2" => Self::PumpfunBuy2,
+            "PumpfunammBuy2" => Self::PumpfunammBuy2,
+            "Humidifi" => Self::Humidifi,
+            "HeavenBuy" => Self::HeavenBuy,
+            "HeavenSell" => Self::HeavenSell,
+            "SolfiV2" => Self::SolfiV2,
+            "PumpfunBuy3" => Self::PumpfunBuy3,
+            "PumpfunSell3" => Self::PumpfunSell3,
+            "PumpfunammBuy3" => Self::PumpfunammBuy3,
+            "PumpfunammSell3" => Self::PumpfunammSell3,
+            "Goonfi" => Self::Goonfi,
+            "MoonitBuy" => Self::MoonitBuy,
+            "MoonitSell" => Self::MoonitSell,
+            "RaydiumSwapV2" => Self::RaydiumSwapV2,
+            "Whalestreet" => Self::Whalestreet,
+            "SugarMoneyBuy" => Self::SugarMoneyBuy(SugarMoneyArgs::default()),
+            "SugarMoneySell" => Self::SugarMoneySell(SugarMoneyArgs::default()),
+            "MeteoraDAMMV2Swap2" => Self::MeteoraDAMMV2Swap2,
+            "AlphaQ" => Self::AlphaQ,
+            "FutarchyAmm" => Self::FutarchyAmm,
+            "PumpfunSell2" => Self::PumpfunSell2,
+            "HumidifiSwap2" => Self::HumidifiSwap2(HumidifiSwap2Args::default()),
+            "Scorch" => Self::Scorch(ScorchArgs::default()),
+            "JupiterLendDeposit" => Self::JupiterLendDeposit,
+            "JupiterLendRedeem" => Self::JupiterLendRedeem,
+            "TaurusFi" => Self::TaurusFi,
+            "BisonFi" => Self::BisonFi,
+            "GoonfiV2" => Self::GoonfiV2,
+            "Quantum" => Self::Quantum,
+            "BoopfunBuy2" => Self::BoopfunBuy2,
+            "BoopfunSell2" => Self::BoopfunSell2,
+            "ByrealClmm2" => Self::ByrealClmm2,
+            "Dooar2" => Self::Dooar2,
+            "HeavenBuy2" => Self::HeavenBuy2,
+            "HeavenSell2" => Self::HeavenSell2,
+            "MoonitBuy2" => Self::MoonitBuy2,
+            "MoonitSell2" => Self::MoonitSell2,
+            "SaberDecimalWrapperDeposit2" => Self::SaberDecimalWrapperDeposit2,
+            "SaberDecimalWrapperWithdraw2" => Self::SaberDecimalWrapperWithdraw2,
+            "ByrealPropAmm" => Self::ByrealPropAmm,
+            "SanctumPrefundSwapViaStake" => Self::SanctumPrefundSwapViaStake(SanctumPrefundSwapViaStakeArgs::default()),
+            "AbyssAmm" => Self::AbyssAmm,
+            "Aquifer" => Self::Aquifer,
+            "WhalestreetV2" => Self::WhalestreetV2(WhalestreetV2Args::default()),
+            "SolfiV2WithSig" => Self::SolfiV2WithSig(SolfiV2WithSigArgs::default()),
+            "SanctumSwapWithoutWsol" => Self::SanctumNonWsolSwap,
+            _ => return Err(ParseError::InvalidLength { expected: 0, got: value.len() }),
+        })
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -114,6 +449,24 @@ pub struct SwapV3Instruction {
     pub commission_info: u32,
     pub platform_fee_rate: u16,
     pub order_id: u64,
+}
+
+impl SwapV3Instruction {
+    fn unpack(payload: &[u8]) -> Result<Self, ParseError> {
+        let mut reader = payload;
+        let instruction = Self::deserialize(&mut reader)?;
+
+        // Mainnet `swap_v3` payloads have been observed with a trailing zero
+        // word after the IDL-defined fields. Keep non-zero trailing bytes strict.
+        if reader.iter().any(|byte| *byte != 0) {
+            return Err(ParseError::InvalidLength {
+                expected: payload.len() - reader.len(),
+                got: payload.len(),
+            });
+        }
+
+        Ok(instruction)
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -138,7 +491,7 @@ impl<'a> TryFrom<&'a [u8]> for OkxV2Instruction {
         let (disc, payload) = data.split_at(8);
         let discriminator: [u8; 8] = disc.try_into().expect("slice len 8");
         Ok(match discriminator {
-            SWAP_V3 => Self::SwapV3(SwapV3Instruction::try_from_slice(payload)?),
+            SWAP_V3 => Self::SwapV3(SwapV3Instruction::unpack(payload)?),
             other => return Err(ParseError::Unknown(other)),
         })
     }

--- a/src/okx/v2/logs.rs
+++ b/src/okx/v2/logs.rs
@@ -1,0 +1,100 @@
+//! OKX Dex v2 human-readable program log parsing helpers.
+
+use crate::{
+    common::ParseError,
+    okx::v2::{events::SwapEvent, instructions::Dex},
+};
+use solana_program::pubkey::Pubkey;
+use std::str::FromStr;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OkxV2Log {
+    Swap(SwapEvent),
+    RouteAmmPool(RouteAmmPoolLog),
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RouteAmmPoolLog {
+    pub dex: Dex,
+    pub amount_in: u64,
+    pub offset: u64,
+    pub amm_pool: Pubkey,
+}
+
+pub fn unpack(line: &str) -> Result<OkxV2Log, ParseError> {
+    let line = strip_program_log_prefix(line);
+    let Some(event) = line.strip_prefix("SwapEvent { ").and_then(|value| value.strip_suffix(" }")) else {
+        return Ok(OkxV2Log::Unknown);
+    };
+
+    let mut dex = None;
+    let mut amount_in = None;
+    let mut amount_out = None;
+
+    for part in event.split(", ") {
+        let Some((name, value)) = part.split_once(": ") else {
+            return Ok(OkxV2Log::Unknown);
+        };
+
+        match name {
+            "dex" => dex = Some(Dex::from_str(value)?),
+            "amount_in" => amount_in = value.parse::<u64>().ok(),
+            "amount_out" => amount_out = value.parse::<u64>().ok(),
+            _ => {}
+        }
+    }
+
+    match (dex, amount_in, amount_out) {
+        (Some(dex), Some(amount_in), Some(amount_out)) => Ok(OkxV2Log::Swap(SwapEvent { dex, amount_in, amount_out })),
+        _ => Ok(OkxV2Log::Unknown),
+    }
+}
+
+pub fn unpack_route_amm_pool(dex_line: &str, pool_line: &str) -> Result<OkxV2Log, ParseError> {
+    let dex_line = strip_program_log_prefix(dex_line);
+    let pool_line = strip_program_log_prefix(pool_line);
+
+    let Some(route) = dex_line.strip_prefix("Dex::") else {
+        return Ok(OkxV2Log::Unknown);
+    };
+    let Some((dex, fields)) = route.split_once(" amount_in: ") else {
+        return Ok(OkxV2Log::Unknown);
+    };
+    let Some((amount_in, offset)) = fields.split_once(", offset: ") else {
+        return Ok(OkxV2Log::Unknown);
+    };
+
+    let Ok(amm_pool) = Pubkey::from_str(pool_line) else {
+        return Ok(OkxV2Log::Unknown);
+    };
+
+    Ok(OkxV2Log::RouteAmmPool(RouteAmmPoolLog {
+        dex: Dex::from_str(dex)?,
+        amount_in: amount_in.parse().map_err(|_| ParseError::InvalidLength {
+            expected: 0,
+            got: amount_in.len(),
+        })?,
+        offset: offset.parse().map_err(|_| ParseError::InvalidLength {
+            expected: 0,
+            got: offset.len(),
+        })?,
+        amm_pool,
+    }))
+}
+
+pub fn unpack_route_amm_pools(lines: &[&str]) -> Result<Vec<RouteAmmPoolLog>, ParseError> {
+    let mut pools = Vec::new();
+
+    for pair in lines.windows(2) {
+        if let Ok(OkxV2Log::RouteAmmPool(log)) = unpack_route_amm_pool(pair[0], pair[1]) {
+            pools.push(log);
+        }
+    }
+
+    Ok(pools)
+}
+
+fn strip_program_log_prefix(line: &str) -> &str {
+    line.strip_prefix("Program log: ").unwrap_or(line)
+}

--- a/src/okx/v2/mod.rs
+++ b/src/okx/v2/mod.rs
@@ -1,7 +1,9 @@
 use substreams_solana::b58;
 
 pub mod accounts;
+pub mod events;
 pub mod instructions;
+pub mod logs;
 
 /// OKX Dex program
 ///

--- a/tests/okx/instructions.rs
+++ b/tests/okx/instructions.rs
@@ -1,4 +1,5 @@
 use substreams_solana_idls::okx::v2::instructions;
+use substreams_solana_idls::okx::v2::{events, events::OkxV2Event};
 
 #[test]
 fn unknown_discriminator() {
@@ -8,4 +9,9 @@ fn unknown_discriminator() {
 #[test]
 fn too_short() {
     assert!(instructions::unpack(&[0u8; 4]).is_err());
+}
+
+#[test]
+fn event_unknown() {
+    assert!(matches!(events::unpack(&[0u8; 24]).unwrap(), OkxV2Event::Unknown));
 }

--- a/tests/okx/okx_v2.rs
+++ b/tests/okx/okx_v2.rs
@@ -1,7 +1,17 @@
 #[cfg(test)]
 mod tests {
+    use base64::Engine;
+    use solana_program::pubkey::Pubkey;
+    use std::str::FromStr;
     use substreams::hex;
-    use substreams_solana_idls::okx::v2::instructions::{self, Dex, Route, SwapArgs, SwapV3Instruction};
+    use substreams_solana::pb::sf::solana::r#type::v1 as pb;
+    use substreams_solana_idls::okx::v2::{
+        accounts,
+        events::{self, OkxV2Event, SwapEvent, SWAP_EVENT},
+        instructions::DEX_VARIANT_NAMES,
+        instructions::{self, Dex, Route, SwapArgs, SwapV3Instruction},
+        logs,
+    };
 
     #[test]
     fn swap_v3_instruction() {
@@ -39,5 +49,281 @@ mod tests {
             }
             _ => panic!("expected SwapV3"),
         }
+    }
+
+    #[test]
+    fn swap_v3_tessera_instruction() {
+        let bytes = hex!("f0e02621b01ff1afbf775f3b05000000db7706a03a000000db7706a03a00000001000000bf775f3b050000000100000001000000010000003f0100000064000000000000000000000000000000000000");
+        match instructions::unpack(&bytes).expect("decode instruction") {
+            instructions::OkxV2Instruction::SwapV3(ix) => {
+                assert_eq!(
+                    ix,
+                    SwapV3Instruction {
+                        args: SwapArgs {
+                            amount_in: 22_470_948_799,
+                            expect_amount_out: 251_792_881_627,
+                            min_return: 251_792_881_627,
+                            amounts: vec![22_470_948_799],
+                            routes: vec![vec![Route {
+                                dexes: vec![Dex::Tessera],
+                                weights: vec![100],
+                            }]],
+                        },
+                        commission_info: 0,
+                        platform_fee_rate: 0,
+                        order_id: 0,
+                    }
+                );
+            }
+            _ => panic!("expected SwapV3"),
+        }
+    }
+
+    #[test]
+    fn swap_v3_sanctum_alphaq_instruction() {
+        let bytes = hex!("f0e02621b01ff1af7cc51c7f010000003bcc0fe901000000bfcc2be401000000010000007cc51c7f01000000010000000200000001000000150100000064010000005301000000640000000000000000000000000000");
+        match instructions::unpack(&bytes).expect("decode instruction") {
+            instructions::OkxV2Instruction::SwapV3(ix) => {
+                assert_eq!(
+                    ix,
+                    SwapV3Instruction {
+                        args: SwapArgs {
+                            amount_in: 6_427_559_292,
+                            expect_amount_out: 8_205_093_947,
+                            min_return: 8_123_043_007,
+                            amounts: vec![6_427_559_292],
+                            routes: vec![vec![
+                                Route {
+                                    dexes: vec![Dex::SanctumNonWsolSwap],
+                                    weights: vec![100],
+                                },
+                                Route {
+                                    dexes: vec![Dex::AlphaQ],
+                                    weights: vec![100],
+                                },
+                            ]],
+                        },
+                        commission_info: 0,
+                        platform_fee_rate: 0,
+                        order_id: 0,
+                    }
+                );
+            }
+            _ => panic!("expected SwapV3"),
+        }
+    }
+
+    #[test]
+    fn dex_variant_names_are_parseable() {
+        assert_eq!(DEX_VARIANT_NAMES.len(), 110);
+
+        for name in DEX_VARIANT_NAMES {
+            Dex::from_str(name).unwrap_or_else(|_| panic!("missing Dex parser for {name}"));
+        }
+    }
+
+    #[test]
+    fn swap_event() {
+        let event = SwapEvent {
+            dex: Dex::RaydiumStableSwap,
+            amount_in: 644_475_000,
+            amount_out: 523_999_958_701,
+        };
+        let mut data = SWAP_EVENT.to_vec();
+        data.extend(borsh::to_vec(&event).unwrap());
+
+        match events::unpack(&data).expect("decode event") {
+            OkxV2Event::Swap(decoded) => assert_eq!(decoded, event),
+            _ => panic!("expected SwapEvent"),
+        }
+    }
+
+    #[test]
+    fn swap_event_from_program_data_log() {
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode("QMbN6CYIceI/v3dfOwUAAACk+K2gOgAAAA==")
+            .expect("decode base64 program data");
+
+        match events::unpack(&bytes).expect("decode event") {
+            OkxV2Event::Swap(event) => {
+                assert_eq!(event.dex, Dex::Tessera);
+                assert_eq!(event.amount_in, 22_470_948_799);
+                assert_eq!(event.amount_out, 251_803_859_108);
+            }
+            _ => panic!("expected SwapEvent"),
+        }
+    }
+
+    #[test]
+    fn swap_event_from_program_log_line() {
+        match logs::unpack("SwapEvent { dex: Tessera, amount_in: 22470948799, amount_out: 251803859108 }").expect("decode log") {
+            logs::OkxV2Log::Swap(event) => {
+                assert_eq!(event.dex, Dex::Tessera);
+                assert_eq!(event.amount_in, 22_470_948_799);
+                assert_eq!(event.amount_out, 251_803_859_108);
+            }
+            _ => panic!("expected SwapEvent log"),
+        }
+    }
+
+    #[test]
+    fn route_amm_pool_from_program_log_pair() {
+        match logs::unpack_route_amm_pool(
+            "Program log: Dex::Tessera amount_in: 13320946404, offset: 0",
+            "Program log: FLckHLGMJy5gEoXWwcE68Nprde1D4araK4TGLw4pQq2n",
+        )
+        .expect("decode route pool")
+        {
+            logs::OkxV2Log::RouteAmmPool(log) => {
+                assert_eq!(log.dex, Dex::Tessera);
+                assert_eq!(log.amount_in, 13_320_946_404);
+                assert_eq!(log.offset, 0);
+                assert_eq!(log.amm_pool.to_string(), "FLckHLGMJy5gEoXWwcE68Nprde1D4araK4TGLw4pQq2n");
+            }
+            _ => panic!("expected route pool log"),
+        }
+    }
+
+    #[test]
+    fn route_amm_pool_from_raw_program_logs() {
+        let raw_logs = r#"Program ComputeBudget111111111111111111111111111111 invoke [1]
+Program ComputeBudget111111111111111111111111111111 success
+Program 6m2CDdhRgxpH4WjvdzxAYbGxwdGUz5MziiL5jek2kBma invoke [1]
+Program log: Instruction: SwapV3
+Program log: before_source_balance: 104910092088, before_destination_balance: 3422088026285, amount_in: 13320946404, expect_amount_out: 149665924142, min_return: 149665924142
+Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]
+Program log: Instruction: TransferChecked
+Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success
+Program log: Dex::Tessera amount_in: 13320946404, offset: 0
+Program log: FLckHLGMJy5gEoXWwcE68Nprde1D4araK4TGLw4pQq2n
+Program TessVdML9pBGgG9yGks7o4HewRaXVAMuoVj4x83GLQH invoke [2]
+Program TessVdML9pBGgG9yGks7o4HewRaXVAMuoVj4x83GLQH success
+Program data: QMbN6CYIceI/5IL9GQMAAABSAdzYIgAAAA==
+Program log: SwapEvent { dex: Tessera, amount_in: 13320946404, amount_out: 149667184978 }
+Program 6m2CDdhRgxpH4WjvdzxAYbGxwdGUz5MziiL5jek2kBma success"#;
+        let lines = raw_logs.lines().collect::<Vec<_>>();
+        let pools = logs::unpack_route_amm_pools(&lines).expect("decode route pools");
+
+        assert_eq!(pools.len(), 1);
+        assert_eq!(pools[0].dex, Dex::Tessera);
+        assert_eq!(pools[0].amount_in, 13_320_946_404);
+        assert_eq!(pools[0].offset, 0);
+        assert_eq!(pools[0].amm_pool.to_string(), "FLckHLGMJy5gEoXWwcE68Nprde1D4araK4TGLw4pQq2n");
+    }
+
+    #[test]
+    fn route_amm_pools_from_sanctum_alphaq_program_logs() {
+        let raw_logs = r#"Program log: Dex::SanctumSwapWithoutWsol amount_in: 6427559292, offset: 0
+Program log: AYhux5gJzCoeoc1PoJ1VxwPDe22RwcvpHviLDD1oCGvW
+Program 5ocnV1qiCgaQR8Jb8xWnVbApfaygJ8tNoZfgPwsgx9kx invoke [2]
+Program data: QMbN6CYIceIVfMUcfwEAAADarlWaAQAAAA==
+Program log: SwapEvent { dex: SanctumNonWsolSwap, amount_in: 6427559292, amount_out: 6884273882 }
+Program log: Dex::AlphaQ amount_in: 6884273882, offset: 25
+Program log: C2GdMFGp2vSZHnU76pH2ukEWxuhoJBuaA54Ftzcvv4z5
+Program ALPHAQmeA7bjrVuccPsYPiCvsi428SNwte66Srvs4pHA invoke [2]
+Program data: QMbN6CYIceJT2q5VmgEAAAB1lizmAQAAAA==
+Program log: SwapEvent { dex: AlphaQ, amount_in: 6884273882, amount_out: 8156649077 }"#;
+        let lines = raw_logs.lines().collect::<Vec<_>>();
+        let pools = logs::unpack_route_amm_pools(&lines).expect("decode route pools");
+
+        assert_eq!(pools.len(), 2);
+        assert_eq!(pools[0].dex, Dex::SanctumNonWsolSwap);
+        assert_eq!(pools[0].amount_in, 6_427_559_292);
+        assert_eq!(pools[0].offset, 0);
+        assert_eq!(pools[0].amm_pool.to_string(), "AYhux5gJzCoeoc1PoJ1VxwPDe22RwcvpHviLDD1oCGvW");
+        assert_eq!(pools[1].dex, Dex::AlphaQ);
+        assert_eq!(pools[1].amount_in, 6_884_273_882);
+        assert_eq!(pools[1].offset, 25);
+        assert_eq!(pools[1].amm_pool.to_string(), "C2GdMFGp2vSZHnU76pH2ukEWxuhoJBuaA54Ftzcvv4z5");
+    }
+
+    #[test]
+    fn swap_v3_accounts_include_mints() {
+        let payer = [1u8; 32];
+        let source_token_account = [2u8; 32];
+        let destination_token_account = [3u8; 32];
+        let source_mint = [4u8; 32];
+        let destination_mint = [5u8; 32];
+        let program = [6u8; 32];
+
+        let trx = pb::ConfirmedTransaction {
+            transaction: Some(pb::Transaction {
+                message: Some(pb::Message {
+                    account_keys: vec![
+                        payer.to_vec(),
+                        source_token_account.to_vec(),
+                        destination_token_account.to_vec(),
+                        source_mint.to_vec(),
+                        destination_mint.to_vec(),
+                        program.to_vec(),
+                    ],
+                    instructions: vec![pb::CompiledInstruction {
+                        program_id_index: 5,
+                        accounts: vec![0, 1, 2, 3, 4],
+                        data: vec![],
+                    }],
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            meta: Some(pb::TransactionStatusMeta::default()),
+        };
+
+        let ix = trx.compiled_instructions().next().expect("instruction view");
+        let decoded = accounts::get_swap_v3_accounts(&ix).expect("decode accounts");
+
+        assert_eq!(decoded.source_mint.to_bytes(), source_mint);
+        assert_eq!(decoded.destination_mint.to_bytes(), destination_mint);
+    }
+
+    #[test]
+    fn swap_v3_fixture_accounts_include_usdc_wsol_mints() {
+        let payer = Pubkey::from_str("BpEBKwah2sGwa9zNtdoUgdmEDdms8L2NkFLfXShrz1ac").unwrap();
+        let source_token_account = Pubkey::from_str("6KiH81VTVqNGqwkDgtk2qV7rRjWfSXrMaRD45KW5VG8K").unwrap();
+        let destination_token_account = Pubkey::from_str("4NYrbAm1jfjgnV9JUTQbZ5VJoXYGHGKZcZqGLupCwJDU").unwrap();
+        let usdc_mint = Pubkey::from_str("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v").unwrap();
+        let wsol_mint = Pubkey::from_str("So11111111111111111111111111111111111111112").unwrap();
+        let okx_program = Pubkey::from_str("6m2CDdhRgxpH4WjvdzxAYbGxwdGUz5MziiL5jek2kBma").unwrap();
+
+        let trx = pb::ConfirmedTransaction {
+            transaction: Some(pb::Transaction {
+                message: Some(pb::Message {
+                    account_keys: vec![
+                        payer.to_bytes().to_vec(),
+                        source_token_account.to_bytes().to_vec(),
+                        destination_token_account.to_bytes().to_vec(),
+                        usdc_mint.to_bytes().to_vec(),
+                        wsol_mint.to_bytes().to_vec(),
+                        [6u8; 32].to_vec(),
+                        [7u8; 32].to_vec(),
+                        [8u8; 32].to_vec(),
+                        [9u8; 32].to_vec(),
+                        [10u8; 32].to_vec(),
+                        [11u8; 32].to_vec(),
+                        [12u8; 32].to_vec(),
+                        [13u8; 32].to_vec(),
+                        [14u8; 32].to_vec(),
+                        okx_program.to_bytes().to_vec(),
+                    ],
+                    instructions: vec![pb::CompiledInstruction {
+                        program_id_index: 14,
+                        accounts: (0..14).collect(),
+                        data: vec![],
+                    }],
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            meta: Some(pb::TransactionStatusMeta::default()),
+        };
+
+        let ix = trx.compiled_instructions().next().expect("instruction view");
+        let decoded = accounts::get_swap_v3_accounts(&ix).expect("decode accounts");
+
+        assert_eq!(decoded.payer, payer);
+        assert_eq!(decoded.source_token_account, source_token_account);
+        assert_eq!(decoded.destination_token_account, destination_token_account);
+        assert_eq!(decoded.source_mint, usdc_mint);
+        assert_eq!(decoded.destination_mint, wsol_mint);
     }
 }


### PR DESCRIPTION
## Summary

- add OKX DEX v2 swap event decoding via `okx::v2::events`
- expose `OkxV2Event::Swap(SwapEvent)` with routed `dex`, `amount_in`, and `amount_out`
- add OKX tests for successful swap event decoding and unknown event discriminators

## Context

This addresses the easy decoder-support portion of #127. The checked-in OKX v2 IDL already defines `SwapEvent { dex, amount_in, amount_out }`, and existing swap account helpers expose the payer plus source/destination token account and mint context needed by downstream dex-swaps normalization.

## Validation

- `cargo test okx`
- `rustfmt --check src/okx/v2/events.rs src/okx/v2/mod.rs tests/okx/instructions.rs tests/okx/okx_v2.rs`

Note: repo-wide `cargo fmt --all -- --check` was not used for this PR because the current tree has pre-existing Metaplex formatting diffs unrelated to this change.
