### PR TITLE
feat(pumpfun): permissive trade-event decoders for pumpswap

### DIFF
--- a/src/pumpfun/bonding_curve/events.rs
+++ b/src/pumpfun/bonding_curve/events.rs
@@ -260,3 +260,208 @@ impl<'a> TryFrom<&'a [u8]> for PumpFunEvent {
 pub fn unpack(data: &[u8]) -> Result<PumpFunEvent, ParseError> {
     PumpFunEvent::try_from(data)
 }
+
+// -----------------------------------------------------------------------------
+// Permissive trade-event decoder
+// -----------------------------------------------------------------------------
+
+/// Minimal trade-event view used by downstream sinks.
+///
+/// Only includes the leading-layout fields that have remained at fixed byte
+/// offsets across every known on-chain schema bump (V0 → V1 → V2 → V3 and the
+/// post-2025-10-17 variant that introduced `ix_name` / cashback / extra volume
+/// fields). Everything after `user` is intentionally ignored so the decoder
+/// stays correct as the program continues to append fields.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TradeEventMinimal {
+    /// SPL mint of the bonding-curve token.
+    pub mint: [u8; 32],
+    /// Lamports moved on the SOL side.
+    pub sol_amount: u64,
+    /// Token amount moved on the SPL side.
+    pub token_amount: u64,
+    /// `true` for buys (SOL → SPL), `false` for sells.
+    pub is_buy: bool,
+    /// Trader wallet (Pubkey).
+    pub user: [u8; 32],
+}
+
+/// Anchor self-CPI envelope tag prepended by `emit_cpi!` to event-carrying
+/// inner-instruction data: `[ANCHOR_SELF_CPI_TAG][event_disc][payload]`.
+const ANCHOR_SELF_CPI_TAG: [u8; 8] = [0xe4, 0x45, 0xa5, 0x2e, 0x51, 0xcb, 0x9a, 0x1d];
+
+// Stable byte offsets within the TradeEvent payload (after the 16-byte
+// preamble has been stripped). Layout:
+//   [mint: pubkey (32B)] [sol_amount: u64] [token_amount: u64]
+//   [is_buy: bool] [user: pubkey (32B)] ...
+const MINT_OFFSET: usize = 0;
+const SOL_AMOUNT_OFFSET: usize = 32;
+const TOKEN_AMOUNT_OFFSET: usize = 40;
+const IS_BUY_OFFSET: usize = 48;
+const USER_OFFSET: usize = 49;
+const TRADE_PAYLOAD_MIN_LEN: usize = USER_OFFSET + 32; // 81 bytes
+
+/// Decode a pump.fun bonding-curve TradeEvent into the stable subset of
+/// fields that downstream sinks need (mint, sol/token amount, direction,
+/// user), reading at fixed byte offsets and ignoring whatever follows.
+///
+/// Tolerates append-only schema growth: works for V0..V3 and any variant
+/// that appends fields after the leading layout.
+///
+/// Expects the inner-instruction data of an `emit_cpi!`-style event:
+/// `[ANCHOR_SELF_CPI_TAG (8B)][TRADE (8B)][payload]`.
+///
+/// Returns `Ok(None)` for envelope-shaped data with a non-trade discriminator
+/// (e.g. Create, Complete, SetParams) so callers can ignore those without
+/// treating them as errors.
+pub fn unpack_trade_event_minimal(data: &[u8]) -> Result<Option<TradeEventMinimal>, ParseError> {
+    if data.len() < 16 {
+        return Err(ParseError::TooShort(data.len()));
+    }
+    if data[..8] != ANCHOR_SELF_CPI_TAG {
+        return Err(ParseError::Unknown(data[..8].try_into().expect("len 8")));
+    }
+    let event_disc: [u8; 8] = data[8..16].try_into().expect("len 8");
+    if event_disc != TRADE {
+        return Ok(None);
+    }
+    let payload = &data[16..];
+    if payload.len() < TRADE_PAYLOAD_MIN_LEN {
+        return Err(ParseError::TooShort(payload.len()));
+    }
+    let mint: [u8; 32] = payload[MINT_OFFSET..MINT_OFFSET + 32]
+        .try_into()
+        .expect("len 32");
+    let sol_amount = u64::from_le_bytes(
+        payload[SOL_AMOUNT_OFFSET..SOL_AMOUNT_OFFSET + 8]
+            .try_into()
+            .expect("len 8"),
+    );
+    let token_amount = u64::from_le_bytes(
+        payload[TOKEN_AMOUNT_OFFSET..TOKEN_AMOUNT_OFFSET + 8]
+            .try_into()
+            .expect("len 8"),
+    );
+    let is_buy = match payload[IS_BUY_OFFSET] {
+        0 => false,
+        1 => true,
+        _ => {
+            return Err(ParseError::InvalidLength {
+                expected: 1,
+                got: payload[IS_BUY_OFFSET] as usize,
+            })
+        }
+    };
+    let user: [u8; 32] = payload[USER_OFFSET..USER_OFFSET + 32]
+        .try_into()
+        .expect("len 32");
+    Ok(Some(TradeEventMinimal {
+        mint,
+        sol_amount,
+        token_amount,
+        is_buy,
+        user,
+    }))
+}
+
+#[cfg(test)]
+mod minimal_tests {
+    use super::*;
+
+    fn make_event(is_buy: bool, mint: [u8; 32], user: [u8; 32], sol: u64, token: u64, trailing: &[u8]) -> Vec<u8> {
+        let mut data = Vec::with_capacity(16 + TRADE_PAYLOAD_MIN_LEN + trailing.len());
+        data.extend_from_slice(&ANCHOR_SELF_CPI_TAG);
+        data.extend_from_slice(&TRADE);
+        data.extend_from_slice(&mint); // 32
+        data.extend_from_slice(&sol.to_le_bytes()); // 8
+        data.extend_from_slice(&token.to_le_bytes()); // 8
+        data.push(if is_buy { 1 } else { 0 }); // 1
+        data.extend_from_slice(&user); // 32
+        data.extend_from_slice(trailing);
+        data
+    }
+
+    fn pk(b: u8) -> [u8; 32] {
+        [b; 32]
+    }
+
+    #[test]
+    fn buy_with_v0_payload() {
+        let data = make_event(true, pk(0xa1), pk(0xa2), 1_000_000_000, 50_000_000, &[]);
+        let ev = unpack_trade_event_minimal(&data).unwrap().unwrap();
+        assert!(ev.is_buy);
+        assert_eq!(ev.sol_amount, 1_000_000_000);
+        assert_eq!(ev.token_amount, 50_000_000);
+        assert_eq!(ev.mint, pk(0xa1));
+        assert_eq!(ev.user, pk(0xa2));
+    }
+
+    #[test]
+    fn sell_with_v0_payload() {
+        let data = make_event(false, pk(0xb1), pk(0xb2), 7, 13, &[]);
+        let ev = unpack_trade_event_minimal(&data).unwrap().unwrap();
+        assert!(!ev.is_buy);
+        assert_eq!(ev.sol_amount, 7);
+        assert_eq!(ev.token_amount, 13);
+    }
+
+    #[test]
+    fn ignores_v3_trailing_fields() {
+        // V3 - V0 = 250 - 81 = 169 bytes of appended fields.
+        let data = make_event(true, pk(0xc1), pk(0xc2), 100, 200, &vec![0u8; 169]);
+        let ev = unpack_trade_event_minimal(&data).unwrap().unwrap();
+        assert_eq!(ev.sol_amount, 100);
+        assert_eq!(ev.token_amount, 200);
+    }
+
+    #[test]
+    fn ignores_post_v3_trailing_fields() {
+        // The post-2025-10-17 variant adds ix_name (String) + cashback fields.
+        let data = make_event(true, pk(0xd1), pk(0xd2), 42, 84, &vec![0u8; 250]);
+        let ev = unpack_trade_event_minimal(&data).unwrap().unwrap();
+        assert_eq!(ev.sol_amount, 42);
+        assert_eq!(ev.token_amount, 84);
+    }
+
+    #[test]
+    fn returns_ok_none_for_non_trade_event() {
+        let mut data = Vec::new();
+        data.extend_from_slice(&ANCHOR_SELF_CPI_TAG);
+        data.extend_from_slice(&CREATE);
+        data.extend_from_slice(&[0u8; TRADE_PAYLOAD_MIN_LEN]);
+        assert!(unpack_trade_event_minimal(&data).unwrap().is_none());
+    }
+
+    #[test]
+    fn errors_on_data_without_anchor_cpi_tag() {
+        let mut data = make_event(true, pk(0), pk(0), 1, 1, &[]);
+        data[..8].fill(0);
+        assert!(matches!(
+            unpack_trade_event_minimal(&data),
+            Err(ParseError::Unknown(_))
+        ));
+    }
+
+    #[test]
+    fn errors_on_short_payload() {
+        let mut data = Vec::new();
+        data.extend_from_slice(&ANCHOR_SELF_CPI_TAG);
+        data.extend_from_slice(&TRADE);
+        data.extend_from_slice(&[0u8; 50]); // < 81-byte minimum
+        assert!(matches!(
+            unpack_trade_event_minimal(&data),
+            Err(ParseError::TooShort(_))
+        ));
+    }
+
+    #[test]
+    fn errors_on_invalid_is_buy_byte() {
+        let mut data = make_event(true, pk(0), pk(0), 1, 1, &[]);
+        // is_buy lives at offset 16 (preamble) + 48 (within payload) = 64
+        data[16 + IS_BUY_OFFSET] = 2;
+        assert!(matches!(
+            unpack_trade_event_minimal(&data),
+            Err(ParseError::InvalidLength { .. })
+        ));
+    }
+}

--- a/src/pumpswap/events.rs
+++ b/src/pumpswap/events.rs
@@ -335,3 +335,212 @@ pub fn unpack_event(data: &[u8]) -> Result<PumpSwapEvent, ParseError> {
         _ => return Err(ParseError::Unknown(disc)),
     })
 }
+
+// -----------------------------------------------------------------------------
+// Permissive trade-event decoder
+// -----------------------------------------------------------------------------
+
+/// Direction of a pump.fun AMM trade.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TradeDirection {
+    Buy,
+    Sell,
+}
+
+/// Minimal trade-event view used by downstream sinks.
+///
+/// Only includes the leading-layout fields that have remained at fixed byte
+/// offsets across every known on-chain schema bump (V1, V2, the post-2026-02-12
+/// PumpSwap rename, and the cashback fields shipped 2026-02-17). Everything
+/// after `user` is intentionally ignored so the decoder stays correct as the
+/// program continues to append fields.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TradeEventMinimal {
+    pub direction: TradeDirection,
+    /// Trader wallet (Pubkey).
+    pub user: [u8; 32],
+    /// `base_amount_out` for buys, `base_amount_in` for sells (lamports of base mint).
+    pub base_amount: u64,
+    /// `quote_amount_in` for buys, `quote_amount_out` for sells (lamports of quote mint).
+    pub quote_amount: u64,
+}
+
+/// Anchor self-CPI envelope tag prepended by `emit_cpi!` to event-carrying
+/// inner-instruction data: `[ANCHOR_SELF_CPI_TAG][event_disc][payload]`.
+const ANCHOR_SELF_CPI_TAG: [u8; 8] = [0xe4, 0x45, 0xa5, 0x2e, 0x51, 0xcb, 0x9a, 0x1d];
+
+// Stable byte offsets within the BuyEvent / SellEvent payload (after the
+// 16-byte preamble). Both events share an identical leading layout:
+//   [i64 timestamp (8B)] [13 × u64 (104B)] [pool: pubkey (32B)] [user: pubkey (32B)] ...
+// `base_amount_(out|in)` is the 2nd numeric field; `quote_amount_(in|out)` is
+// the 8th. `user` is the second pubkey, after `pool`.
+const BASE_AMOUNT_OFFSET: usize = 8;
+const QUOTE_AMOUNT_OFFSET: usize = 56;
+const USER_OFFSET: usize = 144;
+const TRADE_PAYLOAD_MIN_LEN: usize = USER_OFFSET + 32; // 176 bytes
+
+/// Decode a pump.fun AMM trade event into the stable subset of fields that
+/// downstream sinks need (direction, user, base/quote amount), reading at
+/// fixed byte offsets and ignoring whatever follows.
+///
+/// Tolerates append-only schema growth: works for V1, V2, PumpSwap-with-cashback,
+/// and any future variant that appends fields after the leading layout.
+///
+/// Expects the inner-instruction data of an `emit_cpi!`-style event:
+/// `[ANCHOR_SELF_CPI_TAG (8B)][event_disc (8B)][payload]`.
+///
+/// Returns `Ok(None)` for envelope-shaped data with a non-trade discriminator
+/// (e.g. CreateConfig, Deposit) so callers can ignore those without treating
+/// them as errors.
+pub fn unpack_trade_event_minimal(data: &[u8]) -> Result<Option<TradeEventMinimal>, ParseError> {
+    if data.len() < 16 {
+        return Err(ParseError::TooShort(data.len()));
+    }
+    if data[..8] != ANCHOR_SELF_CPI_TAG {
+        return Err(ParseError::Unknown(data[..8].try_into().expect("len 8")));
+    }
+    let event_disc: [u8; 8] = data[8..16].try_into().expect("len 8");
+    let direction = match event_disc {
+        BUY_EVENT => TradeDirection::Buy,
+        SELL_EVENT => TradeDirection::Sell,
+        _ => return Ok(None),
+    };
+    let payload = &data[16..];
+    if payload.len() < TRADE_PAYLOAD_MIN_LEN {
+        return Err(ParseError::TooShort(payload.len()));
+    }
+    let base_amount = u64::from_le_bytes(
+        payload[BASE_AMOUNT_OFFSET..BASE_AMOUNT_OFFSET + 8]
+            .try_into()
+            .expect("len 8"),
+    );
+    let quote_amount = u64::from_le_bytes(
+        payload[QUOTE_AMOUNT_OFFSET..QUOTE_AMOUNT_OFFSET + 8]
+            .try_into()
+            .expect("len 8"),
+    );
+    let user: [u8; 32] = payload[USER_OFFSET..USER_OFFSET + 32]
+        .try_into()
+        .expect("len 32");
+    Ok(Some(TradeEventMinimal {
+        direction,
+        user,
+        base_amount,
+        quote_amount,
+    }))
+}
+
+#[cfg(test)]
+mod minimal_tests {
+    use super::*;
+
+    /// Build a synthetic emit_cpi! event payload: anchor tag + event disc +
+    /// the stable leading layout. `trailing` simulates whatever the program
+    /// has tacked on in the current/future versions.
+    fn make_event(disc: [u8; 8], base: u64, quote: u64, user: [u8; 32], trailing: &[u8]) -> Vec<u8> {
+        let mut data = Vec::with_capacity(16 + TRADE_PAYLOAD_MIN_LEN + trailing.len());
+        data.extend_from_slice(&ANCHOR_SELF_CPI_TAG);
+        data.extend_from_slice(&disc);
+        data.extend_from_slice(&0i64.to_le_bytes()); // timestamp
+        data.extend_from_slice(&base.to_le_bytes()); // 2nd field
+        for _ in 0..5 {
+            data.extend_from_slice(&0u64.to_le_bytes());
+        } // 3rd-7th
+        data.extend_from_slice(&quote.to_le_bytes()); // 8th
+        for _ in 0..6 {
+            data.extend_from_slice(&0u64.to_le_bytes());
+        } // 9th-14th
+        data.extend_from_slice(&[0u8; 32]); // pool
+        data.extend_from_slice(&user); // user
+        data.extend_from_slice(trailing);
+        data
+    }
+
+    fn pk(b: u8) -> [u8; 32] {
+        [b; 32]
+    }
+
+    #[test]
+    fn buy_event_minimal_payload() {
+        let data = make_event(BUY_EVENT, 1_000, 999, pk(0xab), &[]);
+        let ev = unpack_trade_event_minimal(&data).unwrap().unwrap();
+        assert_eq!(ev.direction, TradeDirection::Buy);
+        assert_eq!(ev.base_amount, 1_000);
+        assert_eq!(ev.quote_amount, 999);
+        assert_eq!(ev.user, pk(0xab));
+    }
+
+    #[test]
+    fn sell_event_minimal_payload() {
+        let data = make_event(SELL_EVENT, 7, 13, pk(0xcd), &[]);
+        let ev = unpack_trade_event_minimal(&data).unwrap().unwrap();
+        assert_eq!(ev.direction, TradeDirection::Sell);
+        assert_eq!(ev.base_amount, 7);
+        assert_eq!(ev.quote_amount, 13);
+    }
+
+    #[test]
+    fn ignores_v2_trailing_bytes() {
+        // V2 appended coin_creator + 2 fee u64s = 48 bytes after the leading 176.
+        let data = make_event(BUY_EVENT, 100, 50, pk(0x01), &vec![0u8; 48]);
+        let ev = unpack_trade_event_minimal(&data).unwrap().unwrap();
+        assert_eq!(ev.base_amount, 100);
+        assert_eq!(ev.quote_amount, 50);
+    }
+
+    #[test]
+    fn ignores_pumpswap_trailing_bytes() {
+        // Post-2026-02-12 PumpSwap appended track_volume bool + 5 u64s + ix_name + cashback.
+        // Exact size doesn't matter — decoder ignores whatever follows.
+        let data = make_event(BUY_EVENT, 42, 84, pk(0x02), &vec![0u8; 224]);
+        let ev = unpack_trade_event_minimal(&data).unwrap().unwrap();
+        assert_eq!(ev.base_amount, 42);
+        assert_eq!(ev.quote_amount, 84);
+    }
+
+    #[test]
+    fn returns_ok_none_for_non_trade_event() {
+        // CreateConfig / Deposit / etc. share the envelope; the caller should
+        // be able to skip them without treating them as decode failures.
+        let create_config = CREATE_CONFIG_EVENT;
+        let mut data = Vec::new();
+        data.extend_from_slice(&ANCHOR_SELF_CPI_TAG);
+        data.extend_from_slice(&create_config);
+        data.extend_from_slice(&[0u8; TRADE_PAYLOAD_MIN_LEN]);
+        assert!(unpack_trade_event_minimal(&data).unwrap().is_none());
+    }
+
+    #[test]
+    fn errors_on_data_without_anchor_cpi_tag() {
+        let mut data = make_event(BUY_EVENT, 1, 1, pk(0xff), &[]);
+        data[..8].fill(0);
+        assert!(matches!(
+            unpack_trade_event_minimal(&data),
+            Err(ParseError::Unknown(_))
+        ));
+    }
+
+    #[test]
+    fn errors_on_payload_shorter_than_leading_layout() {
+        let mut data = Vec::new();
+        data.extend_from_slice(&ANCHOR_SELF_CPI_TAG);
+        data.extend_from_slice(&BUY_EVENT);
+        data.extend_from_slice(&[0u8; 100]); // < 176-byte minimum
+        assert!(matches!(
+            unpack_trade_event_minimal(&data),
+            Err(ParseError::TooShort(_))
+        ));
+    }
+
+    #[test]
+    fn errors_on_data_too_short_for_envelope() {
+        assert!(matches!(
+            unpack_trade_event_minimal(&[]),
+            Err(ParseError::TooShort(_))
+        ));
+        assert!(matches!(
+            unpack_trade_event_minimal(&ANCHOR_SELF_CPI_TAG),
+            Err(ParseError::TooShort(_))
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

Add `unpack_trade_event_minimal` to:

- `src/pumpswap/events.rs` — returns `{direction, user, base_amount, quote_amount}`.
- `src/pumpfun/bonding_curve/events.rs` — returns `{mint, sol_amount, token_amount, is_buy, user}`.

Both decoders read the on-chain payload at **fixed byte offsets** within the leading layout and ignore everything that follows.

## Why

Strict `try_from_slice`-based decoders break every time pump.fun appends fields to BuyEvent / SellEvent / TradeEvent. Borsh errors with "Not all bytes read" on trailing bytes. Per the on-chain history we have evidence for, pump.fun has done this multiple times:

| date | change | source |
| --- | --- | --- |
| 2025-10-17 | bonding curve TradeEvent grew past V3 (current ~303-byte payload, IDL has `TRADE_LEN_V3 = 250`) | observed cutoff in our sinks |
| 2025-11-15 | volume accumulator fields | [pump-public-docs commit](https://github.com/pump-fun/pump-public-docs/commit/7d7abd7) |
| 2026-01-09 | creator rewards sharing (`coin_creator`) | [pump-public-docs commit](https://github.com/pump-fun/pump-public-docs/commit/f0ef005) |
| 2026-02-12 | AMM rebrand to PumpSwap, `track_volume` / `ix_name` / extras | observed cutoff in our sinks |
| 2026-02-17 | cashback fields | [pump-public-docs commit](https://github.com/pump-fun/pump-public-docs/commit/82dacac) |

Each downstream sink (e.g. [substreams-svm](https://github.com/pinax-network/substreams-svm)) has been silently dropping trade events past each cutoff. Bumping the IDL once just buys time — the next program upgrade breaks it again.

The new decoders only surface the stable subset of fields downstream sinks actually need. Both events' leading layouts have been **append-only** since their first version — there is no on-chain or docs evidence of any field being reordered or shrunk — so the decoders remain correct as long as that property holds.

## Layouts

**PumpSwap BuyEvent / SellEvent** (176-byte minimum leading payload after the 16-byte preamble):

| offset | type | meaning |
| --- | --- | --- |
| 0 | i64 | timestamp |
| 8 | u64 | base_amount_(out\|in) |
| 16-55 | 5 × u64 | reserves / partial amounts (skipped) |
| 56 | u64 | quote_amount_(in\|out) |
| 64-111 | 6 × u64 | reserves / fee fields (skipped) |
| 112 | pubkey | pool |
| 144 | pubkey | user |

**Pump.fun bonding curve TradeEvent** (81-byte minimum leading payload after the 16-byte preamble):

| offset | type | meaning |
| --- | --- | --- |
| 0 | pubkey | mint |
| 32 | u64 | sol_amount |
| 40 | u64 | token_amount |
| 48 | bool | is_buy |
| 49 | pubkey | user |

## Test plan

- [x] 16 unit tests cover: V0 / V2 / V3 / post-V3 trailing layouts, non-trade discriminator (returns `Ok(None)`), missing anchor self-CPI tag, short payload, and invalid `is_buy` byte for the bonding curve. `cargo test --lib`.
- [ ] Downstream verification will land in [substreams-svm](https://github.com/pinax-network/substreams-svm) where the consumer-side decoders are reduced to thin wrappers around these helpers — that PR will follow once this is merged + tagged.

## Behaviour notes

- Returns `Ok(None)` for envelope-shaped data with a non-trade discriminator (CreateConfig, Deposit, Withdraw, ...) so callers can skip those without treating them as decode failures.
- Returns `Err(TooShort)` for payloads shorter than the leading layout, `Err(Unknown)` for payloads missing the anchor self-CPI tag, and (bonding curve only) `Err(InvalidLength)` for an `is_buy` byte that's neither 0 nor 1.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
