### PR TITLE
[codex] Add SPL Token Swap account helper

### DIFF
--- a/src/spl/token_swap/accounts.rs
+++ b/src/spl/token_swap/accounts.rs
@@ -2,6 +2,9 @@
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use solana_program::pubkey::Pubkey;
+use substreams_solana::block_view::InstructionView;
+
+use crate::common::accounts::AccountsError;
 
 /// Token Swap pool state
 #[derive(Debug, Clone, PartialEq, BorshSerialize, BorshDeserialize)]
@@ -50,4 +53,64 @@ pub struct OffsetCurve {
 #[derive(Debug, Clone, PartialEq, BorshSerialize, BorshDeserialize)]
 pub struct StableCurve {
     pub amp: u64,
+}
+
+// -----------------------------------------------------------------------------
+// Swap instruction accounts
+// -----------------------------------------------------------------------------
+const IDX_SWAP_ACCOUNT: usize = 0;
+const IDX_AUTHORITY: usize = 1;
+const IDX_USER_TRANSFER_AUTHORITY: usize = 2;
+const IDX_SOURCE: usize = 3;
+const IDX_SWAP_SOURCE: usize = 4;
+const IDX_SWAP_DESTINATION: usize = 5;
+const IDX_DESTINATION: usize = 6;
+const IDX_POOL_MINT: usize = 7;
+const IDX_FEE_ACCOUNT: usize = 8;
+const IDX_HOST_FEE_ACCOUNT: usize = 9;
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct SwapAccounts {
+    pub swap_account: Pubkey,
+    pub authority: Pubkey,
+    pub user_transfer_authority: Pubkey,
+    pub source: Pubkey,
+    pub swap_source: Pubkey,
+    pub swap_destination: Pubkey,
+    pub destination: Pubkey,
+    pub pool_mint: Pubkey,
+    pub fee_account: Pubkey,
+    pub host_fee_account: Option<Pubkey>,
+}
+
+impl<'ix> TryFrom<&InstructionView<'ix>> for SwapAccounts {
+    type Error = AccountsError;
+
+    fn try_from(ix: &InstructionView<'ix>) -> Result<Self, Self::Error> {
+        let accounts = ix.accounts();
+
+        let get_req = |index: usize, name: &'static str| -> Result<Pubkey, AccountsError> {
+            let a = accounts.get(index).ok_or(AccountsError::Missing { name, index })?;
+            crate::common::accounts::to_pubkey(name, index, a.0)
+        };
+
+        let get_opt = |index: usize| -> Option<Pubkey> { accounts.get(index).and_then(|a| a.0.as_slice().try_into().ok()).map(Pubkey::new_from_array) };
+
+        Ok(SwapAccounts {
+            swap_account: get_req(IDX_SWAP_ACCOUNT, "swap_account")?,
+            authority: get_req(IDX_AUTHORITY, "authority")?,
+            user_transfer_authority: get_req(IDX_USER_TRANSFER_AUTHORITY, "user_transfer_authority")?,
+            source: get_req(IDX_SOURCE, "source")?,
+            swap_source: get_req(IDX_SWAP_SOURCE, "swap_source")?,
+            swap_destination: get_req(IDX_SWAP_DESTINATION, "swap_destination")?,
+            destination: get_req(IDX_DESTINATION, "destination")?,
+            pool_mint: get_req(IDX_POOL_MINT, "pool_mint")?,
+            fee_account: get_req(IDX_FEE_ACCOUNT, "fee_account")?,
+            host_fee_account: get_opt(IDX_HOST_FEE_ACCOUNT),
+        })
+    }
+}
+
+pub fn get_swap_accounts(ix: &InstructionView) -> Result<SwapAccounts, AccountsError> {
+    SwapAccounts::try_from(ix)
 }

--- a/tests/spl.rs
+++ b/tests/spl.rs
@@ -1,2 +1,4 @@
+#[path = "spl/accounts.rs"]
+mod spl_accounts;
 #[path = "spl/instructions.rs"]
 mod spl_instructions;

--- a/tests/spl/accounts.rs
+++ b/tests/spl/accounts.rs
@@ -1,0 +1,123 @@
+use solana_program::pubkey::Pubkey;
+use substreams_solana::pb::sf::solana::r#type::v1::{CompiledInstruction, ConfirmedTransaction, Message, MessageHeader, Transaction, TransactionStatusMeta};
+
+const PROGRAM: [u8; 32] = [0xfe; 32];
+const SWAP_ACCOUNT: [u8; 32] = [1; 32];
+const AUTHORITY: [u8; 32] = [2; 32];
+const USER_TRANSFER_AUTHORITY: [u8; 32] = [3; 32];
+const SOURCE: [u8; 32] = [4; 32];
+const SWAP_SOURCE: [u8; 32] = [5; 32];
+const SWAP_DESTINATION: [u8; 32] = [6; 32];
+const DESTINATION: [u8; 32] = [7; 32];
+const POOL_MINT: [u8; 32] = [8; 32];
+const FEE_ACCOUNT: [u8; 32] = [9; 32];
+const HOST_FEE_ACCOUNT: [u8; 32] = [10; 32];
+
+fn pubkey(bytes: [u8; 32]) -> Pubkey {
+    Pubkey::new_from_array(bytes)
+}
+
+fn make_tx(accounts: &[[u8; 32]]) -> ConfirmedTransaction {
+    let mut keys: Vec<Vec<u8>> = vec![[0xff; 32].to_vec(), PROGRAM.to_vec()];
+    let mut instruction_accounts = Vec::new();
+
+    for (index, account) in accounts.iter().enumerate() {
+        keys.push(account.to_vec());
+        instruction_accounts.push((index + 2) as u8);
+    }
+
+    ConfirmedTransaction {
+        transaction: Some(Transaction {
+            signatures: vec![vec![0; 64]],
+            message: Some(Message {
+                header: Some(MessageHeader {
+                    num_required_signatures: 1,
+                    num_readonly_signed_accounts: 0,
+                    num_readonly_unsigned_accounts: 0,
+                }),
+                account_keys: keys,
+                recent_blockhash: vec![0; 32],
+                instructions: vec![CompiledInstruction {
+                    program_id_index: 1,
+                    accounts: instruction_accounts,
+                    data: vec![],
+                }],
+                versioned: false,
+                address_table_lookups: vec![],
+            }),
+        }),
+        meta: Some(TransactionStatusMeta::default()),
+    }
+}
+
+#[test]
+fn token_swap_get_swap_accounts_base_form() {
+    let tx = make_tx(&[
+        SWAP_ACCOUNT,
+        AUTHORITY,
+        USER_TRANSFER_AUTHORITY,
+        SOURCE,
+        SWAP_SOURCE,
+        SWAP_DESTINATION,
+        DESTINATION,
+        POOL_MINT,
+        FEE_ACCOUNT,
+    ]);
+    let ix = tx.walk_instructions().next().unwrap();
+
+    let accounts = substreams_solana_idls::spl::token_swap::accounts::get_swap_accounts(&ix).unwrap();
+
+    assert_eq!(accounts.swap_account, pubkey(SWAP_ACCOUNT));
+    assert_eq!(accounts.authority, pubkey(AUTHORITY));
+    assert_eq!(accounts.user_transfer_authority, pubkey(USER_TRANSFER_AUTHORITY));
+    assert_eq!(accounts.source, pubkey(SOURCE));
+    assert_eq!(accounts.swap_source, pubkey(SWAP_SOURCE));
+    assert_eq!(accounts.swap_destination, pubkey(SWAP_DESTINATION));
+    assert_eq!(accounts.destination, pubkey(DESTINATION));
+    assert_eq!(accounts.pool_mint, pubkey(POOL_MINT));
+    assert_eq!(accounts.fee_account, pubkey(FEE_ACCOUNT));
+    assert_eq!(accounts.host_fee_account, None);
+}
+
+#[test]
+fn token_swap_get_swap_accounts_with_host_fee_account() {
+    let tx = make_tx(&[
+        SWAP_ACCOUNT,
+        AUTHORITY,
+        USER_TRANSFER_AUTHORITY,
+        SOURCE,
+        SWAP_SOURCE,
+        SWAP_DESTINATION,
+        DESTINATION,
+        POOL_MINT,
+        FEE_ACCOUNT,
+        HOST_FEE_ACCOUNT,
+    ]);
+    let ix = tx.walk_instructions().next().unwrap();
+
+    let accounts = substreams_solana_idls::spl::token_swap::accounts::get_swap_accounts(&ix).unwrap();
+
+    assert_eq!(accounts.host_fee_account, Some(pubkey(HOST_FEE_ACCOUNT)));
+}
+
+#[test]
+fn token_swap_get_swap_accounts_reports_missing_required_account() {
+    let tx = make_tx(&[
+        SWAP_ACCOUNT,
+        AUTHORITY,
+        USER_TRANSFER_AUTHORITY,
+        SOURCE,
+        SWAP_SOURCE,
+        SWAP_DESTINATION,
+        DESTINATION,
+        POOL_MINT,
+    ]);
+    let ix = tx.walk_instructions().next().unwrap();
+
+    let err = substreams_solana_idls::spl::token_swap::accounts::get_swap_accounts(&ix).unwrap_err();
+
+    assert!(matches!(
+        err,
+        substreams_solana_idls::common::accounts::AccountsError::Missing { name: "fee_account", index: 8 }
+    ));
+}


### PR DESCRIPTION
## Summary
- add `spl::token_swap::accounts::SwapAccounts`
- add `get_swap_accounts(&InstructionView)` for SPL Token Swap swap instructions
- support both the base 9-account form and optional host fee account

## Why
Downstream consumers can already decode SPL Token Swap instruction payloads through `instructions::unpack`, but still need a typed account helper to avoid carrying SPL Token Swap account-layout knowledge locally.

## Validation
- `cargo test spl --test spl`
- `cargo check`
- `rustfmt src/spl/token_swap/accounts.rs tests/spl.rs tests/spl/accounts.rs`
- `git diff --check`

Closes #139
